### PR TITLE
Fix FutureWarning: The provided callable...

### DIFF
--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1274,7 +1274,7 @@ def test_shuffle_aggregate_defaults(shuffle_method):
     assert any("shuffle" in l for l in dsk.layers)
 
 
-@pytest.mark.parametrize("spec", [{"c": "median"}, {"b": np.median, "c": np.max}])
+@pytest.mark.parametrize("spec", [{"c": "median"}, {"b": "median", "c": "max"}])
 @pytest.mark.parametrize("keys", ["a", ["a", "d"]])
 def test_aggregate_median(spec, keys, shuffle_method):
     pdf = pd.DataFrame(
@@ -3321,7 +3321,7 @@ def test_dataframe_named_agg(shuffle):
 
 @pytest.mark.skipif(not PANDAS_GT_140, reason="requires pandas >= 1.4.0")
 @pytest.mark.parametrize("shuffle", [True, False])
-@pytest.mark.parametrize("agg", ["count", np.mean, partial(np.var, ddof=1)])
+@pytest.mark.parametrize("agg", ["count", "mean", partial(np.var, ddof=1)])
 def test_series_named_agg(shuffle, agg):
     df = pd.DataFrame(
         {

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -515,23 +515,23 @@ def test_rolling_agg_aggregate():
     ddf = dd.from_pandas(df, npartitions=3)
 
     assert_eq(
-        df.rolling(window=3).agg([np.mean, np.std]),
-        ddf.rolling(window=3).agg([np.mean, np.std]),
+        df.rolling(window=3).agg(["mean", "std"]),
+        ddf.rolling(window=3).agg(["mean", "std"]),
     )
 
     assert_eq(
-        df.rolling(window=3).agg({"A": np.sum, "B": lambda x: np.std(x, ddof=1)}),
-        ddf.rolling(window=3).agg({"A": np.sum, "B": lambda x: np.std(x, ddof=1)}),
+        df.rolling(window=3).agg({"A": "sum", "B": lambda x: np.std(x, ddof=1)}),
+        ddf.rolling(window=3).agg({"A": "sum", "B": lambda x: np.std(x, ddof=1)}),
     )
 
     assert_eq(
-        df.rolling(window=3).agg([np.sum, np.mean]),
-        ddf.rolling(window=3).agg([np.sum, np.mean]),
+        df.rolling(window=3).agg(["sum", "mean"]),
+        ddf.rolling(window=3).agg(["sum", "mean"]),
     )
 
     assert_eq(
-        df.rolling(window=3).agg({"A": [np.sum, np.mean]}),
-        ddf.rolling(window=3).agg({"A": [np.sum, np.mean]}),
+        df.rolling(window=3).agg({"A": ["sum", "mean"]}),
+        ddf.rolling(window=3).agg({"A": ["sum", "mean"]}),
     )
 
     kwargs = {"raw": True}


### PR DESCRIPTION
Fixes this deprecation:

`dask/dataframe/tests/test_groupby.py::test_aggregate_median[disk-keys1-spec1]: FutureWarning: The provided callable <function median at 0x7f4189befe20> is currently using SeriesGroupBy.median. In a future version of pandas, the provided callable will be used directly. To keep current behavior pass 'median' instead.`

Related to https://github.com/dask/dask/issues/10347

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
