### PR TITLE
Use ``dataframe.convert-string`` in ``read_parquet`` token

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -630,7 +630,9 @@ def read_parquet(
             meta=meta,
             divisions=divisions,
             label="read-parquet",
-            token=tokenize(path, **input_kwargs),
+            token=tokenize(
+                path, dask.config.get("dataframe.convert-string"), **input_kwargs
+            ),
             enforce_metadata=False,
             creation_info={
                 "func": read_parquet,

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4802,6 +4802,14 @@ def test_read_parquet_convert_string(tmp_path, convert_string, engine):
     assert_eq(ddf, expected)
     assert len(ddf.dask.layers) == 1
 
+    # Test collection name takes into account `dataframe.convert-string`
+    with dask.config.set({"dataframe.convert-string": convert_string}):
+        ddf1 = dd.read_parquet(outfile, engine="pyarrow")
+    with dask.config.set({"dataframe.convert-string": not convert_string}):
+        ddf2 = dd.read_parquet(outfile, engine="pyarrow")
+
+    assert ddf1._name != ddf2._name
+
 
 @PYARROW_MARK
 @pytest.mark.skipif(


### PR DESCRIPTION
This makes sure we don't get unexpected results when changing `dataframe.convert-string` a few times in the same Python session. 

cc @phofl 