### PR TITLE
Run tests with ``crick=0.0.4`` release

### DIFF
--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -48,9 +48,6 @@ dependencies:
   - httpretty
   - aiohttp
   - s3fs
-  # Need a new `crick` release with support for `numpy=1.24+`
-  # https://github.com/dask/crick/issues/25
-  # - crick
   - cytoolz
   - distributed
   - ipython
@@ -76,3 +73,4 @@ dependencies:
   - pip
   - pip:
     - git+https://github.com/dask/distributed
+    - crick  # Install with conda once the `crick>=0.0.4` is on conda-forge


### PR DESCRIPTION
There's a new `crick=0.0.4` release out (on PyPI, not yet on conda-forge). This release makes sure we test against this latest release in at least one of our CI builds (Python 3.11). The other Python versions are still testing against `crick=0.0.3` from conda-forge for now and will automatically start pulling in the new version once it's available on conda-forge. 