### PR TITLE
Delay row-wise parquet filtering until just after IO

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -632,7 +632,7 @@ class ArrowDatasetEngine(Engine):
                 row_group,
                 columns,
                 schema,
-                None, # Delay filtering until just after IO
+                None,  # Apply filters just after IO, below
                 partitions,
                 partition_keys,
                 **kwargs,

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -632,7 +632,7 @@ class ArrowDatasetEngine(Engine):
                 row_group,
                 columns,
                 schema,
-                filters,
+                None, # Delay filtering until just after IO
                 partitions,
                 partition_keys,
                 **kwargs,
@@ -642,6 +642,10 @@ class ArrowDatasetEngine(Engine):
 
         if multi_read:
             arrow_table = pa.concat_tables(tables)
+
+        if filters is not None:
+            # Applying filters just after IO tends to be faster
+            arrow_table = arrow_table.filter(_filters_to_expression(filters))
 
         # Convert to pandas
         df = cls._arrow_table_to_pandas(


### PR DESCRIPTION
While investigating benchmark results in dask-expr, @phofl noticed that predicate pushdown was giving us surprisingly bad performance in some cases. Although defining `filters` is clearly beneficial when we can drop entire row-groups from the dataset, the row-wise filtering step that pyarrow applies at read time is much less beneficial. In fact, it is typically faster to delay the row-wise filtering step until just **after** IO is complete (either with pandas or pyarrow).

This PR proposes the minimal possible change needed to delay the row-wise filtering step until just after IO. Note that row-groups and hive-partitions will already have been filtered before the modified function is executed. Therefore, these changes do **not** mean that we will **need** data to be in memory for filtering.