### PR TITLE
Revert changes to `config.get(..., override_with=None)`

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -526,7 +526,7 @@ def get(
     key: str,
     default: Any = no_default,
     config: dict = config,
-    override_with: Any = no_default,
+    override_with: Any = None,
 ) -> Any:
     """
     Get elements from global config
@@ -558,7 +558,7 @@ def get(
     --------
     dask.config.set
     """
-    if override_with is not no_default:
+    if override_with is not None:
         return override_with
     keys = key.split(".")
     result = config

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -642,8 +642,9 @@ def test_deprecations_on_yaml(tmp_path, key):
 
 def test_get_override_with():
     with dask.config.set({"foo": "bar"}):
-        # If override_with is omitted, get the config key
+        # If override_with is None get the config key
         assert dask.config.get("foo") == "bar"
+        assert dask.config.get("foo", override_with=None) == "bar"
 
         # Otherwise pass the default straight through
         assert dask.config.get("foo", override_with="baz") == "baz"


### PR DESCRIPTION
Reintroduce support for explicit None for parameter.
- Partially reverts #10499
- Closes #10519
