### PR TITLE
Fix compatibility variable naming

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4535,12 +4535,12 @@ def test_normalize_chunks_nan():
 
 def test_pandas_from_dask_array():
     pd = pytest.importorskip("pandas")
-    from dask.dataframe._compat import PANDAS_GT_131
+    from dask.dataframe._compat import PANDAS_GE_131
 
     a = da.ones((12,), chunks=4)
     s = pd.Series(a, index=range(12))
 
-    if not PANDAS_GT_131:
+    if not PANDAS_GE_131:
         # https://github.com/pandas-dev/pandas/issues/38645
         assert s.dtype != a.dtype
     else:

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -241,7 +241,7 @@ else:
 
 def is_any_real_numeric_dtype(arr_or_dtype) -> bool:
     try:
-        # `is_any_real_numeric_dtype` was added in PANDAS_GT_200.
+        # `is_any_real_numeric_dtype` was added in PANDAS_GE_200.
         # We can remove this compatibility utility once we only support `pandas>=2.0`
         return pd.api.types.is_any_real_numeric_dtype(arr_or_dtype)
     except AttributeError:

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -9,14 +9,14 @@ import pandas as pd
 from packaging.version import Version
 
 PANDAS_VERSION = Version(pd.__version__)
-PANDAS_GT_131 = PANDAS_VERSION >= Version("1.3.1")
-PANDAS_GT_133 = PANDAS_VERSION >= Version("1.3.3")
-PANDAS_GT_140 = PANDAS_VERSION >= Version("1.4.0")
-PANDAS_GT_150 = PANDAS_VERSION >= Version("1.5.0")
-PANDAS_GT_200 = PANDAS_VERSION.major >= 2
-PANDAS_GT_201 = PANDAS_VERSION.release >= (2, 0, 1)
-PANDAS_GT_202 = PANDAS_VERSION.release >= (2, 0, 2)
-PANDAS_GT_210 = PANDAS_VERSION.release >= (2, 1, 0)
+PANDAS_GE_131 = PANDAS_VERSION >= Version("1.3.1")
+PANDAS_GE_133 = PANDAS_VERSION >= Version("1.3.3")
+PANDAS_GE_140 = PANDAS_VERSION >= Version("1.4.0")
+PANDAS_GE_150 = PANDAS_VERSION >= Version("1.5.0")
+PANDAS_GE_200 = PANDAS_VERSION.major >= 2
+PANDAS_GE_201 = PANDAS_VERSION.release >= (2, 0, 1)
+PANDAS_GE_202 = PANDAS_VERSION.release >= (2, 0, 2)
+PANDAS_GE_210 = PANDAS_VERSION.release >= (2, 1, 0)
 
 import pandas.testing as tm
 
@@ -87,7 +87,7 @@ def makeMixedDataFrame():
 @contextlib.contextmanager
 def check_numeric_only_deprecation(name=None, show_nuisance_warning: bool = False):
     supported_funcs = ["sum", "median", "prod", "min", "max", "std", "var", "quantile"]
-    if name not in supported_funcs and PANDAS_GT_150 and not PANDAS_GT_200:
+    if name not in supported_funcs and PANDAS_GE_150 and not PANDAS_GE_200:
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
@@ -96,7 +96,7 @@ def check_numeric_only_deprecation(name=None, show_nuisance_warning: bool = Fals
             )
             yield
     elif (
-        not show_nuisance_warning and name not in supported_funcs and not PANDAS_GT_150
+        not show_nuisance_warning and name not in supported_funcs and not PANDAS_GE_150
     ):
         with warnings.catch_warnings():
             warnings.filterwarnings(
@@ -111,7 +111,7 @@ def check_numeric_only_deprecation(name=None, show_nuisance_warning: bool = Fals
 
 @contextlib.contextmanager
 def check_nuisance_columns_warning():
-    if not PANDAS_GT_150:
+    if not PANDAS_GE_150:
         with warnings.catch_warnings(record=True):
             warnings.filterwarnings(
                 "ignore", "Dropping of nuisance columns", FutureWarning
@@ -123,7 +123,7 @@ def check_nuisance_columns_warning():
 
 @contextlib.contextmanager
 def check_groupby_axis_deprecation():
-    if PANDAS_GT_210:
+    if PANDAS_GE_210:
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
@@ -137,7 +137,7 @@ def check_groupby_axis_deprecation():
 
 @contextlib.contextmanager
 def check_observed_deprecation():
-    if PANDAS_GT_210:
+    if PANDAS_GE_210:
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
@@ -151,7 +151,7 @@ def check_observed_deprecation():
 
 @contextlib.contextmanager
 def check_axis_keyword_deprecation():
-    if PANDAS_GT_210:
+    if PANDAS_GE_210:
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
@@ -165,7 +165,7 @@ def check_axis_keyword_deprecation():
 
 @contextlib.contextmanager
 def check_convert_dtype_deprecation():
-    if PANDAS_GT_210:
+    if PANDAS_GE_210:
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
@@ -179,7 +179,7 @@ def check_convert_dtype_deprecation():
 
 @contextlib.contextmanager
 def check_to_pydatetime_deprecation(catch_deprecation_warnings: bool):
-    if PANDAS_GT_210 and catch_deprecation_warnings:
+    if PANDAS_GE_210 and catch_deprecation_warnings:
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
@@ -193,7 +193,7 @@ def check_to_pydatetime_deprecation(catch_deprecation_warnings: bool):
 
 @contextlib.contextmanager
 def check_apply_dataframe_deprecation():
-    if PANDAS_GT_210:
+    if PANDAS_GE_210:
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
@@ -207,7 +207,7 @@ def check_apply_dataframe_deprecation():
 
 @contextlib.contextmanager
 def check_applymap_dataframe_deprecation():
-    if PANDAS_GT_210:
+    if PANDAS_GE_210:
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
@@ -221,7 +221,7 @@ def check_applymap_dataframe_deprecation():
 
 @contextlib.contextmanager
 def check_reductions_runtime_warning():
-    if PANDAS_GT_200 and not PANDAS_GT_201:
+    if PANDAS_GE_200 and not PANDAS_GE_201:
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
@@ -233,7 +233,7 @@ def check_reductions_runtime_warning():
         yield
 
 
-if PANDAS_GT_150:
+if PANDAS_GE_150:
     IndexingError = pd.errors.IndexingError
 else:
     IndexingError = pd.core.indexing.IndexingError
@@ -262,6 +262,6 @@ def is_string_dtype(arr_or_dtype) -> bool:
     else:
         dtype = arr_or_dtype
 
-    if not PANDAS_GT_200:
+    if not PANDAS_GE_200:
         return pd.api.types.is_dtype_equal(dtype, "string")
     return pd.api.types.is_string_dtype(dtype)

--- a/dask/dataframe/_dtypes.py
+++ b/dask/dataframe/_dtypes.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 
 import pandas as pd
 
-from dask.dataframe._compat import PANDAS_GT_150
+from dask.dataframe._compat import PANDAS_GE_150
 from dask.dataframe.extensions import make_array_nonempty, make_scalar
 
 
@@ -24,7 +24,7 @@ def _(dtype):
     return pd.array(["a", pd.NA], dtype=dtype)
 
 
-if PANDAS_GT_150:
+if PANDAS_GE_150:
 
     @make_array_nonempty.register(pd.ArrowDtype)
     def _make_array_nonempty_pyarrow_dtype(dtype):

--- a/dask/dataframe/_pyarrow.py
+++ b/dask/dataframe/_pyarrow.py
@@ -5,7 +5,7 @@ from functools import partial
 import pandas as pd
 from packaging.version import Version
 
-from dask.dataframe._compat import PANDAS_GT_150, PANDAS_GT_200
+from dask.dataframe._compat import PANDAS_GE_150, PANDAS_GE_200
 from dask.dataframe.utils import is_dataframe_like, is_index_like, is_series_like
 
 try:
@@ -19,7 +19,7 @@ def is_pyarrow_string_dtype(dtype):
     if pa is None:
         return False
 
-    if PANDAS_GT_150:
+    if PANDAS_GE_150:
         pa_string_types = [pd.StringDtype("pyarrow"), pd.ArrowDtype(pa.string())]
     else:
         pa_string_types = [pd.StringDtype("pyarrow")]
@@ -114,7 +114,7 @@ to_object_string = partial(
 
 def check_pyarrow_string_supported():
     """Make sure we have all the required versions"""
-    if not PANDAS_GT_200:
+    if not PANDAS_GE_200:
         raise RuntimeError(
             "Using dask's `dataframe.convert-string` configuration "
             "option requires `pandas>=2.0` to be installed."

--- a/dask/dataframe/_pyarrow_compat.py
+++ b/dask/dataframe/_pyarrow_compat.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     pa = None
 
-from dask.dataframe._compat import PANDAS_GT_150, PANDAS_GT_200
+from dask.dataframe._compat import PANDAS_GE_150, PANDAS_GE_200
 
 # Pickling of pyarrow arrays is effectively broken - pickling a slice of an
 # array ends up pickling the entire backing array.
@@ -39,8 +39,8 @@ def reduce_arrowextensionarray(x):
 # `pandas=2` includes efficient serialization of `pyarrow`-backed extension arrays.
 # See https://github.com/pandas-dev/pandas/pull/49078 for details.
 # We only need to backport efficient serialization for `pandas<2`.
-if pa is not None and not PANDAS_GT_200:
-    if PANDAS_GT_150:
+if pa is not None and not PANDAS_GE_200:
+    if PANDAS_GE_150:
         # Applies to all `pyarrow`-backed extension arrays (e.g. `string[pyarrow]`, `int64[pyarrow]`)
         for type_ in [pd.arrays.ArrowExtensionArray, pd.arrays.ArrowStringArray]:
             copyreg.dispatch_table[type_] = reduce_arrowextensionarray

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -35,10 +35,10 @@ from dask.blockwise import Blockwise, BlockwiseDep, BlockwiseDepDict, blockwise
 from dask.context import globalmethod
 from dask.dataframe import methods
 from dask.dataframe._compat import (
-    PANDAS_GT_140,
-    PANDAS_GT_150,
-    PANDAS_GT_200,
-    PANDAS_GT_210,
+    PANDAS_GE_140,
+    PANDAS_GE_150,
+    PANDAS_GE_200,
+    PANDAS_GE_210,
     PANDAS_VERSION,
     check_convert_dtype_deprecation,
     check_nuisance_columns_warning,
@@ -107,7 +107,7 @@ DEFAULT_GET = named_schedulers.get("threads", named_schedulers["sync"])
 no_default = "__no_default__"
 
 GROUP_KEYS_DEFAULT: bool | None = True
-if PANDAS_GT_150 and not PANDAS_GT_200:
+if PANDAS_GE_150 and not PANDAS_GE_200:
     GROUP_KEYS_DEFAULT = None
 
 pd.set_option("compute.use_numexpr", False)
@@ -152,7 +152,7 @@ def _numeric_only_maybe_warn(df, numeric_only, default=None):
     if is_dataframe_like(df):
         warn_numeric_only = False
         if numeric_only is no_default:
-            if PANDAS_GT_200:
+            if PANDAS_GE_200:
                 numeric_only = False
             else:
                 warn_numeric_only = True
@@ -426,7 +426,7 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
                 # Prior to pandas=1.4, `pd.Index` couldn't contain extension dtypes.
                 # Here we don't cast objects to pyarrow strings where only the index
                 # contains non-pyarrow string data.
-                if not PANDAS_GT_140 and (
+                if not PANDAS_GE_140 and (
                     (
                         is_object_string_dataframe(meta)
                         and not any(is_object_string_dtype(d) for d in meta.dtypes)
@@ -1801,7 +1801,7 @@ Dask Name: {name}, {layers}"""
 
     @derived_from(pd.DataFrame)
     def replace(self, to_replace=None, value=None, regex=False):
-        # In PANDAS_GT_140 pandas starts using no_default instead of None
+        # In PANDAS_GE_140 pandas starts using no_default instead of None
         value_kwarg = {"value": value} if value is not None else {}
         return self.map_partitions(
             M.replace,
@@ -2211,8 +2211,8 @@ Dask Name: {name}, {layers}"""
     @derived_from(pd.DataFrame)
     def max(self, axis=0, skipna=True, split_every=False, out=None, numeric_only=None):
         if (
-            PANDAS_GT_140
-            and not PANDAS_GT_200
+            PANDAS_GE_140
+            and not PANDAS_GE_200
             and axis is None
             and isinstance(self, DataFrame)
         ):
@@ -2230,15 +2230,15 @@ Dask Name: {name}, {layers}"""
             split_every=split_every,
             out=out,
             # Starting in pandas 2.0, `axis=None` does a full aggregation across both axes
-            none_is_zero=not PANDAS_GT_200,
+            none_is_zero=not PANDAS_GE_200,
             numeric_only=numeric_only,
         )
 
     @derived_from(pd.DataFrame)
     def min(self, axis=0, skipna=True, split_every=False, out=None, numeric_only=None):
         if (
-            PANDAS_GT_140
-            and not PANDAS_GT_200
+            PANDAS_GE_140
+            and not PANDAS_GE_200
             and axis is None
             and isinstance(self, DataFrame)
         ):
@@ -2256,7 +2256,7 @@ Dask Name: {name}, {layers}"""
             split_every=split_every,
             out=out,
             # Starting in pandas 2.0, `axis=None` does a full aggregation across both axes
-            none_is_zero=not PANDAS_GT_200,
+            none_is_zero=not PANDAS_GE_200,
             numeric_only=numeric_only,
         )
 
@@ -2400,8 +2400,8 @@ Dask Name: {name}, {layers}"""
         numeric_only=None,
     ):
         if (
-            PANDAS_GT_140
-            and not PANDAS_GT_200
+            PANDAS_GE_140
+            and not PANDAS_GE_200
             and axis is None
             and isinstance(self, DataFrame)
         ):
@@ -2410,7 +2410,7 @@ Dask Name: {name}, {layers}"""
                 "To retain the old behavior, use 'frame.mean(axis=0)' or just 'frame.mean()'",
                 FutureWarning,
             )
-        axis = self._validate_axis(axis, none_is_zero=not PANDAS_GT_200)
+        axis = self._validate_axis(axis, none_is_zero=not PANDAS_GE_200)
         _raise_if_object_series(self, "mean")
         # NOTE: Do we want to warn here?
         with check_numeric_only_deprecation(), check_nuisance_columns_warning():
@@ -2434,7 +2434,7 @@ Dask Name: {name}, {layers}"""
             s = num.sum(skipna=skipna, split_every=split_every)
             n = num.count(split_every=split_every)
             # Starting in pandas 2.0, `axis=None` does a full aggregation across both axes
-            if PANDAS_GT_200 and axis is None and isinstance(self, DataFrame):
+            if PANDAS_GE_200 and axis is None and isinstance(self, DataFrame):
                 result = s.sum() / n.sum()
             else:
                 name = self._token_prefix + "mean-%s" % tokenize(self, axis, skipna)
@@ -2719,7 +2719,7 @@ Dask Name: {name}, {layers}"""
            Further, this method currently does not support filtering out NaN
            values, which is again a difference to Pandas.
         """
-        if PANDAS_GT_200 and axis is None:
+        if PANDAS_GE_200 and axis is None:
             raise ValueError(
                 "`axis=None` isn't currently supported for `skew` when using `pandas >=2` "
                 f"(pandas={str(PANDAS_VERSION)} is installed)."
@@ -2839,7 +2839,7 @@ Dask Name: {name}, {layers}"""
            Further, this method currently does not support filtering out NaN
            values, which is again a difference to Pandas.
         """
-        if PANDAS_GT_200 and axis is None:
+        if PANDAS_GE_200 and axis is None:
             raise ValueError(
                 "`axis=None` isn't currently supported for `kurtosis` when using `pandas >=2` "
                 f"(pandas={str(PANDAS_VERSION)} is installed)."
@@ -3031,7 +3031,7 @@ Dask Name: {name}, {layers}"""
             num = (
                 self._get_numeric_data()
                 if numeric_only is True
-                or (not PANDAS_GT_200 and numeric_only is no_default)
+                or (not PANDAS_GE_200 and numeric_only is no_default)
                 else self
             )
             quantiles = tuple(
@@ -3066,7 +3066,7 @@ Dask Name: {name}, {layers}"""
         exclude=None,
         datetime_is_numeric=no_default,
     ):
-        if PANDAS_GT_200:
+        if PANDAS_GE_200:
             if datetime_is_numeric is no_default:
                 datetime_is_numeric = True
                 datetime_is_numeric_kwarg = {}
@@ -3284,7 +3284,7 @@ Dask Name: {name}, {layers}"""
         }
         graph = HighLevelGraph.from_collections(name, layer, dependencies=stats)
 
-        if not PANDAS_GT_200:
+        if not PANDAS_GE_200:
             datetime_is_numeric_kwarg = {"datetime_is_numeric": datetime_is_numeric}
         else:
             datetime_is_numeric_kwarg = {}
@@ -3482,11 +3482,11 @@ Dask Name: {name}, {layers}"""
             M.astype, dtype=dtype, meta=meta, enforce_metadata=False
         )
 
-    if not PANDAS_GT_200:
+    if not PANDAS_GE_200:
 
         @derived_from(pd.Series)
         def append(self, other, interleave_partitions=False):
-            if PANDAS_GT_140:
+            if PANDAS_GE_140:
                 warnings.warn(
                     "The frame.append method is deprecated and will be removed from"
                     "dask in a future version. Use dask.dataframe.concat instead.",
@@ -4027,11 +4027,11 @@ Dask Name: {name}, {layers}""".format(
     def _get_numeric_data(self, how="any", subset=None):
         return self
 
-    if not PANDAS_GT_200:
+    if not PANDAS_GE_200:
 
         @derived_from(pd.Series)
         def iteritems(self):
-            if PANDAS_GT_150:
+            if PANDAS_GE_150:
                 warnings.warn(
                     "iteritems is deprecated and will be removed in a future version. "
                     "Use .items instead.",
@@ -4380,7 +4380,7 @@ Dask Name: {name}, {layers}""".format(
                     M.apply, self._meta_nonempty, func, args=args, udf=True, **kwds
                 )
             warnings.warn(meta_warning(meta))
-        elif PANDAS_GT_210:
+        elif PANDAS_GE_210:
             test_meta = make_meta(meta)
             if is_dataframe_like(test_meta):
                 warnings.warn(
@@ -4447,12 +4447,12 @@ Dask Name: {name}, {layers}""".format(
         res2 = other % self
         return res1, res2
 
-    if not PANDAS_GT_200:
+    if not PANDAS_GE_200:
 
         @property
         @derived_from(pd.Series)
         def is_monotonic(self):
-            if PANDAS_GT_150:
+            if PANDAS_GE_150:
                 warnings.warn(
                     "is_monotonic is deprecated and will be removed in a future version. "
                     "Use is_monotonic_increasing instead.",
@@ -4673,12 +4673,12 @@ class Index(Series):
             applied = applied.clear_divisions()
         return applied
 
-    if not PANDAS_GT_200:
+    if not PANDAS_GE_200:
 
         @property
         @derived_from(pd.Index)
         def is_monotonic(self):
-            if PANDAS_GT_150:
+            if PANDAS_GE_150:
                 warnings.warn(
                     "is_monotonic is deprecated and will be removed in a future version. "
                     "Use is_monotonic_increasing instead.",
@@ -5770,7 +5770,7 @@ class DataFrame(_Frame):
             shuffle=shuffle,
         )
 
-    if not PANDAS_GT_200:
+    if not PANDAS_GE_200:
 
         @derived_from(pd.DataFrame)
         def append(self, other, interleave_partitions=False):
@@ -5971,7 +5971,7 @@ class DataFrame(_Frame):
         return elemwise(methods.applymap, self, func, meta=meta)
 
     def map(self, func, meta=no_default, na_action=None):
-        if not PANDAS_GT_210:
+        if not PANDAS_GE_210:
             raise NotImplementedError(
                 f"DataFrame.map requires pandas>=2.1.0, but pandas={PANDAS_VERSION} is "
                 "installed."
@@ -6081,7 +6081,7 @@ class DataFrame(_Frame):
         if len(self.columns) == 0:
             lines.append(f"{type(self.index._meta).__name__}: 0 entries")
             lines.append(f"Empty {type(self).__name__}")
-            if PANDAS_GT_150:
+            if PANDAS_GE_150:
                 # pandas dataframe started adding a newline when info is called.
                 lines.append("")
             put_lines(buf, lines)
@@ -7325,9 +7325,9 @@ def _cov_corr(
     # Handle selecting numeric data and associated deprecation warning
     maybe_warn = False
     if numeric_only is no_default:
-        if PANDAS_GT_200:
+        if PANDAS_GE_200:
             numeric_only = False
-        elif PANDAS_GT_150:
+        elif PANDAS_GE_150:
             maybe_warn = True
             numeric_only = True
         else:
@@ -8000,7 +8000,7 @@ def _reduction_aggregate(x, aca_aggregate=None, **kwargs):
 
 def idxmaxmin_chunk(x, fn=None, skipna=True, numeric_only=False):
     numeric_only_kwargs = (
-        {} if not PANDAS_GT_150 or is_series_like(x) else {"numeric_only": numeric_only}
+        {} if not PANDAS_GE_150 or is_series_like(x) else {"numeric_only": numeric_only}
     )
     minmax = "max" if fn == "idxmax" else "min"
     if len(x) > 0:
@@ -8125,7 +8125,7 @@ def to_datetime(arg, meta=None, **kwargs):
             meta = meta_series_constructor(arg)([pd.Timestamp("2000", **tz_kwarg)])
             meta.index = meta.index.astype(arg.index.dtype)
             meta.index.name = arg.index.name
-    if PANDAS_GT_200 and "infer_datetime_format" in kwargs:
+    if PANDAS_GE_200 and "infer_datetime_format" in kwargs:
         warnings.warn(
             "The argument 'infer_datetime_format' is deprecated and will be removed in a future version. "
             "A strict version of it is now the default, see "

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -15,10 +15,10 @@ from dask import config
 from dask.base import is_dask_collection, tokenize
 from dask.core import flatten
 from dask.dataframe._compat import (
-    PANDAS_GT_140,
-    PANDAS_GT_150,
-    PANDAS_GT_200,
-    PANDAS_GT_210,
+    PANDAS_GE_140,
+    PANDAS_GE_150,
+    PANDAS_GE_200,
+    PANDAS_GE_210,
     check_groupby_axis_deprecation,
     check_numeric_only_deprecation,
     check_observed_deprecation,
@@ -50,7 +50,7 @@ from dask.dataframe.utils import (
 from dask.highlevelgraph import HighLevelGraph
 from dask.utils import M, _deprecated, derived_from, funcname, itemgetter
 
-if PANDAS_GT_140:
+if PANDAS_GE_140:
     from pandas.core.apply import reconstruct_func, validate_func_kwargs
 
 # #############################################
@@ -305,11 +305,11 @@ def numeric_only_deprecate_default(func):
             numeric_only = kwargs.get("numeric_only", no_default)
             # Prior to `pandas=1.5`, `numeric_only` support wasn't uniformly supported
             # in pandas. We don't support `numeric_only=False` in this case.
-            if not PANDAS_GT_150 and numeric_only is False:
+            if not PANDAS_GE_150 and numeric_only is False:
                 raise NotImplementedError(
                     "'numeric_only=False' is not implemented in Dask."
                 )
-            if PANDAS_GT_150 and not PANDAS_GT_200 and not self._all_numeric():
+            if PANDAS_GE_150 and not PANDAS_GE_200 and not self._all_numeric():
                 if numeric_only is no_default:
                     warnings.warn(
                         "The default value of numeric_only will be changed to False in "
@@ -343,20 +343,20 @@ def numeric_only_not_implemented(func):
                 numeric_only = kwargs.get("numeric_only", no_default)
                 # Prior to `pandas=1.5`, `numeric_only` support wasn't uniformly supported
                 # in pandas. We don't support `numeric_only=False` in this case.
-                if not PANDAS_GT_150 and numeric_only is False:
+                if not PANDAS_GE_150 and numeric_only is False:
                     raise NotImplementedError(
                         "'numeric_only=False' is not implemented in Dask."
                     )
                 if not self._all_numeric():
                     if numeric_only is False or (
-                        PANDAS_GT_200 and numeric_only is no_default
+                        PANDAS_GE_200 and numeric_only is no_default
                     ):
                         raise NotImplementedError(
                             "'numeric_only=False' is not implemented in Dask."
                         )
                     if (
-                        PANDAS_GT_150
-                        and not PANDAS_GT_200
+                        PANDAS_GE_150
+                        and not PANDAS_GE_200
                         and numeric_only is no_default
                     ):
                         warnings.warn(
@@ -2046,7 +2046,7 @@ class _GroupBy:
     @derived_from(pd.core.groupby.GroupBy)
     @numeric_only_not_implemented
     def var(self, ddof=1, split_every=None, split_out=1, numeric_only=no_default):
-        if not PANDAS_GT_150 and numeric_only is not no_default:
+        if not PANDAS_GE_150 and numeric_only is not no_default:
             raise TypeError("numeric_only not supported for pandas < 1.5")
 
         if self.sort is None and split_out > 1:
@@ -2086,7 +2086,7 @@ class _GroupBy:
     @derived_from(pd.core.groupby.GroupBy)
     @numeric_only_not_implemented
     def std(self, ddof=1, split_every=None, split_out=1, numeric_only=no_default):
-        if not PANDAS_GT_150 and numeric_only is not no_default:
+        if not PANDAS_GE_150 and numeric_only is not no_default:
             raise TypeError("numeric_only not supported for pandas < 1.5")
         # We sometimes emit this warning ourselves. We ignore it here so users only see it once.
         with check_numeric_only_deprecation():
@@ -2104,7 +2104,7 @@ class _GroupBy:
         """Groupby correlation:
         corr(X, Y) = cov(X, Y) / (std_x * std_y)
         """
-        if not PANDAS_GT_150 and numeric_only is not no_default:
+        if not PANDAS_GE_150 and numeric_only is not no_default:
             raise TypeError("numeric_only not supported for pandas < 1.5")
         return self.cov(
             split_every=split_every,
@@ -2127,7 +2127,7 @@ class _GroupBy:
 
         When `std` is True calculate Correlation
         """
-        if not PANDAS_GT_150 and numeric_only is not no_default:
+        if not PANDAS_GE_150 and numeric_only is not no_default:
             raise TypeError("numeric_only not supported for pandas < 1.5")
         numeric_only_kwargs = get_numeric_only_kwargs(numeric_only)
         if self.sort is None and split_out > 1:
@@ -2235,7 +2235,7 @@ class _GroupBy:
         columns = None
         order = None
         column_projection = None
-        if PANDAS_GT_140:
+        if PANDAS_GE_140:
             if isinstance(self, DataFrameGroupBy):
                 if arg is None:
                     relabeling, arg, columns, order = reconstruct_func(arg, **kwargs)
@@ -2775,7 +2775,7 @@ class _GroupBy:
         )
 
     def _normalize_axis(self, axis, method: str):
-        if PANDAS_GT_210 and axis is not no_default:
+        if PANDAS_GE_210 and axis is not no_default:
             if axis in (0, "index"):
                 warnings.warn(
                     f"The 'axis' keyword in {type(self).__name__}.{method} is deprecated and will "
@@ -2848,7 +2848,7 @@ class _GroupBy:
             meta=meta,
         )
 
-        if PANDAS_GT_150 and self.group_keys:
+        if PANDAS_GE_150 and self.group_keys:
             return result.map_partitions(M.droplevel, self.by)
 
         return result
@@ -2861,7 +2861,7 @@ class _GroupBy:
         result = self.apply(
             _drop_apply, by=self.by, what="ffill", limit=limit, meta=meta
         )
-        if PANDAS_GT_150 and self.group_keys:
+        if PANDAS_GE_150 and self.group_keys:
             return result.map_partitions(M.droplevel, self.by)
         return result
 
@@ -2873,7 +2873,7 @@ class _GroupBy:
         result = self.apply(
             _drop_apply, by=self.by, what="bfill", limit=limit, meta=meta
         )
-        if PANDAS_GT_150 and self.group_keys:
+        if PANDAS_GE_150 and self.group_keys:
             return result.map_partitions(M.droplevel, self.by)
         return result
 

--- a/dask/dataframe/io/json.py
+++ b/dask/dataframe/io/json.py
@@ -11,7 +11,7 @@ from fsspec.core import open_files
 from dask.base import compute as dask_compute
 from dask.bytes import read_bytes
 from dask.core import flatten
-from dask.dataframe._compat import PANDAS_GT_200, PANDAS_VERSION
+from dask.dataframe._compat import PANDAS_GE_200, PANDAS_VERSION
 from dask.dataframe.backends import dataframe_creation_dispatch
 from dask.dataframe.io.io import from_delayed
 from dask.dataframe.utils import insert_meta_param_description, make_meta
@@ -217,7 +217,7 @@ def read_json(
 
     # Handle engine string (Pandas>=2.0)
     if isinstance(engine, str):
-        if not PANDAS_GT_200:
+        if not PANDAS_GE_200:
             raise ValueError(
                 f"Pandas>=2.0 is required to pass a string to the "
                 f"`engine` argument of `read_json` "

--- a/dask/dataframe/io/parquet/fastparquet.py
+++ b/dask/dataframe/io/parquet/fastparquet.py
@@ -13,7 +13,7 @@ import tlz as toolz
 from packaging.version import parse as parse_version
 
 from dask.core import flatten
-from dask.dataframe._compat import PANDAS_GT_201
+from dask.dataframe._compat import PANDAS_GE_201
 
 try:
     import fastparquet
@@ -1115,7 +1115,7 @@ class FastParquetEngine(Engine):
         df, views = pf.pre_allocate(size, columns, categories, index)
         if (
             parse_version(fastparquet.__version__) <= parse_version("2023.02.0")
-            and PANDAS_GT_201
+            and PANDAS_GE_201
             and df.columns.empty
         ):
             df.columns = pd.Index([], dtype=object)

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -19,7 +19,7 @@ from dask.base import compute_as_if_collection
 from dask.bytes.core import read_bytes
 from dask.bytes.utils import compress
 from dask.core import flatten
-from dask.dataframe._compat import PANDAS_GT_140, PANDAS_GT_200, tm
+from dask.dataframe._compat import PANDAS_GE_140, PANDAS_GE_200, tm
 from dask.dataframe.io.csv import (
     _infer_block_size,
     auto_blocksize,
@@ -378,7 +378,7 @@ def test_read_csv(dd_read, pd_read, text, sep):
 
 
 @pytest.mark.skipif(
-    not PANDAS_GT_200, reason="dataframe.convert-string requires pandas>=2.0"
+    not PANDAS_GE_200, reason="dataframe.convert-string requires pandas>=2.0"
 )
 def test_read_csv_convert_string_config():
     pytest.importorskip("pyarrow", reason="Requires pyarrow strings")
@@ -1254,7 +1254,7 @@ def test_read_csv_singleton_dtype():
         assert_eq(pd.read_csv(fn, dtype=float), dd.read_csv(fn, dtype=float))
 
 
-@pytest.mark.skipif(not PANDAS_GT_140, reason="arrow engine available from 1.4")
+@pytest.mark.skipif(not PANDAS_GE_140, reason="arrow engine available from 1.4")
 def test_read_csv_arrow_engine():
     pytest.importorskip("pyarrow")
     sep_text = normalize_text(

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -6,7 +6,7 @@ import pytest
 import dask
 import dask.dataframe as dd
 from dask.blockwise import Blockwise, optimize_blockwise
-from dask.dataframe._compat import PANDAS_GT_200, tm
+from dask.dataframe._compat import PANDAS_GE_200, tm
 from dask.dataframe.optimize import optimize_dataframe_getitem
 from dask.dataframe.utils import assert_eq, get_string_dtype
 
@@ -217,7 +217,7 @@ def test_with_spec_non_default(seed):
     ddf = with_spec(spec, seed=seed)
     assert isinstance(ddf, dd.DataFrame)
     assert ddf.columns.tolist() == ["i1", "f1", "c1", "s1"]
-    if PANDAS_GT_200:
+    if PANDAS_GE_200:
         assert ddf.index.dtype == "int32"
     assert ddf["i1"].dtype == "int32"
     assert ddf["f1"].dtype == "float32"

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -11,7 +11,7 @@ import dask.array as da
 import dask.dataframe as dd
 from dask import config
 from dask.blockwise import Blockwise
-from dask.dataframe._compat import PANDAS_GT_200, tm
+from dask.dataframe._compat import PANDAS_GE_200, tm
 from dask.dataframe.io.io import _meta_from_array
 from dask.dataframe.optimize import optimize
 from dask.dataframe.utils import assert_eq, get_string_dtype, pyarrow_strings_enabled
@@ -280,7 +280,7 @@ def test_from_pandas_npartitions_duplicates(index):
 
 
 @pytest.mark.skipif(
-    not PANDAS_GT_200, reason="dataframe.convert-string requires pandas>=2.0"
+    not PANDAS_GE_200, reason="dataframe.convert-string requires pandas>=2.0"
 )
 def test_from_pandas_convert_string_config():
     pytest.importorskip("pyarrow", reason="Requires pyarrow strings")
@@ -317,7 +317,7 @@ def test_from_pandas_convert_string_config():
     assert_eq(df_pyarrow, ddf)
 
 
-@pytest.mark.skipif(PANDAS_GT_200, reason="Requires pandas<2.0")
+@pytest.mark.skipif(PANDAS_GE_200, reason="Requires pandas<2.0")
 def test_from_pandas_convert_string_config_raises():
     pytest.importorskip("pyarrow", reason="Different error without pyarrow")
     df = pd.DataFrame(

--- a/dask/dataframe/io/tests/test_json.py
+++ b/dask/dataframe/io/tests/test_json.py
@@ -8,7 +8,7 @@ import pytest
 
 import dask
 import dask.dataframe as dd
-from dask.dataframe._compat import PANDAS_GT_200
+from dask.dataframe._compat import PANDAS_GE_200
 from dask.dataframe.utils import assert_eq
 from dask.utils import tmpdir, tmpfile
 
@@ -127,7 +127,7 @@ def test_read_json_fkeyword(fkeyword):
 def test_read_json_engine_str(engine):
     with tmpfile("json") as f:
         df.to_json(f, lines=False)
-        if isinstance(engine, str) and not PANDAS_GT_200:
+        if isinstance(engine, str) and not PANDAS_GE_200:
             with pytest.raises(ValueError, match="Pandas>=2.0 is required"):
                 dd.read_json(f, engine=engine, lines=False)
         else:

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -18,7 +18,7 @@ import dask.dataframe as dd
 import dask.multiprocessing
 from dask.array.numpy_compat import _numpy_124
 from dask.blockwise import Blockwise, optimize_blockwise
-from dask.dataframe._compat import PANDAS_GT_150, PANDAS_GT_200, PANDAS_GT_202
+from dask.dataframe._compat import PANDAS_GE_150, PANDAS_GE_200, PANDAS_GE_202
 from dask.dataframe.io.parquet.core import get_engine
 from dask.dataframe.io.parquet.utils import _parse_pandas_metadata
 from dask.dataframe.optimize import optimize_dataframe_getitem
@@ -603,7 +603,7 @@ def test_roundtrip_nullable_dtypes(tmp_path, write_engine, read_engine):
         pytest.param(
             "pyarrow",
             marks=pytest.mark.skipif(
-                not PANDAS_GT_150, reason="Requires pyarrow-backed nullable dtypes"
+                not PANDAS_GE_150, reason="Requires pyarrow-backed nullable dtypes"
             ),
         ),
     ],
@@ -1149,7 +1149,7 @@ def test_roundtrip(tmpdir, df, write_kwargs, read_kwargs, engine):
         pytest.xfail(reason="fastparquet doesn't support nanosecond precision yet")
     # non-ns times
     if (
-        PANDAS_GT_200
+        PANDAS_GE_200
         and "x" in df
         and (df.x.dtype == "M8[ms]" or df.x.dtype == "M8[us]")
     ):
@@ -2424,13 +2424,13 @@ def test_append_cat_fp(tmpdir, engine):
         pytest.param(
             pd.DataFrame({"x": [3, 2, 1]}).astype("M8[us]"),
             marks=pytest.mark.xfail(
-                PANDAS_GT_200, reason="https://github.com/apache/arrow/issues/15079"
+                PANDAS_GE_200, reason="https://github.com/apache/arrow/issues/15079"
             ),
         ),
         pytest.param(
             pd.DataFrame({"x": [3, 2, 1]}).astype("M8[ms]"),
             marks=pytest.mark.xfail(
-                PANDAS_GT_200, reason="https://github.com/apache/arrow/issues/15079"
+                PANDAS_GE_200, reason="https://github.com/apache/arrow/issues/15079"
             ),
         ),
         pd.DataFrame({"x": [3, 2, 1]}).astype("uint16"),
@@ -3569,7 +3569,7 @@ def test_partitioned_preserve_index(tmpdir, write_engine, read_engine):
     df1.to_parquet(tmp, partition_on="B", engine=write_engine)
 
     expect = data[data["B"] == 1]
-    if PANDAS_GT_200 and read_engine == "fastparquet":
+    if PANDAS_GE_200 and read_engine == "fastparquet":
         # fastparquet does not preserve dtype of cats
         expect = expect.copy()  # SettingWithCopyWarning
         expect["B"] = expect["B"].astype(
@@ -4485,7 +4485,7 @@ def test_custom_filename_with_partition(tmpdir, engine):
 def test_roundtrip_partitioned_pyarrow_dataset(tmpdir, engine):
     # See: https://github.com/dask/dask/issues/8650
 
-    if engine == "fastparquet" and PANDAS_GT_200:
+    if engine == "fastparquet" and PANDAS_GE_200:
         # https://github.com/dask/dask/issues/9966
         pytest.xfail("fastparquet reads as int64 while pyarrow does as int32")
 
@@ -4791,7 +4791,7 @@ def test_select_filtered_column_no_stats(tmp_path, engine):
 
 @pytest.mark.parametrize("convert_string", [True, False])
 @pytest.mark.skipif(
-    not PANDAS_GT_200, reason="dataframe.convert-string requires pandas>=2.0"
+    not PANDAS_GE_200, reason="dataframe.convert-string requires pandas>=2.0"
 )
 def test_read_parquet_convert_string(tmp_path, convert_string, engine):
     df = pd.DataFrame(
@@ -4825,7 +4825,7 @@ def test_read_parquet_convert_string(tmp_path, convert_string, engine):
 
 @PYARROW_MARK
 @pytest.mark.skipif(
-    not PANDAS_GT_200, reason="dataframe.convert-string requires pandas>=2.0"
+    not PANDAS_GE_200, reason="dataframe.convert-string requires pandas>=2.0"
 )
 def test_read_parquet_convert_string_nullable_mapper(tmp_path, engine):
     """Make sure that when convert_string, dtype_backend and types_mapper are set,
@@ -4868,7 +4868,7 @@ def test_read_parquet_convert_string_nullable_mapper(tmp_path, engine):
 
 @PYARROW_MARK
 @pytest.mark.parametrize("dtype_backend", ["numpy_nullable", "pyarrow"])
-@pytest.mark.skipif(not PANDAS_GT_150, reason="Requires pyarrow-backed nullable dtypes")
+@pytest.mark.skipif(not PANDAS_GE_150, reason="Requires pyarrow-backed nullable dtypes")
 def test_dtype_backend(tmp_path, dtype_backend, engine):
     """
     Test reading a parquet file without pandas metadata,
@@ -4911,7 +4911,7 @@ def test_dtype_backend(tmp_path, dtype_backend, engine):
 
 @PYARROW_MARK
 @pytest.mark.skipif(
-    not PANDAS_GT_200, reason="pd.Index does not support int32 before 2.0"
+    not PANDAS_GE_200, reason="pd.Index does not support int32 before 2.0"
 )
 def test_read_parquet_preserve_categorical_column_dtype(tmp_path):
     df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
@@ -4928,7 +4928,7 @@ def test_read_parquet_preserve_categorical_column_dtype(tmp_path):
 
 
 @PYARROW_MARK
-@pytest.mark.skipif(not PANDAS_GT_200, reason="Requires pd.ArrowDtype")
+@pytest.mark.skipif(not PANDAS_GE_200, reason="Requires pd.ArrowDtype")
 def test_dtype_backend_categoricals(tmp_path):
     df = pd.DataFrame({"a": pd.Series(["x", "y"], dtype="category"), "b": [1, 2]})
     outdir = tmp_path / "out.parquet"
@@ -4936,7 +4936,7 @@ def test_dtype_backend_categoricals(tmp_path):
     ddf = dd.read_parquet(outdir, engine="pyarrow", dtype_backend="pyarrow")
     pdf = pd.read_parquet(outdir, engine="pyarrow", dtype_backend="pyarrow")
     # Set sort_results=False because of pandas bug up to 2.0.1
-    assert_eq(ddf, pdf, sort_results=PANDAS_GT_202)
+    assert_eq(ddf, pdf, sort_results=PANDAS_GE_202)
 
 
 @PYARROW_MARK

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -9,9 +9,9 @@ from pandas.api.types import is_extension_array_dtype
 from tlz import partition
 
 from dask.dataframe._compat import (
-    PANDAS_GT_131,
-    PANDAS_GT_140,
-    PANDAS_GT_200,
+    PANDAS_GE_131,
+    PANDAS_GE_140,
+    PANDAS_GE_200,
     check_apply_dataframe_deprecation,
     check_applymap_dataframe_deprecation,
     check_convert_dtype_deprecation,
@@ -111,7 +111,7 @@ def boundary_slice(df, start, stop, right_boundary=True, left_boundary=True, kin
     if len(df.index) == 0:
         return df
 
-    if PANDAS_GT_131:
+    if PANDAS_GE_131:
         if kind is not None:
             warnings.warn(
                 "The `kind` argument is no longer used/supported. "
@@ -351,7 +351,7 @@ def assign(df, *pairs):
     # (to avoid modifying the original)
     # Setitem never modifies an array inplace with pandas 1.4 and up
     pairs = dict(partition(2, pairs))
-    deep = bool(set(pairs) & set(df.columns)) and not PANDAS_GT_140
+    deep = bool(set(pairs) & set(df.columns)) and not PANDAS_GE_140
     df = df.copy(deep=bool(deep))
     for name, val in pairs.items():
         df[name] = val
@@ -381,7 +381,7 @@ def value_counts_aggregate(
         out /= total_length if total_length is not None else out.sum()
     if sort:
         out = out.sort_values(ascending=ascending)
-    if PANDAS_GT_200 and normalize:
+    if PANDAS_GE_200 and normalize:
         out.name = "proportion"
     return out
 

--- a/dask/dataframe/reshape.py
+++ b/dask/dataframe/reshape.py
@@ -6,7 +6,7 @@ from pandas.api.types import is_list_like, is_scalar
 
 import dask
 from dask.dataframe import methods
-from dask.dataframe._compat import PANDAS_GT_200
+from dask.dataframe._compat import PANDAS_GE_200
 from dask.dataframe.core import DataFrame, Series, apply_concat_apply, map_partitions
 from dask.dataframe.utils import has_known_categories
 from dask.utils import M, get_meta_library
@@ -16,7 +16,7 @@ from dask.utils import M, get_meta_library
 ###############################################################
 
 
-_get_dummies_dtype_default = bool if PANDAS_GT_200 else np.uint8
+_get_dummies_dtype_default = bool if PANDAS_GE_200 else np.uint8
 
 
 def get_dummies(

--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -612,10 +612,10 @@ class Rolling:
         args = args or ()
         meta = self.obj._meta.rolling(0)
         if has_keyword(meta.apply, "engine"):
-            # PANDAS_GT_100
+            # PANDAS_GE_100
             compat_kwargs = dict(engine=engine, engine_kwargs=engine_kwargs)
         if raw is None:
-            # PANDAS_GT_100: The default changed from None to False
+            # PANDAS_G_100: The default changed from None to False
             raw = inspect.signature(meta.apply).parameters["raw"]
 
         return self._call_method(

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -7,7 +7,7 @@ import pytest
 
 pd = pytest.importorskip("pandas")
 import dask.dataframe as dd
-from dask.dataframe._compat import PANDAS_GT_140, PANDAS_GT_210
+from dask.dataframe._compat import PANDAS_GE_140, PANDAS_GE_210
 from dask.dataframe._pyarrow import to_pyarrow_string
 from dask.dataframe.utils import assert_eq, pyarrow_strings_enabled
 
@@ -102,7 +102,7 @@ def test_dt_accessor(df_ddf):
     # see https://github.com/pydata/pandas/issues/10712
     assert_eq(ddf.dt_col.dt.date, df.dt_col.dt.date, check_names=False)
 
-    warning = FutureWarning if PANDAS_GT_210 else None
+    warning = FutureWarning if PANDAS_GE_210 else None
     # to_pydatetime returns a numpy array in pandas, but a Series in dask
     # pandas will start returning a Series with 3.0 as well
     with pytest.warns(warning, match="will return a Series"):
@@ -223,7 +223,7 @@ def test_str_accessor_extractall(df_ddf):
     )
 
 
-@pytest.mark.skipif(not PANDAS_GT_140, reason="requires pandas >= 1.4.0")
+@pytest.mark.skipif(not PANDAS_GE_140, reason="requires pandas >= 1.4.0")
 @pytest.mark.parametrize("method", ["removeprefix", "removesuffix"])
 def test_str_accessor_removeprefix_removesuffix(df_ddf, method):
     df, ddf = df_ddf

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -12,9 +12,9 @@ from pandas.api.types import is_scalar
 import dask.dataframe as dd
 from dask.array.numpy_compat import _numpy_125
 from dask.dataframe._compat import (
-    PANDAS_GT_140,
-    PANDAS_GT_150,
-    PANDAS_GT_200,
+    PANDAS_GE_140,
+    PANDAS_GE_150,
+    PANDAS_GE_200,
     PANDAS_VERSION,
     check_numeric_only_deprecation,
 )
@@ -747,7 +747,7 @@ def test_reductions(split_every):
             bias_factor = (n * (n - 1)) ** 0.5 / (n - 2)
             assert_eq(dds.skew(), pds.skew() / bias_factor)
 
-            if PANDAS_GT_200:
+            if PANDAS_GE_200:
                 # TODO: Remove this `if`-block once `axis=None` support is added.
                 # https://github.com/dask/dask/issues/9915
                 with pytest.raises(
@@ -764,7 +764,7 @@ def test_reductions(split_every):
             offset = (6 * (n - 1)) / ((n - 2) * (n - 3))
             assert_eq(factor * dds.kurtosis() + offset, pds.kurtosis())
 
-            if PANDAS_GT_200:
+            if PANDAS_GE_200:
                 # TODO: Remove this `if`-block once `axis=None` support is added.
                 # https://github.com/dask/dask/issues/9915
                 with pytest.raises(
@@ -1151,7 +1151,7 @@ def test_reductions_frame(split_every):
     pytest.raises(ValueError, lambda: ddf1.sum(axis="incorrect").compute())
 
     # axis=None
-    if PANDAS_GT_140 and not PANDAS_GT_200:
+    if PANDAS_GE_140 and not PANDAS_GE_200:
         ctx = pytest.warns(FutureWarning, match="axis=None")
     else:
         ctx = contextlib.nullcontext()
@@ -1355,7 +1355,7 @@ def test_reductions_frame_dtypes_numeric_only_supported(func):
         warning = None
 
     # `numeric_only` default value
-    if PANDAS_GT_200:
+    if PANDAS_GE_200:
         if func in numeric_only_false_raises:
             with pytest.raises(
                 errors,
@@ -1370,7 +1370,7 @@ def test_reductions_frame_dtypes_numeric_only_supported(func):
                 getattr(df, func)(),
                 getattr(ddf, func)(),
             )
-    elif PANDAS_GT_150:
+    elif PANDAS_GE_150:
         with pytest.warns(warning, match="The default value of numeric_only"):
             pd_result = getattr(df, func)()
         with pytest.warns(warning, match="The default value of numeric_only"):
@@ -1473,9 +1473,9 @@ def test_skew_kurt_numeric_only_false(func):
     with ctx:
         getattr(ddf, func)(numeric_only=False)
 
-    if PANDAS_GT_150 and not PANDAS_GT_200:
+    if PANDAS_GE_150 and not PANDAS_GE_200:
         ctx = pytest.warns(FutureWarning, match="default value")
-    elif not PANDAS_GT_150:
+    elif not PANDAS_GE_150:
         ctx = pytest.warns(FutureWarning, match="nuisance columns")
 
     with ctx:
@@ -1790,7 +1790,7 @@ def test_datetime_std_across_axis1_null_results(skipna, numeric_only):
 
     ctx = contextlib.nullcontext()
     success = True
-    if numeric_only is False or (PANDAS_GT_200 and numeric_only is None):
+    if numeric_only is False or (PANDAS_GE_200 and numeric_only is None):
         ctx = pytest.raises(TypeError)
         success = False
     elif numeric_only is None:
@@ -1841,7 +1841,7 @@ def test_std_raises_on_index():
         dd.from_pandas(pd.DataFrame({"test": [1, 2]}), npartitions=2).index.std()
 
 
-@pytest.mark.skipif(not PANDAS_GT_200, reason="ArrowDtype not supported")
+@pytest.mark.skipif(not PANDAS_GE_200, reason="ArrowDtype not supported")
 def test_std_raises_with_arrow_string_ea():
     pa = pytest.importorskip("pyarrow")
     ser = pd.Series(["a", "b", "c"], dtype=pd.ArrowDtype(pa.string()))
@@ -1856,13 +1856,13 @@ def test_std_raises_with_arrow_string_ea():
         pytest.param(
             "int64[pyarrow]",
             marks=pytest.mark.skipif(
-                pa is None or not PANDAS_GT_150, reason="requires pyarrow installed"
+                pa is None or not PANDAS_GE_150, reason="requires pyarrow installed"
             ),
         ),
         pytest.param(
             "float64[pyarrow]",
             marks=pytest.mark.skipif(
-                pa is None or not PANDAS_GT_150, reason="requires pyarrow installed"
+                pa is None or not PANDAS_GE_150, reason="requires pyarrow installed"
             ),
         ),
         "Int64",

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -11,7 +11,7 @@ import pytest
 import dask
 import dask.dataframe as dd
 from dask.dataframe import _compat
-from dask.dataframe._compat import PANDAS_GT_150, PANDAS_GT_200, PANDAS_GT_210, tm
+from dask.dataframe._compat import PANDAS_GE_150, PANDAS_GE_200, PANDAS_GE_210, tm
 from dask.dataframe._pyarrow import to_pyarrow_string
 from dask.dataframe.core import _concat
 from dask.dataframe.utils import (
@@ -131,17 +131,17 @@ def test_concat_unions_categoricals():
             False,
             marks=[
                 pytest.mark.xfail(
-                    PANDAS_GT_200, reason="numeric_only=False not implemented"
+                    PANDAS_GE_200, reason="numeric_only=False not implemented"
                 ),
                 pytest.mark.xfail(
-                    not PANDAS_GT_150, reason="`numeric_only` not implemented"
+                    not PANDAS_GE_150, reason="`numeric_only` not implemented"
                 ),
             ],
         ),
         pytest.param(
             None,
             marks=pytest.mark.xfail(
-                PANDAS_GT_200, reason="numeric_only=False not implemented"
+                PANDAS_GE_200, reason="numeric_only=False not implemented"
             ),
         ),
     ],
@@ -166,7 +166,7 @@ def test_unknown_categoricals(shuffle_method, numeric_only):
 
     ctx = (
         pytest.warns(FutureWarning, match="The default of observed=False")
-        if PANDAS_GT_210
+        if PANDAS_GE_210
         else contextlib.nullcontext()
     )
     numeric_kwargs = {} if numeric_only is None else {"numeric_only": numeric_only}

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -16,10 +16,10 @@ import dask
 import dask.dataframe as dd
 from dask.dataframe import _compat
 from dask.dataframe._compat import (
-    PANDAS_GT_140,
-    PANDAS_GT_150,
-    PANDAS_GT_200,
-    PANDAS_GT_210,
+    PANDAS_GE_140,
+    PANDAS_GE_150,
+    PANDAS_GE_200,
+    PANDAS_GE_210,
     check_nuisance_columns_warning,
     check_numeric_only_deprecation,
     check_observed_deprecation,
@@ -42,7 +42,7 @@ AGG_FUNCS = [
     pytest.param(
         "mean",
         marks=pytest.mark.xfail(
-            condition=PANDAS_GT_200,
+            condition=PANDAS_GE_200,
             reason="numeric_only=False not implemented",
             strict=False,
         ),
@@ -55,7 +55,7 @@ AGG_FUNCS = [
     pytest.param(
         "std",
         marks=pytest.mark.xfail(
-            condition=PANDAS_GT_200,
+            condition=PANDAS_GE_200,
             reason="numeric_only=False not implemented",
             strict=False,
         ),
@@ -63,7 +63,7 @@ AGG_FUNCS = [
     pytest.param(
         "var",
         marks=pytest.mark.xfail(
-            condition=PANDAS_GT_200,
+            condition=PANDAS_GE_200,
             reason="numeric_only=False not implemented",
             strict=False,
         ),
@@ -71,7 +71,7 @@ AGG_FUNCS = [
     pytest.param(
         "cov",
         marks=pytest.mark.xfail(
-            condition=PANDAS_GT_200,
+            condition=PANDAS_GE_200,
             reason="numeric_only=False not implemented",
             strict=False,
         ),
@@ -79,7 +79,7 @@ AGG_FUNCS = [
     pytest.param(
         "corr",
         marks=pytest.mark.xfail(
-            condition=PANDAS_GT_200,
+            condition=PANDAS_GE_200,
             reason="numeric_only=False not implemented",
             strict=False,
         ),
@@ -109,7 +109,7 @@ def auto_shuffle_method(shuffle_method):
 @contextlib.contextmanager
 def groupby_axis_deprecated():
     ctx = contextlib.nullcontext()
-    if PANDAS_GT_210:
+    if PANDAS_GE_210:
         ctx = pytest.warns(FutureWarning, match="axis")
     with ctx:
         yield
@@ -488,7 +488,7 @@ def test_groupby_get_group(categoricals, by):
         ddf = ddf.categorize(columns=["b"])
     pdf = ddf.compute()
 
-    if PANDAS_GT_210 and categoricals:
+    if PANDAS_GE_210 and categoricals:
         ctx = pytest.warns(FutureWarning, match="The default of observed=False")
     else:
         ctx = contextlib.nullcontext()
@@ -1531,7 +1531,7 @@ def test_series_aggregations_multilevel(grouper, split_out, agg_func):
         pytest.param(
             lambda df: [df["a"] > 2, df["b"] > 1],
             marks=pytest.mark.xfail(
-                not PANDAS_GT_150,
+                not PANDAS_GE_150,
                 reason="index dtype does not coincide: boolean != empty",
             ),
         ),
@@ -2191,19 +2191,19 @@ def record_numeric_only_warnings():
         pytest.param(
             "var",
             marks=pytest.mark.xfail(
-                PANDAS_GT_200, reason="numeric_only=False not implemented"
+                PANDAS_GE_200, reason="numeric_only=False not implemented"
             ),
         ),
         pytest.param(
             "std",
             marks=pytest.mark.xfail(
-                PANDAS_GT_200, reason="numeric_only=False not implemented"
+                PANDAS_GE_200, reason="numeric_only=False not implemented"
             ),
         ),
         pytest.param(
             "mean",
             marks=pytest.mark.xfail(
-                PANDAS_GT_200, reason="numeric_only=False not implemented"
+                PANDAS_GE_200, reason="numeric_only=False not implemented"
             ),
         ),
         pytest.param(
@@ -2224,7 +2224,7 @@ def test_std_object_dtype(func):
     with ctx, check_numeric_only_deprecation():
         expected = getattr(df, func)()
     with _check_warning(
-        func in ["std", "var"] and not PANDAS_GT_200,
+        func in ["std", "var"] and not PANDAS_GE_200,
         FutureWarning,
         message="numeric_only",
     ):
@@ -2555,10 +2555,10 @@ def groupby_axis_and_meta():
     # all warnings and inspect them after the fact
     with pytest.warns() as record:
         yield
-    assert len(record) == 2 if PANDAS_GT_210 else 1, [x.message for x in record.list]
+    assert len(record) == 2 if PANDAS_GE_210 else 1, [x.message for x in record.list]
     assert record[-1].category is UserWarning
     assert "`meta` is not specified" in str(record[-1].message)
-    if PANDAS_GT_210:
+    if PANDAS_GE_210:
         assert record[0].category is FutureWarning
         assert "axis" in str(record[0].message)
 
@@ -2766,7 +2766,7 @@ def test_groupby_aggregate_categoricals(grouping, agg):
 
     observed_ctx = (
         pytest.warns(FutureWarning, match="observed")
-        if PANDAS_GT_210
+        if PANDAS_GE_210
         else contextlib.nullcontext()
     )
     with observed_ctx:
@@ -2950,7 +2950,7 @@ def test_groupby_grouper_dispatch(key):
         pytest.param(
             True,
             marks=pytest.mark.skipif(
-                not PANDAS_GT_150,
+                not PANDAS_GE_150,
                 reason="cudf and pandas behave differently",
             ),
         ),
@@ -2987,7 +2987,7 @@ def test_groupby_dropna_with_agg(sort):
     df = pd.DataFrame(
         {"id1": ["a", None, "b"], "id2": [1, 2, None], "v1": [4.5, 5.5, None]}
     )
-    if PANDAS_GT_200:
+    if PANDAS_GE_200:
         expected = df.groupby(["id1", "id2"], dropna=False, sort=sort).agg("sum")
     else:
         # before 2.0, sort=False appears to be disregarded, but only when
@@ -3040,7 +3040,7 @@ def test_groupby_split_out_multiindex(split_out, column):
     df["e"] = df["d"].astype("category")
     ddf = dd.from_pandas(df, npartitions=3)
 
-    if column == ["b", "e"] and PANDAS_GT_210:
+    if column == ["b", "e"] and PANDAS_GE_210:
         ctx = pytest.warns(FutureWarning, match="observed")
     else:
         ctx = contextlib.nullcontext()
@@ -3096,13 +3096,13 @@ def test_groupby_large_ints_exception(backend):
         pytest.param(
             "mean",
             marks=pytest.mark.xfail(
-                PANDAS_GT_200, reason="numeric_only=False not implemented", strict=False
+                PANDAS_GE_200, reason="numeric_only=False not implemented", strict=False
             ),
         ),
         pytest.param(
             "std",
             marks=pytest.mark.xfail(
-                PANDAS_GT_200, reason="numeric_only=False not implemented", strict=False
+                PANDAS_GE_200, reason="numeric_only=False not implemented", strict=False
             ),
         ),
     ],
@@ -3229,7 +3229,7 @@ def test_groupby_aggregate_categorical_observed(
         pytest.skip("Gives zeros rather than nans.")
     if agg_func in ["std", "var"] and observed:
         pytest.skip("Can't calculate observed with all nans")
-    if agg_func in ["sum", "prod"] and PANDAS_GT_200:
+    if agg_func in ["sum", "prod"] and PANDAS_GE_200:
         pytest.xfail("Not implemented for category type with pandas 2.0")
 
     pdf = pd.DataFrame(
@@ -3249,7 +3249,7 @@ def test_groupby_aggregate_categorical_observed(
 
     def agg(grp, **kwargs):
         if isinstance(grp, pd.core.groupby.DataFrameGroupBy) or (
-            PANDAS_GT_150 and not PANDAS_GT_200
+            PANDAS_GE_150 and not PANDAS_GE_200
         ):
             # with pandas 1.5, dask also raises a warning on default numeric_only
             ctx = check_numeric_only_deprecation
@@ -3287,7 +3287,7 @@ def test_groupby_cov_non_numeric_grouping_column():
     assert_eq(ddf.groupby("b").cov(), pdf.groupby("b").cov())
 
 
-@pytest.mark.skipif(not PANDAS_GT_150, reason="requires pandas >= 1.5.0")
+@pytest.mark.skipif(not PANDAS_GE_150, reason="requires pandas >= 1.5.0")
 def test_groupby_numeric_only_None_column_name():
     df = pd.DataFrame({"a": [1, 2, 3], None: ["a", "b", "c"]})
     ddf = dd.from_pandas(df, npartitions=1)
@@ -3295,7 +3295,7 @@ def test_groupby_numeric_only_None_column_name():
         ddf.groupby(lambda x: x).mean(numeric_only=False)
 
 
-@pytest.mark.skipif(not PANDAS_GT_140, reason="requires pandas >= 1.4.0")
+@pytest.mark.skipif(not PANDAS_GE_140, reason="requires pandas >= 1.4.0")
 @pytest.mark.parametrize("shuffle", [True, False])
 def test_dataframe_named_agg(shuffle):
     df = pd.DataFrame(
@@ -3319,7 +3319,7 @@ def test_dataframe_named_agg(shuffle):
     assert_eq(expected, actual)
 
 
-@pytest.mark.skipif(not PANDAS_GT_140, reason="requires pandas >= 1.4.0")
+@pytest.mark.skipif(not PANDAS_GE_140, reason="requires pandas >= 1.4.0")
 @pytest.mark.parametrize("shuffle", [True, False])
 @pytest.mark.parametrize("agg", ["count", "mean", partial(np.var, ddof=1)])
 def test_series_named_agg(shuffle, agg):
@@ -3527,7 +3527,7 @@ def test_groupby_slice_getitem(by, slice_key):
     [None, True, False],
 )
 @pytest.mark.skipif(
-    not PANDAS_GT_150, reason="numeric_only not implemented for pandas < 1.5"
+    not PANDAS_GE_150, reason="numeric_only not implemented for pandas < 1.5"
 )
 def test_groupby_numeric_only_supported(func, numeric_only):
     pdf = pd.DataFrame(
@@ -3546,7 +3546,7 @@ def test_groupby_numeric_only_supported(func, numeric_only):
     # depending on the version of pandas being used. Here we check that
     # dask and panadas have similar behavior
     ctx = contextlib.nullcontext()
-    if PANDAS_GT_150 and not PANDAS_GT_200:
+    if PANDAS_GE_150 and not PANDAS_GE_200:
         if func in ("sum", "prod", "median"):
             if numeric_only is None:
                 ctx = pytest.warns(
@@ -3588,10 +3588,10 @@ def test_groupby_numeric_only_not_implemented(func, numeric_only):
         NotImplementedError, match="'numeric_only=False' is not implemented in Dask"
     )
     if numeric_only is None:
-        if PANDAS_GT_150 and not PANDAS_GT_200:
+        if PANDAS_GE_150 and not PANDAS_GE_200:
             # Start warning about upcoming change to `numeric_only` default value
             ctx = ctx_warn
-        elif PANDAS_GT_200:
+        elif PANDAS_GE_200:
             # Default was changed to `numeric_only=False` in pandas 2.0
             ctx = ctx_error
     else:
@@ -3627,7 +3627,7 @@ def test_groupby_numeric_only_true(func):
     df = pd.DataFrame({"A": [1, 1, 2, 2], "B": [3, 4, 3, 4], "C": ["a", "b", "c", "d"]})
     ddf = dd.from_pandas(df, npartitions=2)
 
-    if func in ["var", "std", "cov", "corr"] and not PANDAS_GT_150:
+    if func in ["var", "std", "cov", "corr"] and not PANDAS_GE_150:
         with pytest.raises(TypeError, match="numeric_only not supported"):
             getattr(ddf.groupby("A"), func)(numeric_only=True)
         with pytest.raises(TypeError, match="got an unexpected keyword"):
@@ -3638,7 +3638,7 @@ def test_groupby_numeric_only_true(func):
         assert_eq(ddf_result, pdf_result)
 
 
-@pytest.mark.skipif(not PANDAS_GT_150, reason="numeric_only not supported for <1.5")
+@pytest.mark.skipif(not PANDAS_GE_150, reason="numeric_only not supported for <1.5")
 @pytest.mark.parametrize("func", ["cov", "corr"])
 def test_groupby_numeric_only_false_cov_corr(func):
     df = pd.DataFrame(
@@ -3671,7 +3671,7 @@ def test_groupby_numeric_only_false(func):
     )
     ddf = dd.from_pandas(df, npartitions=2)
 
-    if PANDAS_GT_200:
+    if PANDAS_GE_200:
         ctx = pytest.raises(TypeError, match="does not support")
 
         with ctx:
@@ -3692,7 +3692,7 @@ def test_groupby_numeric_only_false(func):
             pd_result = getattr(df.groupby("A"), func)(numeric_only=False)
         assert_eq(dd_result, pd_result)
 
-        if PANDAS_GT_150:
+        if PANDAS_GE_150:
             ctx = pytest.warns(FutureWarning, match="default value of numeric_only")
         else:
             ctx = contextlib.nullcontext()

--- a/dask/dataframe/tests/test_methods.py
+++ b/dask/dataframe/tests/test_methods.py
@@ -4,12 +4,12 @@ import numpy as np
 import pandas as pd
 
 import dask.dataframe.methods as methods
-from dask.dataframe._compat import PANDAS_GT_140
+from dask.dataframe._compat import PANDAS_GE_140
 
 
 def test_assign_not_modifying_array_inplace():
     df = pd.DataFrame({"a": [1, 2, 3], "b": 1.5})
     result = methods.assign(df, "a", 5)
     assert not np.shares_memory(df["a"].values, result["a"].values)
-    if PANDAS_GT_140:
+    if PANDAS_GE_140:
         assert np.shares_memory(df["b"].values, result["b"].values)

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -9,7 +9,7 @@ from pandas.api.types import is_object_dtype
 
 import dask.dataframe as dd
 from dask.base import compute_as_if_collection
-from dask.dataframe._compat import PANDAS_GT_140, PANDAS_GT_150, PANDAS_GT_200, tm
+from dask.dataframe._compat import PANDAS_GE_140, PANDAS_GE_150, PANDAS_GE_200, tm
 from dask.dataframe.core import _Frame
 from dask.dataframe.methods import concat
 from dask.dataframe.multi import (
@@ -2241,7 +2241,7 @@ def test_concat_datetimeindex():
 
 
 def check_append_with_warning(dask_obj, dask_append, pandas_obj, pandas_append):
-    if PANDAS_GT_140:
+    if PANDAS_GE_140:
         with pytest.warns(FutureWarning, match="append method is deprecated"):
             expected = pandas_obj.append(pandas_append)
             result = dask_obj.append(dask_append)
@@ -2254,7 +2254,7 @@ def check_append_with_warning(dask_obj, dask_append, pandas_obj, pandas_append):
     return result
 
 
-@pytest.mark.skipif(PANDAS_GT_200, reason="pandas removed append")
+@pytest.mark.skipif(PANDAS_GE_200, reason="pandas removed append")
 def test_append():
     df = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6], "b": [1, 2, 3, 4, 5, 6]})
     df2 = pd.DataFrame(
@@ -2286,7 +2286,7 @@ def test_append():
     check_append_with_warning(ddf.a, df3.b, df.a, df3.b)
 
 
-@pytest.mark.skipif(PANDAS_GT_200, reason="pandas removed append")
+@pytest.mark.skipif(PANDAS_GE_200, reason="pandas removed append")
 def test_append2():
     dsk = {
         ("x", 0): pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}),
@@ -2329,7 +2329,7 @@ def test_append2():
     check_append_with_warning(ddf3, df1, df3, df1)
 
 
-@pytest.mark.skipif(PANDAS_GT_200, reason="pandas removed append")
+@pytest.mark.skipif(PANDAS_GE_200, reason="pandas removed append")
 def test_append_categorical():
     frames = [
         pd.DataFrame(
@@ -2378,7 +2378,7 @@ def test_append_categorical():
         assert has_known_categories(res) == known
 
 
-@pytest.mark.skipif(PANDAS_GT_200, reason="pandas removed append")
+@pytest.mark.skipif(PANDAS_GE_200, reason="pandas removed append")
 def test_append_lose_divisions():
     df = pd.DataFrame({"x": [1, 2, 3, 4]}, index=[1, 2, 3, 4])
     ddf = dd.from_pandas(df, npartitions=2)
@@ -2532,14 +2532,14 @@ def test_concat_ignore_order(ordered):
         pytest.param(
             "int64[pyarrow]",
             marks=pytest.mark.skipif(
-                pa is None or not PANDAS_GT_150,
+                pa is None or not PANDAS_GE_150,
                 reason="Support for ArrowDtypes requires pyarrow and pandas>=1.5.0",
             ),
         ),
         pytest.param(
             "float64[pyarrow]",
             marks=pytest.mark.skipif(
-                pa is None or not PANDAS_GT_150,
+                pa is None or not PANDAS_GE_150,
                 reason="Support for ArrowDtypes requires pyarrow and pandas>=1.5.0",
             ),
         ),

--- a/dask/dataframe/tests/test_pyarrow.py
+++ b/dask/dataframe/tests/test_pyarrow.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 from pandas.tests.extension.decimal.array import DecimalDtype
 
-from dask.dataframe._compat import PANDAS_GT_140, PANDAS_GT_150
+from dask.dataframe._compat import PANDAS_GE_140, PANDAS_GE_150
 from dask.dataframe._pyarrow import (
     is_object_string_dataframe,
     is_object_string_dtype,
@@ -29,18 +29,18 @@ pa = pytest.importorskip("pyarrow")
         pytest.param(
             pa.int64(),
             False,
-            marks=pytest.mark.skipif(not PANDAS_GT_150, reason="Needs pd.ArrowDtype"),
+            marks=pytest.mark.skipif(not PANDAS_GE_150, reason="Needs pd.ArrowDtype"),
         ),
         pytest.param(
             pa.float64(),
             False,
-            marks=pytest.mark.skipif(not PANDAS_GT_150, reason="Needs pd.ArrowDtype"),
+            marks=pytest.mark.skipif(not PANDAS_GE_150, reason="Needs pd.ArrowDtype"),
         ),
         (pd.StringDtype("pyarrow"), True),
         pytest.param(
             pa.string(),
             True,
-            marks=pytest.mark.skipif(not PANDAS_GT_150, reason="Needs pd.ArrowDtype"),
+            marks=pytest.mark.skipif(not PANDAS_GE_150, reason="Needs pd.ArrowDtype"),
         ),
     ],
 )
@@ -62,18 +62,18 @@ def test_is_pyarrow_string_dtype(dtype, expected):
         pytest.param(
             pa.int64(),
             False,
-            marks=pytest.mark.skipif(not PANDAS_GT_150, reason="Needs pd.ArrowDtype"),
+            marks=pytest.mark.skipif(not PANDAS_GE_150, reason="Needs pd.ArrowDtype"),
         ),
         pytest.param(
             pa.float64(),
             False,
-            marks=pytest.mark.skipif(not PANDAS_GT_150, reason="Needs pd.ArrowDtype"),
+            marks=pytest.mark.skipif(not PANDAS_GE_150, reason="Needs pd.ArrowDtype"),
         ),
         (pd.StringDtype("pyarrow"), False),
         pytest.param(
             pa.string(),
             False,
-            marks=pytest.mark.skipif(not PANDAS_GT_150, reason="Needs pd.ArrowDtype"),
+            marks=pytest.mark.skipif(not PANDAS_GE_150, reason="Needs pd.ArrowDtype"),
         ),
     ],
 )
@@ -91,7 +91,7 @@ def test_is_object_string_dtype(dtype, expected):
         # Prior to pandas=1.4, Index couldn't contain extension dtypes
         (
             pd.Index(["a", "b"], dtype="string[pyarrow]"),
-            False if PANDAS_GT_140 else True,
+            False if PANDAS_GE_140 else True,
         ),
         (pd.Index([1, 2], dtype=int), False),
         (pd.Index([1, 2], dtype=float), False),
@@ -113,7 +113,7 @@ def test_is_object_string_dtype(dtype, expected):
                     pd.Index(["a", "b"], dtype="string[pyarrow]"),
                 ]
             ),
-            False if PANDAS_GT_140 else True,
+            False if PANDAS_GE_140 else True,
         ),
         (
             pd.MultiIndex.from_arrays(
@@ -150,7 +150,7 @@ def test_is_object_string_index(index, expected):
                 [1, 2], dtype=float, index=pd.Index(["a", "b"], dtype="string[pyarrow]")
             ),
             # Prior to pandas=1.4, Index couldn't contain extension dtypes
-            False if PANDAS_GT_140 else True,
+            False if PANDAS_GE_140 else True,
         ),
         (pd.Index(["a", "b"], dtype=object), False),
     ],
@@ -180,7 +180,7 @@ def test_is_object_string_series(series, expected):
                 index=pd.Index(["a", "b"], dtype="string[pyarrow]"),
             ),
             # Prior to pandas=1.4, Index couldn't contain extension dtypes
-            False if PANDAS_GT_140 else True,
+            False if PANDAS_GE_140 else True,
         ),
         (pd.Series({"x": ["a", "b"]}, dtype=object), False),
         (pd.Index({"x": ["a", "b"]}, dtype=object), False),

--- a/dask/dataframe/tests/test_pyarrow_compat.py
+++ b/dask/dataframe/tests/test_pyarrow_compat.py
@@ -10,14 +10,14 @@ import pytest
 
 pa = pytest.importorskip("pyarrow")
 
-from dask.dataframe._compat import PANDAS_GT_150
+from dask.dataframe._compat import PANDAS_GE_150
 
 # Tests are from https://github.com/pandas-dev/pandas/pull/49078
 
 
 @pytest.fixture
 def data(dtype):
-    if PANDAS_GT_150:
+    if PANDAS_GE_150:
         pa_dtype = dtype.pyarrow_dtype
     else:
         pa_dtype = pa.string()
@@ -78,12 +78,12 @@ def data(dtype):
     return pd.array(data * 100, dtype=dtype)
 
 
-PYARROW_TYPES = tm.ALL_PYARROW_DTYPES if PANDAS_GT_150 else [pa.string()]
+PYARROW_TYPES = tm.ALL_PYARROW_DTYPES if PANDAS_GE_150 else [pa.string()]
 
 
 @pytest.fixture(params=PYARROW_TYPES, ids=str)
 def dtype(request):
-    if PANDAS_GT_150:
+    if PANDAS_GE_150:
         return pd.ArrowDtype(pyarrow_dtype=request.param)
     else:
         return pd.StringDtype("pyarrow")
@@ -111,7 +111,7 @@ def test_pickle_roundtrip(data):
         "stringdtype",
         pytest.param(
             "arrowdtype",
-            marks=pytest.mark.skipif(not PANDAS_GT_150, reason="Requires ArrowDtype"),
+            marks=pytest.mark.skipif(not PANDAS_GE_150, reason="Requires ArrowDtype"),
         ),
     ],
 )

--- a/dask/dataframe/tests/test_reshape.py
+++ b/dask/dataframe/tests/test_reshape.py
@@ -96,7 +96,7 @@ def test_get_dummies_kwargs():
 
 def check_pandas_issue_45618_warning(test_func):
     # Check for FutureWarning raised in `pandas=1.4.0`-only.
-    # This can be removed when `pandas=1.4.0` is no longer supported (PANDAS_GT_140).
+    # This can be removed when `pandas=1.4.0` is no longer supported (PANDAS_GE_140).
     # See https://github.com/pandas-dev/pandas/issues/45618 for more details.
 
     def decorator():

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -9,7 +9,7 @@ import pytest
 
 import dask.dataframe as dd
 import dask.dataframe.rolling
-from dask.dataframe._compat import PANDAS_GT_210
+from dask.dataframe._compat import PANDAS_GE_210
 from dask.dataframe.utils import assert_eq
 
 N = 40
@@ -363,7 +363,7 @@ def test_rolling_axis(kwargs):
 
     ctx = (
         pytest.warns(FutureWarning, match="The 'axis' keyword|Support for axis")
-        if PANDAS_GT_210
+        if PANDAS_GE_210
         else contextlib.nullcontext()
     )
     if kwargs["axis"] == "series":

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -22,9 +22,9 @@ import dask
 import dask.dataframe as dd
 from dask.base import compute_as_if_collection
 from dask.dataframe._compat import (
-    PANDAS_GT_140,
-    PANDAS_GT_150,
-    PANDAS_GT_200,
+    PANDAS_GE_140,
+    PANDAS_GE_150,
+    PANDAS_GE_200,
     assert_categorical_equal,
     tm,
 )
@@ -202,7 +202,7 @@ def test_set_index_general(npartitions, shuffle_method):
     # Ensure extension dtypes work
     # NOTE: Older version of pandas have known issues with extension dtypes.
     # We generally expect extension dtypes to work well when using `pandas>=1.4.0`.
-    if PANDAS_GT_140:
+    if PANDAS_GE_140:
         df = df.astype({"x": "Float64", "z": "string"})
 
     ddf = dd.from_pandas(df, npartitions=npartitions)
@@ -218,7 +218,7 @@ def test_set_index_general(npartitions, shuffle_method):
 
 
 @pytest.mark.skipif(
-    not PANDAS_GT_150, reason="Only test `string[pyarrow]` on recent versions of pandas"
+    not PANDAS_GE_150, reason="Only test `string[pyarrow]` on recent versions of pandas"
 )
 @pytest.mark.parametrize(
     "string_dtype", ["string[python]", "string[pyarrow]", "object"]
@@ -1120,7 +1120,7 @@ def test_set_index_timestamp():
     assert_eq(df2, ddf.set_index("A"), check_freq=False)
 
 
-@pytest.mark.skipif(not PANDAS_GT_140, reason="EA Indexes not supported before")
+@pytest.mark.skipif(not PANDAS_GE_140, reason="EA Indexes not supported before")
 def test_set_index_ea_dtype():
     pdf = pd.DataFrame({"a": 1, "b": pd.Series([1, 2], dtype="Int64")})
     ddf = dd.from_pandas(pdf, npartitions=2)
@@ -1589,7 +1589,7 @@ def test_calculate_divisions(pdf, expected):
 
 
 @pytest.mark.skipif(pa is None, reason="Need pyarrow")
-@pytest.mark.skipif(not PANDAS_GT_200, reason="dtype support not good before 2.0")
+@pytest.mark.skipif(not PANDAS_GE_200, reason="dtype support not good before 2.0")
 @pytest.mark.parametrize(
     "data, dtype",
     [

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -11,7 +11,7 @@ from packaging.version import Version
 
 import dask
 import dask.dataframe as dd
-from dask.dataframe._compat import PANDAS_GT_200, tm
+from dask.dataframe._compat import PANDAS_GE_200, tm
 from dask.dataframe.core import apply_and_enforce
 from dask.dataframe.utils import (
     UNKNOWN_CATEGORIES,
@@ -273,7 +273,7 @@ def test_meta_nonempty_index():
     idx = pd.Index([1], name="foo", dtype="int")
     res = meta_nonempty(idx)
     assert type(res) is type(idx)
-    if PANDAS_GT_200:
+    if PANDAS_GE_200:
         assert res.dtype == np.int_
     else:
         # before pandas 2.0, index dtypes were only x64
@@ -683,7 +683,7 @@ def test_pyarrow_strings_enabled():
 
     # If `pandas>=2` and `pyarrow>=12` are installed, then default to using pyarrow strings
     if (
-        PANDAS_GT_200
+        PANDAS_GE_200
         and pa is not None
         and Version(pa.__version__) >= Version("12.0.0")
     ):

--- a/dask/dataframe/tseries/resample.py
+++ b/dask/dataframe/tseries/resample.py
@@ -6,7 +6,7 @@ from pandas.core.resample import Resampler as pd_Resampler
 
 from dask.base import tokenize
 from dask.dataframe import methods
-from dask.dataframe._compat import PANDAS_GT_140
+from dask.dataframe._compat import PANDAS_GE_140
 from dask.dataframe.core import DataFrame, Series
 from dask.highlevelgraph import HighLevelGraph
 from dask.utils import derived_from
@@ -28,7 +28,7 @@ def _resample_series(
         *how_args, **how_kwargs
     )
 
-    if PANDAS_GT_140:
+    if PANDAS_GE_140:
         if reindex_closed is None:
             inclusive = "both"
         else:

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -21,7 +21,7 @@ from dask.dataframe import (  # noqa: F401 register pandas extension types
     _dtypes,
     methods,
 )
-from dask.dataframe._compat import PANDAS_GT_150, tm  # noqa: F401
+from dask.dataframe._compat import PANDAS_GE_150, tm  # noqa: F401
 from dask.dataframe.dispatch import (  # noqa : F401
     make_meta,
     make_meta_obj,
@@ -851,7 +851,7 @@ def get_numeric_only_kwargs(numeric_only) -> dict:
 def check_numeric_only_valid(numeric_only, name: str) -> dict:
     from dask.dataframe.core import no_default  # Avoid circular import
 
-    if PANDAS_GT_150 and numeric_only is not no_default:
+    if PANDAS_GE_150 and numeric_only is not no_default:
         return {"numeric_only": numeric_only}
     elif numeric_only is no_default:
         return {}

--- a/dask/tests/test_spark_compat.py
+++ b/dask/tests/test_spark_compat.py
@@ -17,7 +17,7 @@ pytest.importorskip("fastparquet")
 import numpy as np
 import pandas as pd
 
-from dask.dataframe._compat import PANDAS_GT_150, PANDAS_GT_200
+from dask.dataframe._compat import PANDAS_GE_150, PANDAS_GE_200
 from dask.dataframe.utils import assert_eq
 
 pytestmark = [
@@ -26,7 +26,7 @@ pytestmark = [
         reason="Unnecessary, and hard to get spark working on non-linux platforms",
     ),
     pytest.mark.skipif(
-        PANDAS_GT_200,
+        PANDAS_GE_200,
         reason="pyspark doesn't yet have support for pandas 2.0",
     ),
     # we only test with pyarrow strings and pandas 2.0
@@ -163,7 +163,7 @@ def test_roundtrip_parquet_spark_to_dask_extension_dtypes(spark_session, tmpdir)
     assert_eq(ddf, pdf, check_index=False)
 
 
-@pytest.mark.skipif(not PANDAS_GT_150, reason="Requires pyarrow-backed nullable dtypes")
+@pytest.mark.skipif(not PANDAS_GE_150, reason="Requires pyarrow-backed nullable dtypes")
 def test_read_decimal_dtype_pyarrow(spark_session, tmpdir):
     tmpdir = str(tmpdir)
     npartitions = 3


### PR DESCRIPTION
The abbreviation **gt** is commonly used for **greater than (>)**, whereas **greater than or equal (>=)** is commonly abbreviated as **ge**. Libraries following this naming convention include
* Python Standard Library's `operator` (https://docs.python.org/3/library/operator.html#operator.ge)
* `pandas` (https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.ge.html)
* `numpy` (https://numpy.org/doc/stable/reference/generated/numpy.ndarray.__ge__.html)

I suggest that we follow this naming convention.

- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
