### PR TITLE
Add default `types_mapper` to `from_pyarrow_table_dispatch` for pandas

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -230,7 +230,7 @@ def get_pandas_dataframe_from_pyarrow(meta, table, **kwargs):
 
     def default_types_mapper(pyarrow_dtype: pa.DataType) -> object:
         # Avoid converting strings from `string[pyarrow]` to
-        # `string[python]` if we have *some* `string[pyarrow]`
+        # `string[python]` if we have *any* `string[pyarrow]`
         if (
             pyarrow_dtype in {pa.large_string(), pa.string()}
             and pd.StringDtype("pyarrow") in meta.dtypes.values

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -229,8 +229,8 @@ def get_pandas_dataframe_from_pyarrow(meta, table, **kwargs):
     import pyarrow as pa
 
     def default_types_mapper(pyarrow_dtype: pa.DataType) -> object:
-        # Avoid converting strings from `string[pyarrow]` to `string[python]`
-        # if we have *some* `string[pyarrow]`
+        # Avoid converting strings from `string[pyarrow]` to
+        # `string[python]` if we have *some* `string[pyarrow]`
         if (
             pyarrow_dtype in {pa.large_string(), pa.string()}
             and pd.StringDtype("pyarrow") in meta.dtypes.values

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -224,9 +224,22 @@ def get_pyarrow_table_from_pandas(obj, **kwargs):
 
 
 @from_pyarrow_table_dispatch.register((pd.DataFrame,))
-def get_pandas_dataframe_from_pyarrow(_, table, **kwargs):
+def get_pandas_dataframe_from_pyarrow(meta, table, **kwargs):
     # `kwargs` must be supported by `pyarrow.Table.to_pandas`
-    return table.to_pandas(**kwargs)
+    import pyarrow as pa
+
+    def default_types_mapper(pyarrow_dtype: pa.DataType) -> object:
+        # Avoid converting strings from `string[pyarrow]` to `string[python]`
+        # if we have *some* `string[pyarrow]`
+        if (
+            pyarrow_dtype in {pa.large_string(), pa.string()}
+            and pd.StringDtype("pyarrow") in meta.dtypes.values
+        ):
+            return pd.StringDtype("pyarrow")
+        return None
+
+    types_mapper = kwargs.pop("types_mapper", default_types_mapper)
+    return table.to_pandas(types_mapper=types_mapper, **kwargs)
 
 
 @meta_nonempty.register(pd.DatetimeTZDtype)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -6059,6 +6059,7 @@ def test_pyarrow_conversion_dispatch(self_destruct):
     pytest.importorskip("pyarrow")
 
     df1 = pd.DataFrame(np.random.randn(10, 3), columns=list("abc"))
+    df1["d"] = pd.Series(["cat", "dog"] * 5, dtype="string[pyarrow]")
     df2 = from_pyarrow_table_dispatch(
         df1,
         to_pyarrow_table_dispatch(df1),


### PR DESCRIPTION
`dask.dataframe.dispatch.from_pyarrow_table_dispatch` is currently used by `distributed`'s p2p-shuffle algorithm. However, in order to ensure that pyarrow string types are not lost during the pandas-arrow-pandas round trip, a special `types_mapper` argument is passed through to `pa.Table.to_pandas`. The `types_mapper` argument is not backend agnostic, as such an argument must be ignored by the `cudf` implementation of `from_pyarrow_table_dispatch`.

This PR moves the `types_mapper` logic into the pandas implementation of `from_pyarrow_table_dispatch`.
