### PR TITLE
Adding support for cgroup v2 to `cpu_count`

### DIFF
--- a/dask/system.py
+++ b/dask/system.py
@@ -12,6 +12,35 @@ except ImportError:
 __all__ = ("cpu_count", "CPU_COUNT")
 
 
+def _try_extract_cgroup_cpu_quota():
+    # cgroup v1
+    # The directory name isn't standardized across linux distros, check both
+    for dirname in ["cpuacct,cpu", "cpu,cpuacct"]:
+        try:
+            with open("/sys/fs/cgroup/%s/cpu.cfs_quota_us" % dirname) as f:
+                quota = int(f.read())
+            with open("/sys/fs/cgroup/%s/cpu.cfs_period_us" % dirname) as f:
+                period = int(f.read())
+            return quota, period
+        except Exception:
+            pass
+
+    # cgroup v2
+    try:
+        with open("/proc/self/cgroup") as f:
+            group_path = f.read().strip().split(":")[-1]
+        if not group_path.endswith("/"):
+            group_path = f"{group_path}/"
+        with open("/sys/fs/cgroup%scpu.max" % group_path) as f:
+            quota, period = map(int, f.read().split(" "))
+            return quota, period
+    except Exception:
+        pass
+
+    # No cgroup CPU quota found
+    return None, None
+
+
 def cpu_count():
     """Get the available CPU count for this system.
 
@@ -34,20 +63,12 @@ def cpu_count():
 
     # Check cgroups if available
     if sys.platform == "linux":
-        # The directory name isn't standardized across linux distros, check both
-        for dirname in ["cpuacct,cpu", "cpu,cpuacct"]:
-            try:
-                with open("/sys/fs/cgroup/%s/cpu.cfs_quota_us" % dirname) as f:
-                    quota = int(f.read())
-                with open("/sys/fs/cgroup/%s/cpu.cfs_period_us" % dirname) as f:
-                    period = int(f.read())
-                # We round up on fractional CPUs
-                cgroups_count = math.ceil(quota / period)
-                if cgroups_count > 0:
-                    count = min(count, cgroups_count)
-                break
-            except Exception:
-                pass
+        quota, period = _try_extract_cgroup_cpu_quota()
+        if quota is not None and period is not None:
+            # We round up on fractional CPUs
+            cgroups_count = math.ceil(quota / period)
+            if cgroups_count > 0:
+                count = min(count, cgroups_count)
 
     return count
 

--- a/dask/tests/test_system.py
+++ b/dask/tests/test_system.py
@@ -55,3 +55,44 @@ def test_cpu_count_cgroups(dirname, monkeypatch):
         assert count == 201
     else:
         assert count == 250
+
+
+@pytest.mark.parametrize("group_name", ["/", "/user.slice", "/user.slice/more.slice"])
+@pytest.mark.parametrize("quota", ["max", "2005"])
+def test_cpu_count_cgroups_v2(quota, group_name, monkeypatch):
+    def mycpu_count():
+        # Absurdly high, unlikely to match real value
+        return 250
+
+    monkeypatch.setattr(os, "cpu_count", mycpu_count)
+
+    class MyProcess:
+        def cpu_affinity(self):
+            # No affinity set
+            return []
+
+    monkeypatch.setattr(psutil, "Process", MyProcess)
+
+    if not group_name.endswith("/"):
+        group_name = f"{group_name}/"
+
+    paths = {
+        "/proc/self/cgroup": io.StringIO("0::%s" % group_name),
+        "/sys/fs/cgroup%scpu.max" % group_name: io.StringIO("%s 10" % quota),
+    }
+    builtin_open = builtins.open
+
+    def myopen(path, *args, **kwargs):
+        if path in paths:
+            return paths.get(path)
+        return builtin_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", myopen)
+    monkeypatch.setattr(sys, "platform", "linux")
+
+    count = cpu_count()
+    if quota == "max":
+        assert count == 250
+    else:
+        # Rounds up
+        assert count == 201


### PR DESCRIPTION
Control Group v2 has a different folder structure than its v1 counterpart. Currently, the `dask.system.cpu_count()` function only supports reading from Control Group v1. Lots of distributions have already switched to the new version and more importantly Kubernetes 1.25. This change would make the transition seemless and not have the `multiprocessor` scheduler of dask default to the physical number of CPUs all of a sudden.

~~Closes #xxxx~~
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
