### PR TITLE
Raise helpful `ValueError` for invalid time units

### DIFF
--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -683,7 +683,7 @@ def test_parse_timedelta():
         parse_timedelta("1", default=False)
     with pytest.raises(TypeError):
         parse_timedelta("1", default=None)
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError, match="Invalid time unit: foo. Valid units are"):
         parse_timedelta("1 foo")
 
 

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -683,6 +683,8 @@ def test_parse_timedelta():
         parse_timedelta("1", default=False)
     with pytest.raises(TypeError):
         parse_timedelta("1", default=None)
+    with pytest.raises(ValueError):
+        parse_timedelta("1 foo")
 
 
 def test_is_arraylike():

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1755,10 +1755,11 @@ def parse_timedelta(s, default="seconds"):
 
     n = float(prefix)
 
-    if suffix.lower() not in timedelta_sizes:
+    try:
+        multiplier = timedelta_sizes[suffix.lower()]
+    except KeyError:
         valid_units = ", ".join(timedelta_sizes.keys())
-        raise ValueError(f"Invalid time unit: {suffix}. Valid units are: {valid_units}")
-    multiplier = timedelta_sizes[suffix.lower()]
+        raise KeyError(f"Invalid time unit: {suffix}. Valid units are: {valid_units}") from None
 
     result = n * multiplier
     if int(result) == result:

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1755,6 +1755,9 @@ def parse_timedelta(s, default="seconds"):
 
     n = float(prefix)
 
+    if suffix.lower() not in timedelta_sizes:
+        valid_units = ", ".join(timedelta_sizes.keys())
+        raise ValueError(f"Invalid time unit: {suffix}. Valid units are: {valid_units}")
     multiplier = timedelta_sizes[suffix.lower()]
 
     result = n * multiplier

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -1759,7 +1759,9 @@ def parse_timedelta(s, default="seconds"):
         multiplier = timedelta_sizes[suffix.lower()]
     except KeyError:
         valid_units = ", ".join(timedelta_sizes.keys())
-        raise KeyError(f"Invalid time unit: {suffix}. Valid units are: {valid_units}") from None
+        raise KeyError(
+            f"Invalid time unit: {suffix}. Valid units are: {valid_units}"
+        ) from None
 
     result = n * multiplier
     if int(result) == result:


### PR DESCRIPTION
Lately I've been seeing people not know how to format the string for `idle_timeout`, and the current error is not very friendly:

```
  File "/opt/coiled/env/lib/python3.11/site-packages/distributed/scheduler.py", line 3504, in __init__
    self.idle_timeout = parse_timedelta(idle_timeout)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/coiled/env/lib/python3.11/site-packages/dask/utils.py", line 1758, in parse_timedelta
    multiplier = timedelta_sizes[suffix.lower()]
                 ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
KeyError: 'min'
```

This makes that friendlier by telling people what's wrong and what the valid options are.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
