### PR TITLE
[WIP] Fixes for dask.order - Remove change of tactical goal in single dep path

### DIFF
--- a/dask/order.py
+++ b/dask/order.py
@@ -363,8 +363,8 @@ def order(dsk, dependencies=None):
                         else:
                             inner_stack.extend(deps)
                         seen_update(deps)
-                    if not singles:
-                        continue
+                    # if not singles:
+                    continue
                     process_singles = True
                 else:
                     result[item] = i

--- a/dask/order.py
+++ b/dask/order.py
@@ -565,13 +565,13 @@ def order(dsk, dependencies=None):
                     key = partition_keys[dep]
                 else:
                     key = partition_keys[dep]
-                    if key < partition_keys[inner_stack[0]]:
-                        # Run before `inner_stack` (change tactical goal!)
-                        inner_stacks_append(inner_stack)
-                        inner_stack = [dep]
-                        inner_stack_pop = inner_stack.pop
-                        seen_add(dep)
-                        continue
+                    # if key < partition_keys[inner_stack[0]]:
+                    #     # Run before `inner_stack` (change tactical goal!)
+                    #     inner_stacks_append(inner_stack)
+                    #     inner_stack = [dep]
+                    #     inner_stack_pop = inner_stack.pop
+                    #     seen_add(dep)
+                    #     continue
                 if not num_needed[dep]:
                     # We didn't put the single dependency on the stack, but we should still
                     # run it soon, because doing so may free its parent.


### PR DESCRIPTION
This is waaaay too early for a PR but considering how complex this subject is I wanted to share intermediate progress asap.

This is specifically looking at the graph taken from https://github.com/dask/dask/issues/10384. The simplified reproducer I provided over there is part of this test and I started investigating why this is ordered poorly

![test_xarray_reduction](https://github.com/dask/dask/assets/8629629/ac57709d-2723-4eda-ad89-7806df67f93c)

## Main ordering

![test_xarray_reduction_order-age](https://github.com/dask/dask/assets/8629629/6e6b54cf-a2bd-4633-afc9-d19faace71bd)

Pressure 8

## Optimal ordering

I ordered the graph manually to what I consider optimal ordering for this case. I don't necessarily strive to reproduce this but this should serve as an orientation. This is likely not unique. Note how source nodes have a homogeneous age and how terminal/end nodes are computed more quickly.

![test_xarray_reduction_order-age-optimal](https://github.com/dask/dask/assets/8629629/dcc21d02-14c9-444b-9548-cf781eaa0441)

Pressure 6

## This PR (WIP)

As a first step, I looked into why `("b", 1, 0)` is scheduled way too late with priority 22. It should be scheduled immediately after `("a", 1, 0)` to free up `("a", 0, 0)`.

It turns out that this task is scheduled poorly due to a "change of the tactical goal" that is based on the partition_keys. Removing this entirely "fixes" this specific section of the graph and allows `("b", 1, 0)` to be scheduled much more quickly, reducing pressure from 8 to 6.

That's already nice but the resulting ordering is still far away from optimal and a little to heterogenous for my taste considering how symmetrical this problem is.

I haven't found out, yet, whether this "change of tactical goal" is a bad idea in general or whether the partition_key cost function is just bad. FWIW this specific code branch is untested. While it is _covered_ by `test_map_overlap` and `test_array_store_final_order`, removing this condition entirely does not have an impact on any asserted property. In fact, at least for `test_map_overlap`, removing this condition also reduces pressure and generates a better graph (the other graph is more difficult to analyze)

![test_xarray_reduction_order-age](https://github.com/dask/dask/assets/8629629/afb372db-26a2-45c3-b98c-9ee527938312)


cc @eriknw 