### PR TITLE
Use SPDX in `license` metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "dask"
 description = "Parallel PyData with Task Scheduling"
 maintainers = [{name = "Matthew Rocklin", email = "mrocklin@gmail.com"}]
-license = {text = "BSD"}
+license = {text = "BSD-3-Clause"}
 keywords = ["task-scheduling parallel numpy pandas pydata"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
As there are different variants of BSD, specifying the type of BSD makes this clearer to (potential) users seeing this metadata. Also following SPDX standardizes the metadata so it is human and machine readable, which may be important for some users.

https://spdx.org/licenses/BSD-3-Clause

<hr>

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
