### PR TITLE
Fix a few errors with upstream pandas and pyarrow

### DIFF
--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3563,7 +3563,8 @@ def test_groupby_numeric_only_supported(func, numeric_only):
         # Make sure dask and pandas raise the same error message
         # We raise the error on _meta_nonempty, actual element may differ
         ctx = pytest.raises(
-            TypeError, match="Cannot convert|could not convert|does not support"
+            TypeError,
+            match="Cannot convert|could not convert|does not support|agg function failed",
         )
         successful_compute = False
 


### PR DESCRIPTION
Fixes the following:

```
dask/dataframe/io/tests/test_parquet.py::test_roundtrip_arrow[df8]: [XPASS(strict)] https://github.com/apache/arrow/issues/15079
dask/dataframe/io/tests/test_parquet.py::test_roundtrip_arrow[df9]: [XPASS(strict)] https://github.com/apache/arrow/issues/15079
dask/dataframe/io/tests/test_parquet.py::test_pandas_timestamp_overflow_pyarrow: Failed: DID NOT RAISE <class 'pyarrow.lib.ArrowInvalid'>
dask/dataframe/tests/test_groupby.py::test_groupby_numeric_only_supported[disk-None-median]: TypeError: Cannot convert ['foo' 'foo'] to numeric
dask/dataframe/tests/test_groupby.py::test_groupby_numeric_only_supported[disk-False-median]: TypeError: Cannot convert ['foo' 'foo'] to numeric
dask/dataframe/tests/test_groupby.py::test_groupby_numeric_only_supported[tasks-None-median]: TypeError: Cannot convert ['foo' 'foo'] to numeric
dask/dataframe/tests/test_groupby.py::test_groupby_numeric_only_supported[tasks-False-median]: TypeError: Cannot convert ['foo' 'foo'] to numeric

```

Related: 
* https://github.com/dask/dask/issues/10347
* https://github.com/apache/arrow/issues/33321

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
