### PR TITLE
Convert to ``pyarrow`` strings if proper dependencies are installed

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -61,13 +61,20 @@ def pytest_runtest_setup(item):
         pytest.skip("need --runslow option to run")
 
 
+try:
+    from dask.dataframe.utils import pyarrow_strings_enabled
+
+    convert_string = pyarrow_strings_enabled()
+except (ImportError, RuntimeError):
+    convert_string = False
+
 skip_with_pyarrow_strings = pytest.mark.skipif(
-    bool(dask.config.get("dataframe.convert-string")),
+    convert_string,
     reason="No need to run with pyarrow strings",
 )
 
 xfail_with_pyarrow_strings = pytest.mark.xfail(
-    bool(dask.config.get("dataframe.convert-string")),
+    convert_string,
     reason="Known failure with pyarrow strings",
 )
 

--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -171,13 +171,7 @@ def test_open_glob(dir_server):
 
 
 @pytest.mark.network
-@pytest.mark.parametrize(
-    "engine",
-    (
-        "pyarrow",
-        pytest.param("fastparquet", marks=pytest.mark.xfail_with_pyarrow_strings),
-    ),
-)
+@pytest.mark.parametrize("engine", ["pyarrow", "fastparquet"])
 def test_parquet(engine):
     pytest.importorskip("requests", minversion="2.21.0")
     dd = pytest.importorskip("dask.dataframe")

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -439,13 +439,7 @@ def test_modification_time_read_bytes(s3, s3so):
     assert [aa._key for aa in concat(a)] != [cc._key for cc in concat(c)]
 
 
-@pytest.mark.parametrize(
-    "engine",
-    [
-        "pyarrow",
-        pytest.param("fastparquet", marks=pytest.mark.xfail_with_pyarrow_strings),
-    ],
-)
+@pytest.mark.parametrize("engine", ["pyarrow", "fastparquet"])
 @pytest.mark.parametrize("metadata_file", [True, False])
 def test_parquet(s3, engine, s3so, metadata_file):
     dd = pytest.importorskip("dask.dataframe")

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -538,13 +538,7 @@ def test_parquet(s3, engine, s3so, metadata_file):
     dd.utils.assert_eq(data, df4)
 
 
-@pytest.mark.parametrize(
-    "engine",
-    [
-        "pyarrow",
-        pytest.param("fastparquet", marks=pytest.mark.xfail_with_pyarrow_strings),
-    ],
-)
+@pytest.mark.parametrize("engine", ["pyarrow", "fastparquet"])
 def test_parquet_append(s3, engine, s3so):
     pytest.importorskip(engine)
     dd = pytest.importorskip("dask.dataframe")
@@ -599,13 +593,7 @@ def test_parquet_append(s3, engine, s3so):
     )
 
 
-@pytest.mark.parametrize(
-    "engine",
-    [
-        "pyarrow",
-        pytest.param("fastparquet", marks=pytest.mark.xfail_with_pyarrow_strings),
-    ],
-)
+@pytest.mark.parametrize("engine", ["pyarrow", "fastparquet"])
 def test_parquet_wstoragepars(s3, s3so, engine):
     pytest.importorskip(engine)
     dd = pytest.importorskip("dask.dataframe")

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -86,7 +86,7 @@ properties:
               Specifying 0 will result in serial execution on the client.
 
       convert-string:
-        type: boolean
+        type: [boolean, 'null']
         description: |
           Whether to convert string-like data to pyarrow strings.
 

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -14,7 +14,7 @@ dataframe:
   parquet:
     metadata-task-size-local: 512  # Number of files per local metadata-processing task
     metadata-task-size-remote: 1  # Number of files per remote metadata-processing task
-  convert-string: false  # Whether to convert string-like data to pyarrow strings
+  convert-string: null  # Whether to convert string-like data to pyarrow strings
 
 array:
   backend: "numpy"  # Backend array library for input IO and data creation

--- a/dask/dataframe/_pyarrow.py
+++ b/dask/dataframe/_pyarrow.py
@@ -65,6 +65,10 @@ def _to_string_dtype(df, dtype_check, index_check, string_dtype):
     if not (is_dataframe_like(df) or is_series_like(df) or is_index_like(df)):
         return df
 
+    # Guards against importing `pyarrow` at the module level (where it may not be installed)
+    if string_dtype == "pyarrow":
+        string_dtype = pd.StringDtype("pyarrow")
+
     # Possibly convert DataFrame/Series/Index to `string[pyarrow]`
     dtypes = None
     if is_dataframe_like(df):
@@ -98,7 +102,7 @@ to_pyarrow_string = partial(
     _to_string_dtype,
     dtype_check=is_object_string_dtype,
     index_check=is_object_string_index,
-    string_dtype=pd.StringDtype("pyarrow"),
+    string_dtype="pyarrow",
 )
 to_object_string = partial(
     _to_string_dtype,
@@ -110,10 +114,10 @@ to_object_string = partial(
 
 def check_pyarrow_string_supported():
     """Make sure we have all the required versions"""
-    if pa is None and Version(pa.__version__) >= Version("12.0.0"):
+    if pa is None or Version(pa.__version__) < Version("12.0.0"):
         raise RuntimeError(
             "Using dask's `dataframe.convert-string` configuration "
-            "option requires `pyarrow` to be installed."
+            "option requires `pyarrow>=12` to be installed."
         )
     if not PANDAS_GT_200:
         raise RuntimeError(

--- a/dask/dataframe/_pyarrow.py
+++ b/dask/dataframe/_pyarrow.py
@@ -114,13 +114,13 @@ to_object_string = partial(
 
 def check_pyarrow_string_supported():
     """Make sure we have all the required versions"""
-    if pa is None or Version(pa.__version__) < Version("12.0.0"):
-        raise RuntimeError(
-            "Using dask's `dataframe.convert-string` configuration "
-            "option requires `pyarrow>=12` to be installed."
-        )
     if not PANDAS_GT_200:
         raise RuntimeError(
             "Using dask's `dataframe.convert-string` configuration "
             "option requires `pandas>=2.0` to be installed."
+        )
+    if pa is None or Version(pa.__version__) < Version("12.0.0"):
+        raise RuntimeError(
+            "Using dask's `dataframe.convert-string` configuration "
+            "option requires `pyarrow>=12` to be installed."
         )

--- a/dask/dataframe/_pyarrow.py
+++ b/dask/dataframe/_pyarrow.py
@@ -78,9 +78,7 @@ def _to_string_dtype(df, dtype_check, index_check, string_dtype):
         df = df.astype(dtypes, copy=False)
 
     # Convert DataFrame/Series index too
-    if (is_dataframe_like(df) or is_series_like(df)) and index_check(
-        df.index
-    ):
+    if (is_dataframe_like(df) or is_series_like(df)) and index_check(df.index):
         if isinstance(df.index, pd.MultiIndex):
             levels = {
                 i: level.astype(string_dtype)

--- a/dask/dataframe/_pyarrow.py
+++ b/dask/dataframe/_pyarrow.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from functools import partial
+
 import pandas as pd
+from packaging.version import Version
 
 from dask.dataframe._compat import PANDAS_GT_150, PANDAS_GT_200
 from dask.dataframe.utils import is_dataframe_like, is_index_like, is_series_like
@@ -33,6 +36,12 @@ def is_object_string_dtype(dtype):
     )
 
 
+def is_pyarrow_string_index(x):
+    if isinstance(x, pd.MultiIndex):
+        return any(is_pyarrow_string_index(level) for level in x.levels)
+    return isinstance(x, pd.Index) and is_pyarrow_string_dtype(x.dtype)
+
+
 def is_object_string_index(x):
     if isinstance(x, pd.MultiIndex):
         return any(is_object_string_index(level) for level in x.levels)
@@ -52,7 +61,7 @@ def is_object_string_dataframe(x):
     )
 
 
-def to_pyarrow_string(df):
+def _to_string_dtype(df, dtype_check, index_check, string_dtype):
     if not (is_dataframe_like(df) or is_series_like(df) or is_index_like(df)):
         return df
 
@@ -60,38 +69,50 @@ def to_pyarrow_string(df):
     dtypes = None
     if is_dataframe_like(df):
         dtypes = {
-            col: pd.StringDtype("pyarrow")
-            for col, dtype in df.dtypes.items()
-            if is_object_string_dtype(dtype)
+            col: string_dtype for col, dtype in df.dtypes.items() if dtype_check(dtype)
         }
-    elif is_object_string_dtype(df.dtype):
-        dtypes = pd.StringDtype("pyarrow")
+    elif dtype_check(df.dtype):
+        dtypes = string_dtype
 
     if dtypes:
         df = df.astype(dtypes, copy=False)
 
     # Convert DataFrame/Series index too
-    if (is_dataframe_like(df) or is_series_like(df)) and is_object_string_index(
+    if (is_dataframe_like(df) or is_series_like(df)) and index_check(
         df.index
     ):
         if isinstance(df.index, pd.MultiIndex):
             levels = {
-                i: level.astype(pd.StringDtype("pyarrow"))
+                i: level.astype(string_dtype)
                 for i, level in enumerate(df.index.levels)
-                if is_object_string_dtype(level.dtype)
+                if dtype_check(level.dtype)
             }
             # set verify_integrity=False to preserve index codes
             df.index = df.index.set_levels(
                 levels.values(), level=levels.keys(), verify_integrity=False
             )
         else:
-            df.index = df.index.astype(pd.StringDtype("pyarrow"))
+            df.index = df.index.astype(string_dtype)
     return df
+
+
+to_pyarrow_string = partial(
+    _to_string_dtype,
+    dtype_check=is_object_string_dtype,
+    index_check=is_object_string_index,
+    string_dtype=pd.StringDtype("pyarrow"),
+)
+to_object_string = partial(
+    _to_string_dtype,
+    dtype_check=is_pyarrow_string_dtype,
+    index_check=is_pyarrow_string_index,
+    string_dtype=object,
+)
 
 
 def check_pyarrow_string_supported():
     """Make sure we have all the required versions"""
-    if pa is None:
+    if pa is None and Version(pa.__version__) >= Version("12.0.0"):
         raise RuntimeError(
             "Using dask's `dataframe.convert-string` configuration "
             "option requires `pyarrow` to be installed."

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -20,7 +20,6 @@ from pandas.api.types import (
 )
 from tlz import first, merge, partition_all, remove, unique
 
-import dask
 import dask.array as da
 from dask import core
 from dask.array.core import Array, normalize_arg
@@ -72,6 +71,7 @@ from dask.dataframe.utils import (
     make_meta,
     meta_frame_constructor,
     meta_series_constructor,
+    pyarrow_strings_enabled,
     raise_on_meta_error,
     valid_divisions,
 )
@@ -402,8 +402,10 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
         self._meta = meta
         self.divisions = tuple(divisions)
 
-        # Optionally cast object dtypes to `pyarrow` strings
-        if dask.config.get("dataframe.convert-string"):
+        # Optionally cast object dtypes to `pyarrow` strings.
+        # By default, if `pyarrow` and `pandas>=2` are installed,
+        # we convert to pyarrow strings.
+        if pyarrow_strings_enabled():
             from dask.dataframe._pyarrow import check_pyarrow_string_supported
 
             check_pyarrow_string_supported()

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -441,7 +441,9 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
 
                 # this is an internal call, and if we enforce metadata,
                 # it may interfere when reading csv with enforce=False
-                result = self.map_partitions(to_pyarrow_string, enforce_metadata=False)
+                result = self.map_partitions(
+                    to_pyarrow_string, enforce_metadata=False, token="to_pyarrow_string"
+                )
                 self.dask = result.dask
                 self._name = result._name
                 self._meta = result._meta

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -36,7 +36,7 @@ from dask.dataframe.io.parquet.utils import (
     _sort_and_analyze_paths,
 )
 from dask.dataframe.io.utils import _get_pyarrow_dtypes, _is_local_fs, _open_input_files
-from dask.dataframe.utils import clear_known_categories
+from dask.dataframe.utils import clear_known_categories, pyarrow_strings_enabled
 from dask.delayed import Delayed
 from dask.utils import getargspec, natural_sort_key
 
@@ -1157,7 +1157,7 @@ class ArrowDatasetEngine(Engine):
             "metadata_task_size": metadata_task_size,
             "kwargs": {
                 "dataset": _dataset_kwargs,
-                "convert_string": dask.config.get("dataframe.convert-string"),
+                "convert_string": pyarrow_strings_enabled(),
                 **kwargs,
             },
         }

--- a/dask/dataframe/tests/test_format.py
+++ b/dask/dataframe/tests/test_format.py
@@ -34,7 +34,7 @@ def _format_string_dtype():
 
 def _format_footer(suffix="", layers=1):
     if pyarrow_strings_enabled():
-        return f"Dask Name: to_pyarrow_string{suffix}, {maybe_pluralize(layers + 1, 'graph layer')}"
+        return f"Dask Name: to_string_dtype{suffix}, {maybe_pluralize(layers + 1, 'graph layer')}"
     return f"Dask Name: from_pandas{suffix}, {maybe_pluralize(layers, 'graph layer')}"
 
 

--- a/dask/dataframe/tests/test_format.py
+++ b/dask/dataframe/tests/test_format.py
@@ -34,7 +34,7 @@ def _format_string_dtype():
 
 def _format_footer(suffix="", layers=1):
     if pyarrow_strings_enabled():
-        return f"Dask Name: to_string_dtype{suffix}, {maybe_pluralize(layers + 1, 'graph layer')}"
+        return f"Dask Name: to_pyarrow_string{suffix}, {maybe_pluralize(layers + 1, 'graph layer')}"
     return f"Dask Name: from_pandas{suffix}, {maybe_pluralize(layers, 'graph layer')}"
 
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -541,9 +541,7 @@ def _maybe_sort(a, check_index: bool):
 
 
 def _maybe_convert_string(a, b):
-    import dask
-
-    if bool(dask.config.get("dataframe.convert-string")):
+    if pyarrow_strings_enabled():
         from dask.dataframe._pyarrow import to_pyarrow_string
 
         if isinstance(a, (pd.DataFrame, pd.Series, pd.Index)):
@@ -827,11 +825,7 @@ def meta_series_constructor(like):
 
 def get_string_dtype():
     """Depending on config setting, we might convert objects to pyarrow strings"""
-    return (
-        pd.StringDtype("pyarrow")
-        if bool(dask.config.get("dataframe.convert-string"))
-        else object
-    )
+    return pd.StringDtype("pyarrow") if pyarrow_strings_enabled() else object
 
 
 def pyarrow_strings_enabled() -> bool:


### PR DESCRIPTION
We've seen really nice memory / performance improvements when using `string[pyarrow]` for text data in Dask DataFrame. The changes here makes it so that if `pandas>=2` and `pyarrow` are installed, we automatically convert objects to `string[pyarrow]` by default. If those required dependencies aren't installed, then stick with `object`-backed dtypes for text data. 

Also, I don't think this should be included in the release tomorrow (xref https://github.com/dask/community/issues/330) but rather the release after that (2023.7.1). Marking as `[DNM]` for now to signal this. 

TODO: 

- [x] Add test coverage for the new default behavior
- [x] Make decision on how to handle `fastparquet` engine in `read_parquet`