### PR TITLE
Update versioneer version to >= 0.28

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=62.6", "versioneer[toml]==0.28"]
+requires = ["setuptools>=62.6", "versioneer[toml]>=0.28"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
versioneer [released](https://github.com/python-versioneer/python-versioneer/releases/tag/0.29) version 0.29

I'm not sure how to test this properly. I was able to install this package locally using `pip install .`

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
