### PR TITLE
Category dtype is lost when concatenating `MultiIndex`

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -501,13 +501,7 @@ def _non_agg_chunk(df, *by, key, dropna=None, observed=None, **kwargs):
         ):
             has_categoricals = True
             full_index = pd.MultiIndex.from_product(
-                (
-                    level.categories
-                    if isinstance(level, pd.CategoricalIndex)
-                    else level
-                    for level in result.index.levels
-                ),
-                names=result.index.names,
+                result.index.levels, names=result.index.names
             )
         if has_categoricals:
             # If we found any categoricals, append unobserved values to the end of the


### PR DESCRIPTION
Fix for this failure with upstream pandas:

```
dask/dataframe/tests/test_groupby.py::test_groupby_aggregate_categorical_observed[median-disk-unobserved-groupby1-ordered-known]: AssertionError: MultiIndex level [0] are different

MultiIndex level [0] classes are different
[left]:  CategoricalIndex(['A', 'A', 'A', 'B', 'B', 'B', 'C', 'C', 'C', 'D', 'D', 'D',
                  'E', 'E', 'E'],
                 categories=['A', 'B', 'C', 'D', 'E'], ordered=True, dtype='category', name='cat_1')
[right]: Index(['A', 'A', 'A', 'B', 'B', 'B', 'C', 'C', 'C', 'D', 'D', 'D', 'E', 'E',
       'E'],
      dtype='object', name='cat_1')
```

Introduced by this pandas upstream PR:

* https://github.com/pandas-dev/pandas/pull/53697

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
