### PR TITLE
Enable file mode="x" with a single_file=True for dask dataframe to_csv

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -941,7 +941,7 @@ def to_csv(
     if single_file:
         first_file = open_file(filename, mode=mode, **file_options)
         value = to_csv_chunk(dfs[0], first_file, **kwargs)
-        append_mode = mode.replace("w", "") + "a"
+        append_mode = mode.replace("w", "").replace("x", "") + "a"
         append_file = open_file(filename, mode=append_mode, **file_options)
         kwargs["header"] = False
         for d in dfs[1:]:

--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -942,7 +942,7 @@ def to_csv(
         first_file = open_file(filename, mode=mode, **file_options)
         value = to_csv_chunk(dfs[0], first_file, **kwargs)
         append_mode = mode if "a" in mode else mode + "a"
-        append_mode = mode.replace("w", "").replace("x", "")
+        append_mode = append_mode.replace("w", "").replace("x", "")
         append_file = open_file(filename, mode=append_mode, **file_options)
         kwargs["header"] = False
         for d in dfs[1:]:

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1475,6 +1475,18 @@ def test_to_single_csv_with_header_first_partition_only():
             )
 
 
+def test_to_csv_with_single_file_and_exclusive_mode():
+    df0 = pd.DataFrame(
+        {"x": ["a", "b", "c", "d"], "y": [1, 2, 3, 4]}
+    )
+    df = dd.from_pandas(df0, npartitions=2)
+    with tmpdir() as dir:
+        csv_path = os.path.join(dir, "test.csv")
+        df.to_csv(csv_path, index=False, mode="x", single_file=True)
+        result = dd.read_csv(os.path.join(dir, "*")).compute()
+    assert_eq(result, df0, check_index=False)
+
+
 def test_to_single_csv_gzip():
     df = pd.DataFrame({"x": ["a", "b", "c", "d"], "y": [1, 2, 3, 4]})
 

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1478,11 +1478,25 @@ def test_to_single_csv_with_header_first_partition_only():
 def test_to_csv_with_single_file_and_exclusive_mode():
     df0 = pd.DataFrame({"x": ["a", "b", "c", "d"], "y": [1, 2, 3, 4]})
     df = dd.from_pandas(df0, npartitions=2)
-    with tmpdir() as dir:
-        csv_path = os.path.join(dir, "test.csv")
+    with tmpdir() as directory:
+        csv_path = os.path.join(directory, "test.csv")
         df.to_csv(csv_path, index=False, mode="x", single_file=True)
-        result = dd.read_csv(os.path.join(dir, "*")).compute()
+        result = dd.read_csv(os.path.join(directory, "*")).compute()
     assert_eq(result, df0, check_index=False)
+
+
+def test_to_csv_single_file_exlusive_mode_no_overwrite():
+    df0 = pd.DataFrame({"x": ["a", "b", "c", "d"], "y": [1, 2, 3, 4]})
+    df = dd.from_pandas(df0, npartitions=2)
+    with tmpdir() as directory:
+        csv_path = os.path.join(str(directory), "test.csv")
+        df.to_csv(csv_path, index=False, mode="x", single_file=True)
+        assert os.path.exists(csv_path)
+        # mode="x" should fail if file already exists
+        with pytest.raises(FileExistsError):
+            df.to_csv(csv_path, index=False, mode="x", single_file=True)
+        # but mode="w" will overwrite an existing file
+        df.to_csv(csv_path, index=False, mode="w", single_file=True)
 
 
 def test_to_single_csv_gzip():

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1476,9 +1476,7 @@ def test_to_single_csv_with_header_first_partition_only():
 
 
 def test_to_csv_with_single_file_and_exclusive_mode():
-    df0 = pd.DataFrame(
-        {"x": ["a", "b", "c", "d"], "y": [1, 2, 3, 4]}
-    )
+    df0 = pd.DataFrame({"x": ["a", "b", "c", "d"], "y": [1, 2, 3, 4]})
     df = dd.from_pandas(df0, npartitions=2)
     with tmpdir() as dir:
         csv_path = os.path.join(dir, "test.csv")


### PR DESCRIPTION
- [x] Closes https://github.com/dask/dask/issues/10442
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Issue https://github.com/dask/dask/issues/10442 describes two closely related issues.
This PR addresses the second issue, using file `mode="x"` with a `single_file=True` in dask dataframe `to_csv()`

@hendrikmakait provides a test demonstrating the problem in the issue, and points out the problematic line here:
> (See https://github.com/dask/dask/pull/10441#discussion_r1293437311 for a pointer to where the problem might be.) cc @benrutter
