### PR TITLE
Fix `_partitions` `dtype` in `meta` for `DataFrame.set_index` and `DataFrame.sort_values`

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -310,6 +310,11 @@ def set_partition(
     else:
         divisions = df._meta._constructor_sliced(divisions, dtype=dtype)
 
+    meta = df._meta._constructor_sliced([0])
+    # Ensure that we have the same index as before to avoid alignment
+    # when calculating meta dtypes later on
+    meta.index = df._meta_nonempty.index[:1]
+
     if not isinstance(index, Series):
         partitions = df[index].map_partitions(
             set_partitions_pre, divisions=divisions, meta=meta

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -288,7 +288,6 @@ def set_partition(
     shuffle
     partd
     """
-    meta = df._meta._constructor_sliced([0])
     if isinstance(divisions, tuple):
         # pd.isna considers tuples to be scalars. Convert to a list.
         divisions = list(divisions)

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -456,6 +456,9 @@ def rearrange_by_divisions(
     if not duplicates:
         divisions = divisions.drop_duplicates()
     meta = df._meta._constructor_sliced([0])
+    # Ensure that we have the same index as before to avoid alignment
+    # when calculating meta dtypes later on
+    meta.index = df._meta_nonempty.index[:1]
     # Assign target output partitions to every row
     partitions = df[column].map_partitions(
         set_partitions_pre,

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1434,13 +1434,35 @@ def test_set_index_partitions_meta_dtype():
         npartitions=10,
     )
     # Disk-based shuffle doesn't use HLG layers at the moment, so we only test tasks
-    ddf_shuffled = ddf.set_index("a", shuffle="tasks")
+    ddf = ddf.set_index("a", shuffle="tasks")
     # Cull the HLG
-    dsk = ddf_shuffled.__dask_graph__()
+    dsk = ddf.__dask_graph__()
 
     for layer in dsk.layers.values():
         if isinstance(layer, dd.shuffle.SimpleShuffleLayer):
             assert layer.meta_input["_partitions"].dtype == np.int64
+
+
+def test_sort_values_partitions_meta_dtype_with_divisions():
+    with dask.config.set({"dataframe.shuffle.method": "tasks"}):
+        ddf = dd.from_pandas(
+            pd.DataFrame(
+                {
+                    "a": np.random.randint(0, 10, 100),
+                    "b": np.random.randint(0, 10, 100),
+                },
+                index=np.random.random(100),
+            ),
+            npartitions=10,
+        )
+        # Disk-based shuffle doesn't use HLG layers at the moment, so we only test tasks
+        ddf = ddf.set_index("a", shuffle="tasks").sort_values("b")
+        # Cull the HLG
+        dsk = ddf.__dask_graph__()
+
+        for layer in dsk.layers.values():
+            if isinstance(layer, dd.shuffle.SimpleShuffleLayer):
+                assert layer.meta_input["_partitions"].dtype == np.int64
 
 
 @pytest.mark.parametrize("ascending", [True, False])

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1428,6 +1428,21 @@ def test_set_index_with_series_uses_fastpath():
     assert_eq(res, expected)
 
 
+def test_set_index_partitions_meta_dtype():
+    ddf = dd.from_pandas(
+        pd.DataFrame({"a": np.random.randint(0, 10, 100)}, index=np.random.random(100)),
+        npartitions=10,
+    )
+    # Disk-based shuffle doesn't use HLG layers at the moment, so we only test tasks
+    ddf_shuffled = ddf.set_index("a", shuffle="tasks")
+    # Cull the HLG
+    dsk = ddf_shuffled.__dask_graph__()
+
+    for layer in dsk.layers.values():
+        if isinstance(layer, dd.shuffle.SimpleShuffleLayer):
+            assert layer.meta_input["_partitions"].dtype == np.int64
+
+
 @pytest.mark.parametrize("ascending", [True, False])
 @pytest.mark.parametrize("by", ["a", "b", ["a", "b"]])
 @pytest.mark.parametrize("nelem", [10, 500])


### PR DESCRIPTION
- [x] Fixes issue with `DataFrame.set_index()` that occurred in dask/distributed#8157
- [x] Closes dask/distributed#8165
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
