### PR TITLE
Prevent an error caused by concurrent use of a cache on multiple threads

### DIFF
--- a/dask/cache.py
+++ b/dask/cache.py
@@ -55,9 +55,11 @@ class Cache(Callback):
         self.starttimes[key] = default_timer()
 
     def _posttask(self, key, value, dsk, state, id):
-        # In the case that finish cleared the starttime for this task on
-        # another thread, assume a zero duration, which is given the least
-        # priority and should evict no other results with accurate timings.
+        # In the case that _finish cleared the starttime for this task on
+        # another thread, assume a zero duration, which should evict no other
+        # results with more accurate/non-zero durations.
+        # For more details and discussion see:
+        # https://github.com/dask/dask/issues/10396
         duration = 0
         if starttime := self.starttimes.get(key):
             duration += default_timer() - starttime

--- a/dask/tests/test_cache.py
+++ b/dask/tests/test_cache.py
@@ -129,15 +129,15 @@ def test_multithreaded_access(executor: ThreadPoolExecutor, index: tuple[int, in
     # Create a small cache that can only store one result at most.
     cache = PosttaskBlockingCache(1)
     # Hold the posttask_lock to prevent the thread from executing
-    # the actual cache's posttask.
+    # the actual cache's _posttask method.
     with cache.posttask_lock:
         with cache.posttask_condition:
             # Access the first element with the cache on another thread
-            # and wait for it reach posttask.
+            # and wait for it reach the _posttask method.
             task = executor.submit(cached_array_index, cache, array, index[0])
             cache.posttask_condition.wait()
         # Access the second element with the cache on the main thread
-        # before the other thread starts the actual posttask.
+        # before the other thread executes the actual _posttask method.
         cached_array_index(cache, array, index[1])
     # Wait for the other thread to finish executing.
     task.result(timeout=1)

--- a/dask/tests/test_cache.py
+++ b/dask/tests/test_cache.py
@@ -87,7 +87,7 @@ class PosttaskBlockingCache(Cache):
     """Cache that controls execution of the posttask callback.
 
     This is useful for reproducing concurrency bugs caused by execution
-    of the Cache's posttask callback.
+    of the Cache's _posttask method.
     """
 
     def __init__(self, cache):


### PR DESCRIPTION
This modifies the cache's cost calculation so that determining the start time of the task never raises a `KeyError`. This can happen due to interleaving of the cache's `_posttask` method (which accesses `starttimes`) and the `_finish` method (which clears `starttimes`). Now, when the start time is not present, the initial duration (not including dependencies) is 0, so that the task has no extra power to evict other results from the cache, but can still be put in there when there's space. This also makes access of `starttimes` more consistent with `durations`.

This adds a parametrized test to reproduce that specific case as described in #10396. That test needs some specific concurrency control, so seems a little artificial, but it does reproduce a possible interleaving of task and callback execution. The control also means that it runs fast and should not be flaky.

This also adds implementation comments to explain the new code and some of the existing code.

Closes #10396
