### PR TITLE
Avoid ``repartition`` before ``shuffle`` for ``p2p``

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -485,7 +485,7 @@ def rearrange_by_column(
     # we repartition first as shuffling overhead is
     # proportionate to the number of input partitions
 
-    if npartitions is not None and npartitions < df.npartitions:
+    if shuffle != "p2p" and npartitions is not None and npartitions < df.npartitions:
         df = df.repartition(npartitions=npartitions)
 
     if shuffle == "disk":


### PR DESCRIPTION
- [x] ref https://github.com/dask/distributed/issues/8015
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

cc @hendrikmakait 

test at https://github.com/dask/distributed/pull/8016