### PR TITLE
Special handling for None in DASK_ environment variables

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -260,7 +260,10 @@ def collect_env(env: Mapping[str, str] | None = None) -> dict:
             try:
                 d[varname] = ast.literal_eval(value)
             except (SyntaxError, ValueError):
-                d[varname] = value
+                if value.lower() in ("none", "null"):
+                    d[varname] = None
+                else:
+                    d[varname] = value
 
     result: dict = {}
     set(d, config=result)

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -227,10 +227,33 @@ def test_env():
     assert res == expected
 
 
+def test_env_none_values():
+    env = {
+        "DASK_A": "None",
+        "DASK_B": "NONE",
+        "DASK_C": "none",
+        "DASK_D": "Null",
+        "DASK_E": "NULL",
+        "DASK_F": "null",
+    }
+
+    expected = {
+        "a": None,
+        "b": None,
+        "c": None,
+        "d": None,
+        "e": None,
+        "f": None,
+    }
+
+    res = collect_env(env)
+    assert res == expected
+
+
 def test_collect():
     a = {"x": 1, "y": {"a": 1}}
     b = {"x": 2, "z": 3, "y": {"b": 2}}
-    env = {"DASK_W": 4}
+    env = {"DASK_W": "4"}
 
     expected = {"w": 4, "x": 2, "y": {"a": 1, "b": 2}, "z": 3}
 


### PR DESCRIPTION
- Complements https://github.com/dask/distributed/pull/8144

We use `ast.literal_eval` to parse environment variables. While that works fine for numbers and even for complicated nested python objects, it's not user friendly for None, where users are likely to get confused with capitalization (keys are all uppercase) and with yaml/json where the value is null.

CC @ntabris 