### PR TITLE
Add ``_Frame.enforce_runtime_divisions`` method

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -727,8 +727,9 @@ Dask Name: {name}, {layers}"""
             # Upper division of the last partition is often set to
             # the max value. For all other partitions, the upper
             # division should be greater than the maximum value.
+            valid_min = real_min >= expect_min
             valid_max = (real_max <= expect_max) if last else (real_max < expect_max)
-            if real_min < expect_min or not valid_max:
+            if not (valid_min and valid_max):
                 raise RuntimeError(
                     f"`enforce_runtime_divisions` failed for partition {id}."
                     f" Expected a range of [{expect_min}, {expect_max}), "


### PR DESCRIPTION
Adds a new `_Frame` method to validate that the min and max value of each partition is consistent with the `divisions` metadata at run time. Note that I decided to use "enforce" instead of "ensure", since ensure suggests that we will be able to somehow fix/adjust the divisions at run time (which we cannot do).

- [x] Closes #10378
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

**Other Notes**:
- This functionality feels similar to the `enforce_metadata` argument used by `_Frame.map_partitions`. Perhaps we should add a `enforce_divisions=False` kwarg to `map_partitions`? If so, `_Frame.enforce_runtime_divisions` could simply return a no-op `map_partitions` call with `enforce_divisions=True`.
- I noticed that rules are a little bit tricky for the last partition. For this special cases, the upper division is often set to be **equal** to the maximum value in the partition (rather than being strictly **less than** the upper divisions).

