### PR TITLE
Fix ValueError when running to_csv in append mode with single_file as True

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -941,7 +941,8 @@ def to_csv(
     if single_file:
         first_file = open_file(filename, mode=mode, **file_options)
         value = to_csv_chunk(dfs[0], first_file, **kwargs)
-        append_mode = mode.replace("w", "") + "a"
+        append_mode = mode if mode.endswith("a") else mode + "a"
+        append_mode = append_mode.replace("w", "")
         append_file = open_file(filename, mode=append_mode, **file_options)
         kwargs["header"] = False
         for d in dfs[1:]:

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -941,7 +941,7 @@ def to_csv(
     if single_file:
         first_file = open_file(filename, mode=mode, **file_options)
         value = to_csv_chunk(dfs[0], first_file, **kwargs)
-        append_mode = mode if mode.endswith("a") else mode + "a"
+        append_mode = mode if "a" in mode else mode + "a"
         append_mode = append_mode.replace("w", "")
         append_file = open_file(filename, mode=append_mode, **file_options)
         kwargs["header"] = False

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1547,7 +1547,7 @@ def test_to_csv_with_single_file_and_append_mode():
         )
         result = dd.read_csv(os.path.join(dir, "*"), skiprows=[1]).compute()
     assert (result.x.values == df0.x.values).all()
-    
+
 
 def test_to_csv_series():
     df0 = pd.Series(["a", "b", "c", "d"], index=[1.0, 2.0, 3.0, 4.0])
@@ -1893,4 +1893,3 @@ def test_names_with_header_0(tmpdir, use_names):
 
     # Result should only leave out 0th row
     assert_eq(df, ddf, check_index=False)
-

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1529,6 +1529,26 @@ def test_to_csv_simple():
     assert (result.x.values == df0.x.values).all()
 
 
+def test_to_csv_with_single_file_and_append_mode():
+    df0 = pd.DataFrame(
+        {"x": ["a", "b", "c", "d"], "y": [1, 2, 3, 4]},
+    )
+    df = dd.from_pandas(df0, npartitions=2)
+    with tmpdir() as dir:
+        csv_path = os.path.join(dir, "test.csv")
+        with open(csv_path, mode="w") as file:
+            file.write("x, y\n1, 3\n")
+        df.to_csv(
+            str(csv_path),
+            mode="a",
+            header=False,
+            index=False,
+            single_file=True,
+        )
+        result = dd.read_csv(os.path.join(dir, "*"), skiprows=[1]).compute()
+    assert (result.x.values == df0.x.values).all()
+    
+
 def test_to_csv_series():
     df0 = pd.Series(["a", "b", "c", "d"], index=[1.0, 2.0, 3.0, 4.0])
     df = dd.from_pandas(df0, npartitions=2)
@@ -1873,3 +1893,4 @@ def test_names_with_header_0(tmpdir, use_names):
 
     # Result should only leave out 0th row
     assert_eq(df, ddf, check_index=False)
+

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1530,6 +1530,7 @@ def test_to_csv_simple():
 
 
 def test_to_csv_with_single_file_and_append_mode():
+    # regression test for https://github.com/dask/dask/issues/10414
     df0 = pd.DataFrame(
         {"x": ["a", "b", "c", "d"], "y": [1, 2, 3, 4]},
     )

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1541,11 +1541,11 @@ def test_to_csv_with_single_file_and_append_mode():
     with tmpdir() as dir:
         csv_path = os.path.join(dir, "test.csv")
         df0.to_csv(
-            str(csv_path),
+            csv_path,
             index=False,
         )
         df.to_csv(
-            str(csv_path),
+            csv_path,
             mode="a",
             header=False,
             index=False,

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1547,7 +1547,7 @@ def test_to_csv_with_single_file_and_append_mode():
             single_file=True,
         )
         result = dd.read_csv(os.path.join(dir, "*"), skiprows=[1]).compute()
-    assert (result.x.values == df0.x.values).all()
+    assert assert_eq(result, df0)
 
 
 def test_to_csv_series():


### PR DESCRIPTION
- [x] Closes #10414
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

I think this is pretty well described here: https://github.com/dask/dask/issues/10414

Currently dask adds on "a" to the mode when single_file is True, but this clashes when the mode is already set to "a".

This PR adds in a conditional check the the mode ending with "a" before appending "a" to the end.

Also, testing added to cover the bug fix.
