### PR TITLE
Deprecation cycle for `admin.traceback.shorten`

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -126,7 +126,7 @@ def update(
         k = canonical_name(k, old)
 
         if isinstance(v, Mapping):
-            if k not in old or old[k] is None:
+            if k not in old or old[k] is None or not isinstance(old[k], dict):
                 old[k] = {}
             update(
                 old[k],
@@ -673,6 +673,7 @@ deprecations: dict[str, str | None] = {
     "array.rechunk-threshold": "array.rechunk.threshold",
     "dataframe.shuffle.algorithm": "dataframe.shuffle.method",
     "dataframe.shuffle-compression": "dataframe.shuffle.compression",
+    "admin.traceback.shorten.what": "admin.traceback.shorten",  # changed in 2023.9.0
 }
 
 

--- a/dask/config.py
+++ b/dask/config.py
@@ -501,6 +501,7 @@ def refresh(
     2.  Updating from the stored defaults from downstream libraries
         (see update_defaults)
     3.  Updating from yaml files and environment variables
+    4.  Automatically renaming deprecated keys (with a warning)
 
     Note that some functionality only checks configuration once at startup and
     may not change behavior, even if configuration changes.  It is recommended
@@ -518,6 +519,7 @@ def refresh(
         update(config, d, priority="old")
 
     update(config, collect(**kwargs))
+    rename(deprecations, config)
 
 
 def get(
@@ -595,26 +597,6 @@ def pop(key: str, default: Any = no_default, config: dict = config) -> Any:
             return default
 
 
-def rename(aliases: Mapping, config: dict = config) -> None:
-    """Rename old keys to new keys
-
-    This helps migrate older configuration versions over time
-    """
-    new = {}
-    for o, n in aliases.items():
-        try:
-            value = pop(o, config=config)
-        except (TypeError, IndexError, KeyError):
-            continue
-        warnings.warn(
-            f"dask config key {o!r} has been renamed to {n!r}",
-            FutureWarning,
-        )
-        new[n] = value
-
-    set(new, config=config)
-
-
 def update_defaults(
     new: Mapping, config: dict = config, defaults: list[Mapping] = defaults
 ) -> None:
@@ -662,15 +644,24 @@ def expand_environment_variables(config: Any) -> Any:
         return config
 
 
-deprecations = {
-    "fuse_ave_width": "optimization.fuse.ave-width",
-    "fuse_max_height": "optimization.fuse.max-height",
-    "fuse_max_width": "optimization.fuse.max-width",
-    "fuse_subgraphs": "optimization.fuse.subgraphs",
-    "fuse_rename_keys": "optimization.fuse.rename-keys",
-    "fuse_max_depth_new_edges": "optimization.fuse.max-depth-new-edges",
+#: Mapping of {deprecated key: new key} for renamed keys, or {deprecated key: None} for
+#: removed keys. All deprecated keys must use '-' instead of '_'.
+#: This is used in three places:
+#: 1. In refresh(), which calls rename() to rename and warn upon loading
+#:    from ~/.config/dask.yaml, DASK_ env variables, etc.
+#: 2. in distributed/config.py and equivalent modules, where we perform additional
+#:    distributed-specific renames for the yaml/env config and enrich this dict
+#: 3. from individual calls to dask.config.set(), which internally invoke
+#     check_deprecations()
+deprecations: dict[str, str | None] = {
+    "fuse-ave-width": "optimization.fuse.ave-width",
+    "fuse-max-height": "optimization.fuse.max-height",
+    "fuse-max-width": "optimization.fuse.max-width",
+    "fuse-subgraphs": "optimization.fuse.subgraphs",
+    "fuse-rename-keys": "optimization.fuse.rename-keys",
+    "fuse-max-depth-new-edges": "optimization.fuse.max-depth-new-edges",
     # See https://github.com/dask/distributed/pull/4916
-    "ucx.cuda_copy": "distributed.ucx.cuda_copy",
+    "ucx.cuda-copy": "distributed.ucx.cuda_copy",
     "ucx.tcp": "distributed.ucx.tcp",
     "ucx.nvlink": "distributed.ucx.nvlink",
     "ucx.infiniband": "distributed.ucx.infiniband",
@@ -685,7 +676,31 @@ deprecations = {
 }
 
 
-def check_deprecations(key: str, deprecations: dict = deprecations) -> str:
+def rename(
+    deprecations: Mapping[str, str | None] = deprecations, config: dict = config
+) -> None:
+    """Rename old keys to new keys
+
+    This helps migrate older configuration versions over time
+
+    See Also
+    --------
+    check_deprecations
+    """
+    for key in deprecations:
+        try:
+            value = pop(key, config=config)
+        except (TypeError, IndexError, KeyError):
+            continue
+        key = canonical_name(key, config=config)
+        new = check_deprecations(key, deprecations)
+        if new:
+            set({new: value}, config=config)
+
+
+def check_deprecations(
+    key: str, deprecations: Mapping[str, str | None] = deprecations
+) -> str:
     """Check if the provided value has been renamed or removed
 
     Parameters
@@ -699,12 +714,12 @@ def check_deprecations(key: str, deprecations: dict = deprecations) -> str:
     --------
     >>> deprecations = {"old_key": "new_key", "invalid": None}
     >>> check_deprecations("old_key", deprecations=deprecations)  # doctest: +SKIP
-    UserWarning: Configuration key "old_key" has been deprecated. Please use "new_key" instead.
+    FutureWarning: Dask configuration key 'old_key' has been deprecated; please use "new_key" instead
 
     >>> check_deprecations("invalid", deprecations=deprecations)
     Traceback (most recent call last):
         ...
-    ValueError: Configuration value "invalid" has been removed
+    ValueError: Dask configuration key 'invalid' has been removed
 
     >>> check_deprecations("another_key", deprecations=deprecations)
     'another_key'
@@ -714,17 +729,23 @@ def check_deprecations(key: str, deprecations: dict = deprecations) -> str:
     new: str
         The proper key, whether the original (if no deprecation) or the aliased
         value
+
+    See Also
+    --------
+    rename
     """
-    if key in deprecations:
-        new = deprecations[key]
+    old = key.replace("_", "-")
+    if old in deprecations:
+        new = deprecations[old]
         if new:
             warnings.warn(
-                'Configuration key "{}" has been deprecated. '
-                'Please use "{}" instead'.format(key, new)
+                f"Dask configuration key {key!r} has been deprecated; "
+                f"please use {new!r} instead",
+                FutureWarning,
             )
             return new
         else:
-            raise ValueError(f'Configuration value "{key}" has been removed')
+            raise ValueError(f"Dask configuration key {key!r} has been removed")
     else:
         return key
 

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -91,6 +91,20 @@ def test_update_defaults():
     assert current == {"a": 0, "b": {"c": 0, "d": 3}, "extra": 0, "new-extra": 0}
 
 
+def test_update_list_to_dict():
+    a = {"x": {"y": 1, "z": 2}}
+    b = {"x": [1, 2], "w": 3}
+    update(b, a)
+    assert b == {"x": {"y": 1, "z": 2}, "w": 3}
+
+
+def test_update_dict_to_list():
+    a = {"x": [1, 2]}
+    b = {"x": {"y": 1, "z": 2}, "w": 3}
+    update(b, a)
+    assert b == {"x": [1, 2], "w": 3}
+
+
 def test_merge():
     a = {"x": 1, "y": {"a": 1}}
     b = {"x": 2, "z": 3, "y": {"b": 2}}
@@ -565,16 +579,29 @@ def test_rename():
         "x.y": "foo.y",
         "a.b": "ab",
         "not-found": "not.found",
+        "super.old": "super",
     }
-    config = {"foo_bar": 1, "x": {"y": 2, "z": 3}, "a": {"b": None}}
+    config = {
+        "foo_bar": 1,
+        "x": {"y": 2, "z": 3},
+        "a": {"b": None},
+        "super": {"old": 4},
+    }
     with pytest.warns(FutureWarning) as w:
         rename(aliases, config=config)
     assert [str(wi.message) for wi in w.list] == [
         "Dask configuration key 'foo-bar' has been deprecated; please use 'foo.bar' instead",
         "Dask configuration key 'x.y' has been deprecated; please use 'foo.y' instead",
         "Dask configuration key 'a.b' has been deprecated; please use 'ab' instead",
+        "Dask configuration key 'super.old' has been deprecated; please use 'super' instead",
     ]
-    assert config == {"foo": {"bar": 1, "y": 2}, "x": {"z": 3}, "a": {}, "ab": None}
+    assert config == {
+        "foo": {"bar": 1, "y": 2},
+        "x": {"z": 3},
+        "a": {},
+        "ab": None,
+        "super": 4,
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Follow-up to #10456
- Closes #10507
- Blocked by and incorporates #10499

Actual change in the third commit