### PR TITLE
Add ``distributed.print`` to debugging docs

### DIFF
--- a/docs/source/how-to/debug.rst
+++ b/docs/source/how-to/debug.rst
@@ -11,6 +11,19 @@ your situation, some of these approaches may be more appropriate than others.
 These approaches are ordered from lightweight or easy solutions to more
 involved solutions.
 
+Printing
+--------
+
+One of the most basic methods of debugging is to simply print values and inspect them.
+However, when using Python's built-in :func:`print` function with Dask, those prints
+often happen on remote machines instead of in the user's Python session, which typically
+isn't the experience developers want when debugging.
+
+Because of this, Dask offers a :func:`dask.distributed.print <distributed.print>` function which acts
+just like Python's built-in :func:`print` but also forwards the printed output to the
+client side Python session. This makes distributed debugging feel more like debugging
+locally.
+
 Exceptions
 ----------
 


### PR DESCRIPTION
While talking with users recently, `distributed.print` has been useful for debugging, but folks tend to not know about it because we only have API docs for it. This PR increases the visibility of `distributed.print` for users by adding it to the debugging doc page. This seems like a natural fit to me, but I'm definitely open to suggestions if folks thinks there's a better place for this prose to live. 

cc @phofl for visibility 