### PR TITLE
Make `preserve_index` explicit in `pyarrow_schema_dispatch`

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -209,10 +209,10 @@ except ImportError:
 
 
 @pyarrow_schema_dispatch.register((pd.DataFrame,))
-def get_pyarrow_schema_pandas(obj, **kwargs):
+def get_pyarrow_schema_pandas(obj, preserve_index=None):
     import pyarrow as pa
 
-    return pa.Schema.from_pandas(obj, **kwargs)
+    return pa.Schema.from_pandas(obj, preserve_index=preserve_index)
 
 
 @to_pyarrow_table_dispatch.register((pd.DataFrame,))

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -6101,6 +6101,27 @@ def test_pyarrow_schema_dispatch_preserves_index(preserve_index):
     assert schema.equals(table.schema)
 
 
+@pytest.mark.parametrize("self_destruct", [True, False])
+def test_pyarrow_conversion_dispatch(self_destruct):
+    from dask.dataframe.dispatch import (
+        from_pyarrow_table_dispatch,
+        to_pyarrow_table_dispatch,
+    )
+
+    pytest.importorskip("pyarrow")
+
+    df1 = pd.DataFrame(np.random.randn(10, 3), columns=list("abc"))
+    df1["d"] = pd.Series(["cat", "dog"] * 5, dtype="string[pyarrow]")
+    df2 = from_pyarrow_table_dispatch(
+        df1,
+        to_pyarrow_table_dispatch(df1),
+        self_destruct=self_destruct,
+    )
+
+    assert type(df1) == type(df2)
+    assert_eq(df1, df2)
+
+
 @pytest.mark.gpu
 def test_pyarrow_conversion_dispatch_cudf():
     # NOTE: This test can probably be removed (or simplified) once


### PR DESCRIPTION
- [x] Closes https://github.com/dask/dask/pull/10500/files#r1319881063
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
