### PR TITLE
Add `**kwargs` support for `pyarrow_schema_dispatch`

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -209,10 +209,10 @@ except ImportError:
 
 
 @pyarrow_schema_dispatch.register((pd.DataFrame,))
-def get_pyarrow_schema_pandas(obj):
+def get_pyarrow_schema_pandas(obj, **kwargs):
     import pyarrow as pa
 
-    return pa.Schema.from_pandas(obj)
+    return pa.Schema.from_pandas(obj, **kwargs)
 
 
 @to_pyarrow_table_dispatch.register((pd.DataFrame,))

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -6068,25 +6068,37 @@ def test_mask_where_callable():
     assert_eq(pdf.x.where(lambda d: d == 1, 2), ddf.x.where(lambda d: d == 1, 2))
 
 
-@pytest.mark.parametrize("self_destruct", [True, False])
-def test_pyarrow_conversion_dispatch(self_destruct):
+def test_pyarrow_schema_dispatch():
     from dask.dataframe.dispatch import (
-        from_pyarrow_table_dispatch,
+        pyarrow_schema_dispatch,
         to_pyarrow_table_dispatch,
     )
 
     pytest.importorskip("pyarrow")
 
-    df1 = pd.DataFrame(np.random.randn(10, 3), columns=list("abc"))
-    df1["d"] = pd.Series(["cat", "dog"] * 5, dtype="string[pyarrow]")
-    df2 = from_pyarrow_table_dispatch(
-        df1,
-        to_pyarrow_table_dispatch(df1),
-        self_destruct=self_destruct,
+    df = pd.DataFrame(np.random.randn(10, 3), columns=list("abc"))
+    df["d"] = pd.Series(["cat", "dog"] * 5, dtype="string[pyarrow]")
+    table = to_pyarrow_table_dispatch(df)
+    schema = pyarrow_schema_dispatch(df)
+
+    assert schema.equals(table.schema)
+
+
+@pytest.mark.parametrize("preserve_index", [True, False])
+def test_pyarrow_schema_dispatch_preserves_index(preserve_index):
+    from dask.dataframe.dispatch import (
+        pyarrow_schema_dispatch,
+        to_pyarrow_table_dispatch,
     )
 
-    assert type(df1) == type(df2)
-    assert_eq(df1, df2)
+    pytest.importorskip("pyarrow")
+
+    df = pd.DataFrame(np.random.randn(10, 3), columns=list("abc"))
+    df["d"] = pd.Series(["cat", "dog"] * 5, dtype="string[pyarrow]")
+    table = to_pyarrow_table_dispatch(df, preserve_index=preserve_index)
+    schema = pyarrow_schema_dispatch(df, preserve_index=preserve_index)
+
+    assert schema.equals(table.schema)
 
 
 @pytest.mark.gpu


### PR DESCRIPTION
- [x] Fixes https://github.com/dask/distributed/pull/8157#discussion_r1319807620
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

I'm not sure how to test this such that it also works for cudf. @rjzamora, would you have some pointers?