### PR TITLE
Bugfix for writing empty array to zarr

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4374,7 +4374,7 @@ def load_store_chunk(
     if lock:
         lock.acquire()
     try:
-        if x is not None:
+        if x is not None and x.size != 0:
             if is_arraylike(x):
                 out[index] = x
             else:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -49,6 +49,7 @@ from dask.array.core import (
     optimize,
     stack,
     store,
+    load_store_chunk,
 )
 from dask.array.reshape import _not_implemented_message
 from dask.array.tests.test_dispatch import EncapsulateNDArray
@@ -5346,3 +5347,28 @@ def test_to_backend():
         # Moving to a "missing" backend should raise an error
         with pytest.raises(ValueError, match="No backend dispatch registered"):
             x.to_backend("missing")
+
+
+def test_load_store_chunk():
+    actual = np.array([0, 0, 0, 0, 0, 0])
+    load_store_chunk(
+        x=np.array([1, 2, 3]),
+        out=actual,
+        index=slice(2, 5),
+        lock=False,
+        return_stored=False,
+        load_stored=False,
+    )
+    expected = np.array([0, 0, 1, 2, 3, 0])
+    assert all(actual == expected)
+    # index should not be used on empty array
+    actual = load_store_chunk(
+        x=np.array([]),
+        out=np.array([]),
+        index=2,
+        lock=False,
+        return_stored=True,
+        load_stored=False,
+    )
+    expected = np.array([])
+    assert all(actual == expected)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -45,11 +45,11 @@ from dask.array.core import (
     from_func,
     getter,
     graph_from_arraylike,
+    load_store_chunk,
     normalize_chunks,
     optimize,
     stack,
     store,
-    load_store_chunk,
 )
 from dask.array.reshape import _not_implemented_message
 from dask.array.tests.test_dispatch import EncapsulateNDArray

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4580,6 +4580,13 @@ def test_zarr_roundtrip_with_path_like():
         assert a2.chunks == a.chunks
 
 
+def test_to_zarr_accepts_empty_array_without_exception_raised():
+    pytest.importorskip("zarr")
+    with tmpdir() as d:
+        a = da.from_array(np.arange(0))
+        a.to_zarr(d)
+
+
 @pytest.mark.parametrize("compute", [False, True])
 def test_zarr_return_stored(compute):
     pytest.importorskip("zarr")


### PR DESCRIPTION
- [x] Closes #10438
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

See issue for discussion- this PR extends the checks in load_store_chunk from simply "is None" to also check size is not 0. This avoids setting with index on "out" if there is no data.
