### PR TITLE
Avoid materializing all iterator in delayed tasks

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -4,7 +4,7 @@ import operator
 import types
 import uuid
 import warnings
-from collections.abc import Iterator, Sequence
+from collections.abc import Sequence
 from dataclasses import fields, is_dataclass, replace
 from functools import partial
 
@@ -98,8 +98,12 @@ def unpack_collections(expr):
         finalized = finalize(expr)
         return finalized._key, (finalized,)
 
-    if isinstance(expr, Iterator):
+    if type(expr) is type(iter(list())):
+        expr = list(expr)
+    elif type(expr) is type(iter(tuple())):
         expr = tuple(expr)
+    elif type(expr) is type(iter(set())):
+        expr = set(expr)
 
     typ = type(expr)
 
@@ -209,8 +213,12 @@ def to_task_dask(expr):
         dsk.update(opt(expr.__dask_graph__(), keys))
         return name, dsk
 
-    if isinstance(expr, Iterator):
+    if type(expr) is type(iter(list())):
         expr = list(expr)
+    elif type(expr) is type(iter(tuple())):
+        expr = tuple(expr)
+    elif type(expr) is type(iter(set())):
+        expr = set(expr)
     typ = type(expr)
 
     if typ in (list, tuple, set):

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -377,17 +377,19 @@ def test_lists_are_concrete():
     assert c.compute() == 20
 
 
-def test_iterators():
+@pytest.mark.parametrize("typ", [list, tuple, set])
+def test_iterators(typ):
     a = delayed(1)
     b = delayed(2)
-    c = delayed(sum)(iter([a, b]))
+    c = delayed(sum)(iter(typ([a, b])))
 
-    assert c.compute() == 3
+    x = c.compute()
+    assert x == 3
 
     def f(seq):
         return sum(seq)
 
-    c = delayed(f)(iter([a, b]))
+    c = delayed(f)(iter(typ([a, b])))
     assert c.compute() == 3
 
 


### PR DESCRIPTION
Materializing all iterators can have unexpected negative behavior. This PR limits to `list`, `tuple`, and `set` iterators. 

cc @martindurant 

- [x] Closes https://github.com/dask/dask/issues/10497
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
