### PR TITLE
Avoiding tying things together when write_meta_file=False

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1045,18 +1045,14 @@ def to_parquet(
                 {"append": append, "compression": compression},
             )
         }
-    else:
-        # NOTE: We still define a single task to tie everything together
-        # when we are not writing a _metadata file. We do not want to
-        # return `data_write` (or a `data_write.to_bag()`), because calling
-        # `compute()` on a multi-partition collection requires the overhead
-        # of trying to concatenate results on the client.
-        final_name = "store-" + data_write._name
-        dsk = {(final_name, 0): (lambda x: None, data_write.__dask_keys__())}
 
-    # Convert data_write + dsk to computable collection
-    graph = HighLevelGraph.from_collections(final_name, dsk, dependencies=(data_write,))
-    out = Scalar(graph, final_name, "")
+        # Convert data_write + dsk to computable collection
+        graph = HighLevelGraph.from_collections(
+            final_name, dsk, dependencies=(data_write,)
+        )
+        out = Scalar(graph, final_name, "")
+    else:
+        out = data_write
 
     if compute:
         out = out.compute(**compute_kwargs)


### PR DESCRIPTION
This PR stems from [this conversation](https://dask.discourse.group/t/improving-pipeline-resilience-when-using-to-parquet-and-preemptible-workers/2141). I gathered from the comments that this could be worth opening a PR.

On the one hand tying things together is neat and avoid the overhead of concatenating results on the client.
On the other hand  when using preemptible workers you would want to return the last `map_partitions` instead so that you could release memory as soon as possible if you wish to. 

I am sorry if I didn't raise an issue before, feel free to close it if it's not something worth integrating to dask.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
