### PR TITLE
Make ``repartition`` a no-op when list of divisions match

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -7954,7 +7954,7 @@ def repartition(df, divisions=None, force=False):
     """
 
     # no-op fastpath for when we already have matching divisions
-    if is_dask_collection(df) and df.divisions == divisions:
+    if is_dask_collection(df) and df.divisions == tuple(divisions):
         return df
 
     token = tokenize(df, divisions)


### PR DESCRIPTION
Closes #10394
