### PR TITLE
Handle `cached_property` decorators in `derived_from`

### DIFF
--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -605,15 +605,7 @@ def test_derived_from():
 
 @pytest.mark.parametrize(
     "decorator",
-    [
-        property,
-        pytest.param(
-            functools.cached_property,
-            marks=pytest.mark.xfail(
-                reason="derived_from must special-case cached_property"
-            ),
-        ),
-    ],
+    [property, functools.cached_property],
     ids=["@property", "@cached_property"],
 )
 def test_derived_from_prop_cached_prop(decorator):

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -603,6 +603,42 @@ def test_derived_from():
     assert "  extra docstring\n\n" in Zap.f.__doc__
 
 
+@pytest.mark.parametrize(
+    "decorator",
+    [
+        property,
+        pytest.param(
+            functools.cached_property,
+            marks=pytest.mark.xfail(
+                reason="derived_from must special-case cached_property"
+            ),
+        ),
+    ],
+    ids=["@property", "@cached_property"],
+)
+def test_derived_from_prop_cached_prop(decorator):
+    class Base:
+        @decorator
+        def prop(self):
+            """A property
+
+            Long details"""
+            return 1
+
+    class Derived:
+        @decorator
+        @derived_from(Base)
+        def prop(self):
+            "Some extra doc"
+            return 3
+
+    docstring = Derived.prop.__doc__
+    assert docstring is not None
+    assert docstring.strip().startswith("A property")
+    assert any("inconsistencies" in line for line in docstring.split("\n"))
+    assert any("Some extra doc" in line for line in docstring.split("\n"))
+
+
 def test_derived_from_func():
     import builtins
 

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -775,6 +775,11 @@ def _derived_from(
         if not doc:
             doc = getattr(original_method, "__doc__", None)
 
+    if isinstance(original_method, functools.cached_property):
+        original_method = original_method.func
+        if not doc:
+            doc = getattr(original_method, "__doc__", None)
+
     if doc is None:
         doc = ""
 


### PR DESCRIPTION
Similar to normal property decorators, if we encounter a cached_property in derived_from introspection, we must unwrap it to find the docstring on the original function.

(Ran into this wrapping a cudf object which exposes cached_properties rather than properties).

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
