### PR TITLE
Remove unnecessary check in ``timeseries``

### DIFF
--- a/dask/dataframe/io/demo.py
+++ b/dask/dataframe/io/demo.py
@@ -287,8 +287,6 @@ class MakeDataframePart(DataFrameIOFunction):
 
     def __call__(self, part):
         divisions, state_data = part
-        if isinstance(state_data, int):
-            state_data = random_state_data(1, state_data)
         return make_dataframe_part(
             self.index_dtype,
             divisions[0],


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

This is never hit (because we have a np.int64 integer instead of int) which is good, because we would fail otherwise