### PR TITLE
Feat/parquet notie

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -177,7 +177,7 @@ class ToParquetFunctionWrapper:
             **(dict(self.kwargs_pass, head=True) if part_i == 0 else self.kwargs_pass),
         )
 
-        # Return a value compatible with parquet format
+        # Return a value compatible with dask dataframe format
         # (value will be empty list when write_metadata_file=False)
         return out if out else 0
 

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1028,7 +1028,7 @@ def to_parquet(
             # return 0s.
             # This is necessary, because we are not
             # expecting a dataframe-like output.
-            meta=df._meta if write_metadata_file else (None, "i8"),
+            meta=df._meta,
             enforce_metadata=False,
             transform_divisions=False,
             align_dataframes=False,

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -1058,7 +1058,24 @@ def to_parquet(
         )
         out = Scalar(graph, final_name, "")
     else:
-        out = data_write
+        if compute:
+            # NOTE: We still define a single task to tie everything together
+            # when we are not writing a _metadata file. We do not want to
+            # return `data_write` (or a `data_write.to_bag()`), because calling
+            # `compute()` on a multi-partition collection requires the overhead
+            # of trying to concatenate results on the client.
+            final_name = "store-" + data_write._name
+            dsk = {(final_name, 0): (lambda x: None, data_write.__dask_keys__())}
+            # Convert data_write + dsk to computable collection
+            graph = HighLevelGraph.from_collections(
+                final_name, dsk, dependencies=(data_write,)
+            )
+            out = Scalar(graph, final_name, "")
+        else:
+            # We let the user have more control over the task in that case
+            # for usage where for instance you would want to release memory
+            # earlier.
+            out = data_write
 
     if compute:
         out = out.compute(**compute_kwargs)

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -179,7 +179,7 @@ class ToParquetFunctionWrapper:
 
         # Return a value compatible with dask dataframe format
         # (value will be empty list when write_metadata_file=False)
-        return out if out else 0
+        return out if self.write_metadata_file else 0
 
 
 @dataframe_creation_dispatch.register_inplace("pandas")

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2601,7 +2601,7 @@ def test_getitem_optimization(tmpdir, engine, preserve_index, index):
     # Write ddf back to disk to check that the round trip
     # preserves the getitem optimization
     out = ddf.to_frame().to_parquet(tmp_path_wt, engine=engine, compute=False)
-    dsk = optimize_dataframe_getitem(out.dask, keys=[out.key])
+    dsk = optimize_dataframe_getitem(out.dask, keys=[out._name])
 
     subgraph_rd = hlg_layer(dsk, "read-parquet")
     assert isinstance(subgraph_rd, DataFrameIOLayer)


### PR DESCRIPTION
- [x] Closes [#10463](https://github.com/dask/dask/issues/10463)
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

This MR remove the `Scalar` object returned when `compute`=False in `to_parquet`. Instead we give the user more control over the final `map_partitions` task.

This would allow the user to do things like [in this post](https://dask.discourse.group/t/improving-pipeline-resilience-when-using-to-parquet-and-preemptible-workers/2141) where we would release memory as soon as possible.

I feel like we could add the following snipped in the [resilience docs](https://examples.dask.org/resilience.html) for users that are using preemptible tasks

```
    ddf = df.to_parquet(name, compute=False)

    parquet_files = ddf.to_delayed()

    client: dask.distributed.Client = dask.distributed.get_client()
    futures = client.compute(parquet_files)

    for future in as_completed(futures):
        # Release memory
        future.result()
        future.release()
```

I am using it on my own project right now and it seems to work but I am happy to hear about downside of such approaches as well :) 