### PR TITLE
API to generate random Dask dataframes

### DIFF
--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -27,7 +27,9 @@ default_int_args: dict[str, tuple[tuple[Any, ...], dict[str, Any]]] = {
 class ColumnSpec:
     """Encapsulates properties of a family of columns with the same dtype.
     Different method can be specified for integer dtype ("poisson", "uniform",
-    "binomial", etc.)"""
+    "binomial", etc.)
+
+    Note: this API is still experimental, and will likely change in the future"""
 
     prefix: str | None = None
     dtype: str | type | None = None
@@ -44,7 +46,9 @@ class ColumnSpec:
 
 @dataclass
 class IndexSpec:
-    """Properties of the dataframe index"""
+    """Properties of the dataframe index
+
+    Note: this API is still experimental, and will likely change in the future"""
 
     dtype: str | type = int
     start: str | None = None  # should be set for DatetimeIndex
@@ -54,7 +58,9 @@ class IndexSpec:
 
 @dataclass
 class DatasetSpec:
-    """Defines a dataset with random data, such as which columns and data types to generate"""
+    """Defines a dataset with random data, such as which columns and data types to generate
+
+    Note: this API is still experimental, and will likely change in the future"""
 
     npartitions: int = 1
     nrecords: int = 1000  # total records
@@ -340,6 +346,10 @@ def with_spec(spec: DatasetSpec, seed: int | None = None):
         Specify all the parameters of the dataset
     seed: int (optional)
         Randomstate seed
+
+    Note
+    ----
+    This API is still experimental, and will likely change in the future
 
     Examples
     --------

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -55,7 +55,7 @@ class DatasetSpec:
     """Defines a dataset with random data, such as which columns and data types to generate"""
 
     npartitions: int = 1
-    nrecords: int = 1000
+    nrecords: int = 1000  # total records
     index_spec: IndexSpec = field(default_factory=IndexSpec)
     column_specs: list[ColumnSpec] = field(default_factory=list)
 

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -37,7 +37,7 @@ class ColumnSpec:
     """Column prefix. If not specified, will default to str(dtype)"""
 
     dtype: str | type | None = None
-    """Column data type"""
+    """Column data type. Only supports numpy dtypes"""
 
     number: int = 1
     """How many columns to create with these properties. Default 1.
@@ -54,20 +54,21 @@ class ColumnSpec:
     high and low."""
 
     high: int | None = None
-    """For a "category" column, how many unique categories to generate"""
+    """For an int column, high end of range"""
 
     length: int | None = None
-    """For a str or "category" column, how many unique categories to generate"""
+    """For a str or "category" column with random=True, how large a string to generate"""
 
     random: bool = False
-    """For an int column, whether to use ``randint``"""
+    """For an int column, whether to use ``randint``. For a string column produces a random string
+    of specified ``length``"""
 
     method: str | None = None
     """For an int column, method to use when generating the value, such as "poisson", "uniform", "binomial".
     Default "poisson". Delegates to the same method of ``RandomState``"""
 
     kwargs: dict[str, Any] = field(default_factory=dict)
-    """For an int column, any other kwargs to pass into the method"""
+    """Any other kwargs to pass into the method"""
 
 
 @dataclass
@@ -263,6 +264,7 @@ class MakeDataframePart(DataFrameIOFunction):
 def make_dataframe_part(index_dtype, start, end, dtypes, columns, state_data, kwargs):
     state = np.random.RandomState(state_data)
     if pd.api.types.is_datetime64_any_dtype(index_dtype):
+        # FIXME: tzinfo would be lost in pd.date_range
         index = pd.date_range(
             start=start, end=end, freq=kwargs.get("freq"), name="timestamp"
         )

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -174,8 +174,8 @@ def make_dataframe_part(index_dtype, start, end, dtypes, columns, state_data, kw
         )
     elif pd.api.types.is_integer_dtype(index_dtype):
         step = kwargs.get("freq")
-        index = pd.RangeIndex(
-            start=start, stop=end + step, step=step, dtype=index_dtype
+        index = pd.RangeIndex(start=start, stop=end + step, step=step).astype(
+            index_dtype
         )
     else:
         raise TypeError(f"Unhandled index dtype: {index_dtype}")
@@ -301,7 +301,7 @@ def with_spec(spec: DatasetSpec, seed: int | None = None):
     if len(spec.column_specs) == 0:
         spec.column_specs = [
             ColumnSpec(prefix="i", dtype=int, low=0, high=1_000_000, random=True),
-            ColumnSpec(prefix="f", dtype=float, low=0, high=10_000, random=True),
+            ColumnSpec(prefix="f", dtype=float, random=True),
             ColumnSpec(prefix="c", dtype="category", choices=["a", "b", "c", "d"]),
             ColumnSpec(prefix="s", dtype=str, length=25),
         ]

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -321,7 +321,8 @@ def make_partition(columns: list, dtypes: dict[str, type | str], index, kwargs, 
             data[k] = result
     df = pd.DataFrame(data, index=index, columns=columns)
     for k, dtype in dtypes.items():
-        df[k] = df[k].astype(dtype)
+        if k in columns:
+            df[k] = df[k].astype(dtype)
     return df
 
 

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -490,7 +490,7 @@ def with_spec(spec: DatasetSpec, seed: int | None = None):
         if col.prefix:
             prefix = col.prefix
         elif isinstance(col.dtype, str):
-            prefix = col.dtype
+            prefix = "str"
         elif hasattr(col.dtype, "name"):
             prefix = col.dtype.name  # type: ignore[union-attr]
         else:

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import string
 from dataclasses import asdict, dataclass, field
 from typing import Any, Callable, cast
@@ -15,7 +16,7 @@ from dask.utils import random_state_data
 __all__ = ["make_timeseries", "with_spec", "ColumnSpec", "IndexSpec", "DatasetSpec"]
 
 default_int_args: dict[str, tuple[tuple[Any, ...], dict[str, Any]]] = {
-    "poisson": ((1000,), {}),
+    "poisson": ((), {"lam": 1000}),
     "normal": ((), {"scale": 1000}),
     "uniform": ((), {"high": 1000}),
     "binomial": ((1000, 0.5), {}),
@@ -45,7 +46,7 @@ class IndexSpec:
     """Properties of the dataframe index"""
 
     dtype: str | type = int
-    freq: int | str = 1  #
+    freq: int | str = 1
 
 
 @dataclass
@@ -81,6 +82,7 @@ def make_int(
         if isinstance(method, str):
             # "poisson", "binomial", etc.
             handler_args, handler_kwargs = default_int_args.get(method, ((), {}))
+            handler_kwargs = copy.copy(handler_kwargs)
             handler_kwargs.update(**kwargs)
             handler = getattr(rstate, method)
             data = handler(*handler_args, size=n, **handler_kwargs)

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -32,6 +32,7 @@ class ColumnSpec:
     prefix: str | None = None
     dtype: str | type | None = None
     number: int = 1
+    nunique: int | None = None  # number of unique categories
     choices: list = field(default_factory=list)
     low: int | None = None
     high: int | None = None
@@ -136,8 +137,12 @@ def make_string(n, rstate, choices=None, random=False, length=None, **_):
     return rstate.choice(choices, size=n)
 
 
-def make_categorical(n, rstate, choices=None, **_):
-    choices = choices or names
+def make_categorical(n, rstate, choices=None, nunique=None, **_):
+    if nunique is not None:
+        cat_len = len(str(nunique))
+        choices = [str(x + 1).zfill(cat_len) for x in range(nunique)]
+    else:
+        choices = choices or names
     return pd.Categorical.from_codes(rstate.randint(0, len(choices), size=n), choices)
 
 

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -29,43 +29,88 @@ class ColumnSpec:
     Different method can be specified for integer dtype ("poisson", "uniform",
     "binomial", etc.)
 
-    Note: this API is still experimental, and will likely change in the future"""
+    Notes
+    -----
+    This API is still experimental, and will likely change in the future"""
 
     prefix: str | None = None
+    """Column prefix. If not specified, will default to str(dtype)"""
+
     dtype: str | type | None = None
+    """Column data type"""
+
     number: int = 1
+    """How many columns to create with these properties. Default 1.
+    If more than one columns are specified, they will be numbered: "int1", "int2", etc."""
+
     nunique: int | None = None  # number of unique categories
+    """For a "category" column, how many unique categories to generate"""
+
     choices: list = field(default_factory=list)
+    """For a "category" or str column, list of possible values"""
+
     low: int | None = None
+    """Start value for an int column. Optional if random=True, since ``randint`` doesn't accept
+    high and low."""
+
     high: int | None = None
+    """For a "category" column, how many unique categories to generate"""
+
     length: int | None = None
+    """For a str or "category" column, how many unique categories to generate"""
+
     random: bool = False
+    """For an int column, whether to use ``randint``"""
+
     method: str | None = None
+    """For an int column, method to use when generating the value, such as "poisson", "uniform", "binomial".
+    Default "poisson". Delegates to the same method of ``RandomState``"""
+
     kwargs: dict[str, Any] = field(default_factory=dict)
+    """For an int column, any other kwargs to pass into the method"""
 
 
 @dataclass
 class IndexSpec:
     """Properties of the dataframe index
 
-    Note: this API is still experimental, and will likely change in the future"""
+    Notes
+    -----
+    This API is still experimental, and will likely change in the future"""
 
     dtype: str | type = int
-    start: str | None = None  # should be set for DatetimeIndex
-    freq: int | str = 1  # int for RangeIndex, str for DatetimeIndex ("1H", "1D", etc.)
-    partition_freq: str | None = None  # should be set for datetime index
+    """Index dtype. Currently only supports integer and datetime types"""
+
+    start: str | None = None
+    """First value of the index, only required for a DatetimeIndex"""
+
+    freq: int | str = 1
+    """Step for a RangeIndex, frequency for a DatetimeIndex ("1H", "1D", etc.)"""
+
+    partition_freq: str | None = None
+    """Partition frequency, required for a DatetimeIndex ("1D", "1M", etc.)"""
 
 
 @dataclass
 class DatasetSpec:
     """Defines a dataset with random data, such as which columns and data types to generate
 
-    Note: this API is still experimental, and will likely change in the future"""
+    Notes
+    -----
+    This API is still experimental, and will likely change in the future"""
 
     npartitions: int = 1
-    nrecords: int = 1000  # total records
+    """How many partitions generate in the dataframe. If the dataframe has a DatetimeIndex, specify
+    its ``partition_freq`` instead"""
+
+    nrecords: int = 1000
+    """Total number of records to generate"""
+
     index_spec: IndexSpec = field(default_factory=IndexSpec)
+    """Properties of the index"""
+
     column_specs: list[ColumnSpec] = field(default_factory=list)
+    """List of column definitions"""
 
 
 def make_float(n, rstate, random=False, dtype=None, **kwargs):
@@ -347,29 +392,26 @@ def with_spec(spec: DatasetSpec, seed: int | None = None):
     seed: int (optional)
         Randomstate seed
 
-    Note
-    ----
+    Notes
+    -----
     This API is still experimental, and will likely change in the future
 
     Examples
     --------
     >>> from dask.dataframe.io.demo import ColumnSpec, DatasetSpec, with_spec
-
     >>> ddf = with_spec(
-    ...        DatasetSpec(
-    ...             npartitions=10,
-    ...             nrecords=10_000,
-    ...             column_specs=[
-    ...                 ColumnSpec(dtype=int, number=2, prefix="p"),
-    ...                 ColumnSpec(dtype=int, number=2, prefix="n", method="normal"),
-    ...                 ColumnSpec(dtype=float, number=2, prefix="f"),
-    ...                 ColumnSpec(dtype=str, prefix="s", number=2, random=True, length=10),
-    ...                 ColumnSpec(dtype="category", prefix="c", choices=["Y", "N"]),
-    ...             ],
-    ...        ),
-    ...        seed=42)
+    ...     DatasetSpec(
+    ...         npartitions=10,
+    ...         nrecords=10_000,
+    ...         column_specs=[
+    ...             ColumnSpec(dtype=int, number=2, prefix="p"),
+    ...             ColumnSpec(dtype=int, number=2, prefix="n", method="normal"),
+    ...             ColumnSpec(dtype=float, number=2, prefix="f"),
+    ...             ColumnSpec(dtype=str, prefix="s", number=2, random=True, length=10),
+    ...             ColumnSpec(dtype="category", prefix="c", choices=["Y", "N"]),
+    ...         ],
+    ...     ), seed=42)
     >>> ddf.head(10)  # doctest: +SKIP
-
          p1    p2    n1    n2        f1        f2          s1          s2 c1
     0  1002   972  -811    20  0.640846 -0.176875  L#h98#}J`?  _8C607/:6e  N
     1   985   982 -1663  -777  0.790257  0.792796  u:XI3,omoZ  w~@ /d)'-@  N

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import string
 from dataclasses import asdict, dataclass, field
 from typing import Any, Callable, cast
@@ -490,7 +491,7 @@ def with_spec(spec: DatasetSpec, seed: int | None = None):
         if col.prefix:
             prefix = col.prefix
         elif isinstance(col.dtype, str):
-            prefix = "str"
+            prefix = re.sub(r"[^a-zA-Z0-9]", "_", f"{col.dtype}").rstrip("_")
         elif hasattr(col.dtype, "name"):
             prefix = col.dtype.name  # type: ignore[union-attr]
         else:

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import string
 from dataclasses import asdict, dataclass, field
 from typing import Any, Callable, cast
@@ -137,7 +136,7 @@ def make_int(
         if isinstance(method, str):
             # "poisson", "binomial", etc.
             handler_args, handler_kwargs = default_int_args.get(method, ((), {}))
-            handler_kwargs = copy.copy(handler_kwargs)
+            handler_kwargs = handler_kwargs.copy()
             handler_kwargs.update(**kwargs)
             handler = getattr(rstate, method)
             data = handler(*handler_args, size=n, **handler_kwargs)

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -451,7 +451,7 @@ def with_spec(spec: DatasetSpec, seed: int | None = None):
     """
     if len(spec.column_specs) == 0:
         spec.column_specs = [
-            ColumnSpec(prefix="i", dtype=int, low=0, high=1_000_000, random=True),
+            ColumnSpec(prefix="i", dtype="int64", low=0, high=1_000_000, random=True),
             ColumnSpec(prefix="f", dtype=float, random=True),
             ColumnSpec(prefix="c", dtype="category", choices=["a", "b", "c", "d"]),
             ColumnSpec(prefix="s", dtype=str),

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -338,6 +338,37 @@ def with_spec(spec: DatasetSpec, seed: int | None = None):
         Specify all the parameters of the dataset
     seed: int (optional)
         Randomstate seed
+
+    Examples
+    --------
+    >>> from dask.dataframe.io.demo import ColumnSpec, DatasetSpec, with_spec
+
+    >>> ddf = with_spec(
+    ...        DatasetSpec(
+    ...             npartitions=10,
+    ...             nrecords=10_000,
+    ...             column_specs=[
+    ...                 ColumnSpec(dtype=int, number=2, prefix="p"),
+    ...                 ColumnSpec(dtype=int, number=2, prefix="n", method="normal"),
+    ...                 ColumnSpec(dtype=float, number=2, prefix="f"),
+    ...                 ColumnSpec(dtype=str, prefix="s", number=2, random=True, length=10),
+    ...                 ColumnSpec(dtype="category", prefix="c", choices=["Y", "N"]),
+    ...             ],
+    ...        ),
+    ...        seed=42)
+    >>> ddf.head(10)  # doctest: +SKIP
+
+         p1    p2    n1    n2        f1        f2          s1          s2 c1
+    0  1002   972  -811    20  0.640846 -0.176875  L#h98#}J`?  _8C607/:6e  N
+    1   985   982 -1663  -777  0.790257  0.792796  u:XI3,omoZ  w~@ /d)'-@  N
+    2   947   970   799  -269  0.740869 -0.118413  O$dnwCuq\\  !WtSe+(;#9  Y
+    3  1003   983  1133   521 -0.987459  0.278154  j+Qr_2{XG&  &XV7cy$y1T  Y
+    4  1017  1049   826     5 -0.875667 -0.744359  \4bJ3E-{:o  {+jC).?vK+  Y
+    5   984  1017  -492  -399  0.748181  0.293761  ~zUNHNgD"!  yuEkXeVot|  Y
+    6   992  1027  -856    67 -0.125132 -0.234529  j.7z;o]Gc9  g|Fi5*}Y92  Y
+    7  1011   974   762 -1223  0.471696  0.937935  yT?j~N/-u]  JhEB[W-}^$  N
+    8   984   974   856    74  0.109963  0.367864  _j"&@ i&;/  OYXQ)w{hoH  N
+    9  1030  1001  -792  -262  0.435587 -0.647970  Pmrwl{{|.K  3UTqM$86Sg  N
     """
     if len(spec.column_specs) == 0:
         spec.column_specs = [

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -466,9 +466,9 @@ def with_spec(spec: DatasetSpec, seed: int | None = None):
         elif isinstance(col.dtype, str):
             prefix = col.dtype
         elif hasattr(col.dtype, "name"):
-            prefix = col.dtype.name  # type: ignore
+            prefix = col.dtype.name  # type: ignore[union-attr]
         else:
-            prefix = col.dtype.__name__  # type: ignore
+            prefix = col.dtype.__name__  # type: ignore[union-attr]
         for i in range(col.number):
             col_n = i + 1
             while (col_name := f"{prefix}{col_n}") in dtypes:

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -24,7 +24,9 @@ default_int_args: dict[str, tuple[tuple[Any, ...], dict[str, Any]]] = {
 
 @dataclass
 class ColumnSpec:
-    """Encapsulates properties of a family of columns with the same dtype"""
+    """Encapsulates properties of a family of columns with the same dtype.
+    Different method can be specified for integer dtype ("poisson", "uniform",
+    "binomial", etc.)"""
 
     prefix: str | None = None
     dtype: str | type | None = None
@@ -48,6 +50,8 @@ class IndexSpec:
 
 @dataclass
 class DatasetSpec:
+    """Defines a dataset with random data, such as which columns and data types to generate"""
+
     npartitions: int = 1
     nrecords: int = 1000
     index_spec: IndexSpec = field(default_factory=IndexSpec)

--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -375,7 +375,7 @@ def with_spec(spec: DatasetSpec, seed: int | None = None):
             ColumnSpec(prefix="i", dtype=int, low=0, high=1_000_000, random=True),
             ColumnSpec(prefix="f", dtype=float, random=True),
             ColumnSpec(prefix="c", dtype="category", choices=["a", "b", "c", "d"]),
-            ColumnSpec(prefix="s", dtype=str, length=25),
+            ColumnSpec(prefix="s", dtype=str),
         ]
 
     columns = []

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -317,8 +317,7 @@ def test_with_spec_default_integer(seed):
         assert 500 < res[col].max() < 1500
 
 
-@pytest.mark.parametrize("seed", [None, 42])
-def test_with_spec_integer_method(seed):
+def test_with_spec_integer_method():
     from dask.dataframe.io.demo import ColumnSpec, DatasetSpec, with_spec
 
     spec = DatasetSpec(
@@ -328,7 +327,10 @@ def test_with_spec_integer_method(seed):
             ColumnSpec(prefix="pois", dtype=int, method="poisson"),
             ColumnSpec(prefix="norm", dtype=int, method="normal"),
             ColumnSpec(prefix="unif", dtype=int, method="uniform"),
-            ColumnSpec(prefix="binom", dtype=int, method="binomial"),
+            ColumnSpec(prefix="binom", dtype=int, method="binomial", args=(100, 0.4)),
+            ColumnSpec(prefix="choice", dtype=int, method="choice", args=(10,)),
+            ColumnSpec(prefix="rand", dtype=int, random=True, low=0, high=10),
+            ColumnSpec(prefix="rand", dtype=int, random=True),
         ],
     )
     ddf = with_spec(spec, seed=42)
@@ -336,7 +338,10 @@ def test_with_spec_integer_method(seed):
     assert res["pois1"].tolist() == [1002, 985, 947, 1003, 1017]
     assert res["norm1"].tolist() == [-1097, -276, 853, 272, 784]
     assert res["unif1"].tolist() == [772, 972, 798, 393, 656]
-    assert res["binom1"].tolist() == [507, 492, 489, 481, 508]
+    assert res["binom1"].tolist() == [34, 46, 38, 37, 43]
+    assert res["choice1"].tolist() == [0, 3, 1, 6, 6]
+    assert res["rand1"].tolist() == [4, 6, 9, 4, 5]
+    assert res["rand2"].tolist() == [883, 104, 192, 648, 256]
 
 
 def test_with_spec_datetime_index():

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -226,7 +226,8 @@ def test_with_spec_non_default(seed):
     assert len(res.s1.unique()) == 10
 
 
-def test_same_prefix_col_numbering():
+@pytest.mark.parametrize("seed", [None, 42])
+def test_same_prefix_col_numbering(seed):
     from dask.dataframe.io.demo import ColumnSpec, DatasetSpec, with_spec
 
     spec = DatasetSpec(
@@ -239,8 +240,29 @@ def test_same_prefix_col_numbering():
             ColumnSpec(dtype=int),
         ],
     )
-    ddf = with_spec(spec)
+    ddf = with_spec(spec, seed=seed)
     assert ddf.columns.tolist() == ["int1", "int2", "int3", "int4"]
+
+
+@pytest.mark.parametrize("seed", [None, 42])
+def test_with_spec_default_integer(seed):
+    from dask.dataframe.io.demo import ColumnSpec, DatasetSpec, with_spec
+
+    spec = DatasetSpec(
+        npartitions=1,
+        nrecords=5,
+        column_specs=[
+            ColumnSpec(dtype=int),
+            ColumnSpec(dtype=int),
+            ColumnSpec(dtype=int),
+            ColumnSpec(dtype=int),
+        ],
+    )
+    ddf = with_spec(spec, seed=seed)
+    res = ddf.compute()
+    for col in res.columns:
+        assert 500 < res[col].min() < 1500
+        assert 500 < res[col].max() < 1500
 
 
 def test_with_spec_integer_method():

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -186,7 +186,7 @@ def test_with_spec(seed):
     assert isinstance(ddf, dd.DataFrame)
     assert ddf.npartitions == 2
     assert ddf.columns.tolist() == ["i1", "f1", "c1", "s1"]
-    assert ddf["i1"].dtype == int
+    assert ddf["i1"].dtype == "int64"
     assert ddf["f1"].dtype == float
     assert ddf["c1"].dtype.name == "category"
     assert ddf["s1"].dtype == get_string_dtype()

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -312,3 +312,19 @@ def test_with_spec_integer_method(seed):
     assert res["norm1"].tolist() == [-1097, -276, 853, 272, 784]
     assert res["unif1"].tolist() == [772, 972, 798, 393, 656]
     assert res["binom1"].tolist() == [507, 492, 489, 481, 508]
+
+
+def test_with_spec_datetime_index():
+    from dask.dataframe.io.demo import ColumnSpec, DatasetSpec, IndexSpec, with_spec
+
+    spec = DatasetSpec(
+        nrecords=10,
+        index_spec=IndexSpec(
+            dtype="datetime64[ns]", freq="1H", start="2023-01-02", partition_freq="1D"
+        ),
+        column_specs=[ColumnSpec(dtype=int)],
+    )
+    ddf = with_spec(spec, seed=42)
+    assert ddf.index.dtype == "datetime64[ns]"
+    res = ddf.compute()
+    assert len(res) == 10

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -245,11 +245,11 @@ def test_with_spec_pyarrow():
     )
     ddf = with_spec(spec, seed=42)
     assert isinstance(ddf, dd.DataFrame)
-    assert ddf.columns.tolist() == ["str1"]
-    assert ddf["str1"].dtype == "string[pyarrow]"
+    assert ddf.columns.tolist() == ["string_pyarrow1"]
+    assert ddf["string_pyarrow1"].dtype == "string[pyarrow]"
     res = ddf.compute()
-    assert res["str1"].dtype == "string[pyarrow]"
-    assert all(len(s) == 10 for s in res["str1"].tolist())
+    assert res["string_pyarrow1"].dtype == "string[pyarrow]"
+    assert all(len(s) == 10 for s in res["string_pyarrow1"].tolist())
 
 
 @pytest.mark.parametrize("seed", [None, 42])

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -6,7 +6,7 @@ import pytest
 import dask
 import dask.dataframe as dd
 from dask.blockwise import Blockwise, optimize_blockwise
-from dask.dataframe._compat import tm
+from dask.dataframe._compat import PANDAS_GT_200, tm
 from dask.dataframe.optimize import optimize_dataframe_getitem
 from dask.dataframe.utils import assert_eq, get_string_dtype
 
@@ -189,7 +189,7 @@ def test_with_spec(seed):
     assert ddf["i1"].dtype == int
     assert ddf["f1"].dtype == float
     assert ddf["c1"].dtype.name == "category"
-    assert ddf["s1"].dtype == "object"
+    assert ddf["s1"].dtype == get_string_dtype()
     res = ddf.compute()
     assert len(res) == 10
 
@@ -212,11 +212,12 @@ def test_with_spec_non_default(seed):
     ddf = with_spec(spec, seed=seed)
     assert isinstance(ddf, dd.DataFrame)
     assert ddf.columns.tolist() == ["i1", "f1", "c1", "s1"]
-    assert ddf.index.dtype == "int32"
+    if PANDAS_GT_200:
+        assert ddf.index.dtype == "int32"
     assert ddf["i1"].dtype == "int32"
     assert ddf["f1"].dtype == "float32"
     assert ddf["c1"].dtype.name == "category"
-    assert ddf["s1"].dtype == "object"
+    assert ddf["s1"].dtype == get_string_dtype()
     res = ddf.compute().sort_index()
     assert len(res) == 10
     assert set(res.c1.cat.categories) == {"apple", "banana"}

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -265,7 +265,8 @@ def test_with_spec_default_integer(seed):
         assert 500 < res[col].max() < 1500
 
 
-def test_with_spec_integer_method():
+@pytest.mark.parametrize("seed", [None, 42])
+def test_with_spec_integer_method(seed):
     from dask.dataframe.io.demo import ColumnSpec, DatasetSpec, with_spec
 
     spec = DatasetSpec(

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -196,12 +196,17 @@ def test_with_spec(seed):
 
 @pytest.mark.parametrize("seed", [None, 42])
 def test_with_spec_non_default(seed):
-    from dask.dataframe.io.demo import ColumnSpec, DatasetSpec, IndexSpec, with_spec
+    from dask.dataframe.io.demo import (
+        ColumnSpec,
+        DatasetSpec,
+        RangeIndexSpec,
+        with_spec,
+    )
 
     spec = DatasetSpec(
         npartitions=3,
         nrecords=10,
-        index_spec=IndexSpec(dtype="int32", freq=2),
+        index_spec=RangeIndexSpec(dtype="int32", step=2),
         column_specs=[
             ColumnSpec(prefix="i", dtype="int32", low=1, high=100, random=True),
             ColumnSpec(prefix="f", dtype="float32", random=True),
@@ -315,11 +320,16 @@ def test_with_spec_integer_method(seed):
 
 
 def test_with_spec_datetime_index():
-    from dask.dataframe.io.demo import ColumnSpec, DatasetSpec, IndexSpec, with_spec
+    from dask.dataframe.io.demo import (
+        ColumnSpec,
+        DatasetSpec,
+        DatetimeIndexSpec,
+        with_spec,
+    )
 
     spec = DatasetSpec(
         nrecords=10,
-        index_spec=IndexSpec(
+        index_spec=DatetimeIndexSpec(
             dtype="datetime64[ns]", freq="1H", start="2023-01-02", partition_freq="1D"
         ),
         column_specs=[ColumnSpec(dtype=int)],

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -244,6 +244,32 @@ def test_same_prefix_col_numbering(seed):
     assert ddf.columns.tolist() == ["int1", "int2", "int3", "int4"]
 
 
+def test_with_spec_category_nunique():
+    from dask.dataframe.io.demo import ColumnSpec, DatasetSpec, with_spec
+
+    spec = DatasetSpec(
+        npartitions=1,
+        nrecords=20,
+        column_specs=[
+            ColumnSpec(dtype="category", nunique=10),
+        ],
+    )
+    ddf = with_spec(spec, seed=42)
+    res = ddf.compute()
+    assert res.category1.cat.categories.tolist() == [
+        "01",
+        "02",
+        "03",
+        "04",
+        "05",
+        "06",
+        "07",
+        "08",
+        "09",
+        "10",
+    ]
+
+
 @pytest.mark.parametrize("seed", [None, 42])
 def test_with_spec_default_integer(seed):
     from dask.dataframe.io.demo import ColumnSpec, DatasetSpec, with_spec

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -212,24 +212,27 @@ def test_with_spec_non_default(seed):
             ColumnSpec(prefix="f", dtype="float32", random=True),
             ColumnSpec(prefix="c", dtype="category", choices=["apple", "banana"]),
             ColumnSpec(prefix="s", dtype=str, length=15, random=True),
+            ColumnSpec(prefix="arr", dtype="string[pyarrow]", length=10, random=True),
         ],
     )
     ddf = with_spec(spec, seed=seed)
     assert isinstance(ddf, dd.DataFrame)
-    assert ddf.columns.tolist() == ["i1", "f1", "c1", "s1"]
+    assert ddf.columns.tolist() == ["i1", "f1", "c1", "s1", "arr1"]
     if PANDAS_GT_200:
         assert ddf.index.dtype == "int32"
     assert ddf["i1"].dtype == "int32"
     assert ddf["f1"].dtype == "float32"
     assert ddf["c1"].dtype.name == "category"
     assert ddf["s1"].dtype == get_string_dtype()
+    assert ddf["arr1"].dtype == "string[pyarrow]"
     res = ddf.compute().sort_index()
     assert len(res) == 10
     assert set(res.c1.cat.categories) == {"apple", "banana"}
     assert res.i1.min() >= 1
     assert res.i1.max() <= 100
     assert all(len(s) == 15 for s in res.s1.tolist())
-    assert len(res.s1.unique()) == 10
+    assert all(len(s) == 10 for s in res.arr1.tolist())
+    assert len(res.s1.unique()) <= 10
 
 
 @pytest.mark.parametrize("seed", [None, 42])

--- a/dask/datasets.py
+++ b/dask/datasets.py
@@ -71,13 +71,6 @@ def timeseries(
     )
 
 
-def with_spec(spec):
-    """"""
-    from dask.dataframe.io.demo import with_spec
-
-    return with_spec(spec)
-
-
 def _generate_mimesis(field, schema_description, records_per_partition, seed):
     """Generate data for a single partition of a dask bag
 

--- a/dask/datasets.py
+++ b/dask/datasets.py
@@ -71,6 +71,13 @@ def timeseries(
     )
 
 
+def with_spec(spec):
+    """"""
+    from dask.dataframe.io.demo import with_spec
+
+    return with_spec(spec)
+
+
 def _generate_mimesis(field, schema_description, records_per_partition, seed):
     """Generate data for a single partition of a dask bag
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -72,28 +72,28 @@ The following helpers are still experimental:
 .. autofunction:: with_spec
 
 The ``ColumnSpec`` class
-*****************************
+************************
 .. autoclass:: dask.dataframe.io.demo.ColumnSpec
     :members:
     :undoc-members:
     :show-inheritance:
 
 The ``RangeIndexSpec`` class
-*****************************
+****************************
 .. autoclass:: dask.dataframe.io.demo.RangeIndexSpec
     :members:
     :undoc-members:
     :show-inheritance:
 
 The ``DatetimeIndexSpec`` class
-*****************************
+*******************************
 .. autoclass:: dask.dataframe.io.demo.DatetimeIndexSpec
     :members:
     :undoc-members:
     :show-inheritance:
 
 The ``DatasetSpec`` class
-*****************************
+*************************
 .. autoclass:: dask.dataframe.io.demo.DatasetSpec
     :members:
     :undoc-members:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -78,9 +78,16 @@ The ``ColumnSpec`` class
     :undoc-members:
     :show-inheritance:
 
-The ``IndexSpec`` class
+The ``RangeIndexSpec`` class
 *****************************
-.. autoclass:: dask.dataframe.io.demo.IndexSpec
+.. autoclass:: dask.dataframe.io.demo.RangeIndexSpec
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+The ``DatetimeIndexSpec`` class
+*****************************
+.. autoclass:: dask.dataframe.io.demo.DatetimeIndexSpec
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -62,6 +62,36 @@ Dask has a few helpers for generating demo datasets
 .. autofunction:: make_people
 .. autofunction:: timeseries
 
+Datasets with defined specs
+---------------------------
+
+The following helpers are still experimental:
+
+.. currentmodule:: dask.dataframe.io.demo
+
+.. autofunction:: with_spec
+
+The ``ColumnSpec`` class
+*****************************
+.. autoclass:: dask.dataframe.io.demo.ColumnSpec
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+The ``IndexSpec`` class
+*****************************
+.. autoclass:: dask.dataframe.io.demo.IndexSpec
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+The ``DatasetSpec`` class
+*****************************
+.. autoclass:: dask.dataframe.io.demo.DatasetSpec
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 .. _api.utilities:
 
 Utilities


### PR DESCRIPTION
API to generate random Dask dataframes. Very similar to what `dask.dataset.timeseries` is doing, only more generic.

This is not perfectly polished, but will be useful even in the current shape.

Usage example:

```python
    >>> from dask.dataframe.io.demo import ColumnSpec, DatasetSpec, with_spec

    >>> ddf = with_spec(
    ...        DatasetSpec(
    ...             npartitions=10,
    ...             nrecords=10_000,
    ...             column_specs=[
    ...                 ColumnSpec(dtype=int, number=2, prefix="p"),
    ...                 ColumnSpec(dtype=int, number=2, prefix="n", method="normal"),
    ...                 ColumnSpec(dtype=float, number=2, prefix="f"),
    ...                 ColumnSpec(dtype=str, prefix="s", number=2, random=True, length=10),
    ...                 ColumnSpec(dtype="category", prefix="c", choices=["Y", "N"]),
    ...             ],
    ...        ),
    ...        seed=42)
    >>> ddf.head(10)  # doctest: +SKIP

         p1    p2    n1    n2        f1        f2          s1          s2 c1
    0  1002   972  -811    20  0.640846 -0.176875  L#h98#}J`?  _8C607/:6e  N
    1   985   982 -1663  -777  0.790257  0.792796  u:XI3,omoZ  w~@ /d)'-@  N
    2   947   970   799  -269  0.740869 -0.118413  O$dnwCuq\\  !WtSe+(;#9  Y
    3  1003   983  1133   521 -0.987459  0.278154  j+Qr_2{XG&  &XV7cy$y1T  Y
    4  1017  1049   826     5 -0.875667 -0.744359  \4bJ3E-{:o  {+jC).?vK+  Y
    5   984  1017  -492  -399  0.748181  0.293761  ~zUNHNgD"!  yuEkXeVot|  Y
    6   992  1027  -856    67 -0.125132 -0.234529  j.7z;o]Gc9  g|Fi5*}Y92  Y
    7  1011   974   762 -1223  0.471696  0.937935  yT?j~N/-u]  JhEB[W-}^$  N
    8   984   974   856    74  0.109963  0.367864  _j"&@ i&;/  OYXQ)w{hoH  N
    9  1030  1001  -792  -262  0.435587 -0.647970  Pmrwl{{|.K  3UTqM$86Sg  N
```

If nothing is specified, will generate 1000 records with one `int`, `float`, `category`, and `str` column each:

```python
>>> from dask.dataframe.io.demo import DatasetSpec, with_spec

>>> ddf = with_spec(DatasetSpec())

>>> ddf.compute()

         i1        f1 c1        s1
0    909505  0.678504  a    Yvonne
1    767969  0.821720  a  Patricia
2    772473  0.312959  a     Kevin
3    914339  0.703716  b  Patricia
4    279354  0.067557  a     Jerry
..      ...       ... ..       ...
995  623166  0.329424  c     Sarah
996  262497  0.530753  d   Norbert
997  559945  0.540155  b     Alice
998   71791  0.884584  d    Oliver
999  723881  0.988442  b     Laura

[1000 rows x 4 columns]
```

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
