### PR TITLE
Match `pandas` reverting `apply` deprecation

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -4417,15 +4417,6 @@ Dask Name: {name}, {layers}""".format(
                     M.apply, self._meta_nonempty, func, args=args, udf=True, **kwds
                 )
             warnings.warn(meta_warning(meta))
-        elif PANDAS_GE_210:
-            test_meta = make_meta(meta)
-            if is_dataframe_like(test_meta):
-                warnings.warn(
-                    "Returning a DataFrame from Series.apply when the supplied function "
-                    "returns a Series is deprecated and will be removed in a future version.",
-                    FutureWarning,
-                    stacklevel=2,
-                )
 
         return map_partitions(methods.apply, self, func, args=args, meta=meta, **kwds)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3219,22 +3219,13 @@ def test_apply():
         warnings.simplefilter("ignore", UserWarning)
         assert_eq(ddf.apply(lambda xy: xy, axis=1), df.apply(lambda xy: xy, axis=1))
 
-    warning = FutureWarning if PANDAS_GE_210 else None
     # specify meta
     func = lambda x: pd.Series([x, x])
-    with pytest.warns(warning, match="Returning a DataFrame"):
-        ddf_result = ddf.x.apply(func, meta=[(0, int), (1, int)])
-    with pytest.warns(warning, match="Returning a DataFrame"):
-        pdf_result = df.x.apply(func)
-    assert_eq(ddf_result, pdf_result)
+    assert_eq(ddf.x.apply(func, meta=[(0, int), (1, int)]), df.x.apply(func))
     # inference
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
-        with pytest.warns(warning, match="Returning a DataFrame"):
-            ddf_result = ddf.x.apply(func)
-        with pytest.warns(warning, match="Returning a DataFrame"):
-            pdf_result = df.x.apply(func)
-        assert_eq(ddf_result, pdf_result)
+        assert_eq(ddf.x.apply(func), df.x.apply(func))
 
     # axis=0
     with pytest.raises(NotImplementedError):
@@ -3689,16 +3680,13 @@ def test_apply_infer_columns():
     def return_df2(x):
         return pd.Series([x * 2, x * 3], index=["x2", "x3"])
 
-    warning = FutureWarning if PANDAS_GE_210 else None
     # Series to completely different DataFrame
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
-        with pytest.warns(warning, match="Returning a DataFrame"):
-            result = ddf.x.apply(return_df2)
+        result = ddf.x.apply(return_df2)
     assert isinstance(result, dd.DataFrame)
     tm.assert_index_equal(result.columns, pd.Index(["x2", "x3"]))
-    with pytest.warns(warning, match="Returning a DataFrame"):
-        assert_eq(result, df.x.apply(return_df2))
+    assert_eq(result, df.x.apply(return_df2))
 
     # Series to Series
     with warnings.catch_warnings():

--- a/dask/dataframe/tests/test_merge_column_and_index.py
+++ b/dask/dataframe/tests/test_merge_column_and_index.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 import dask.dataframe as dd
-from dask.dataframe._compat import PANDAS_GE_210, PANDAS_GE_211
+from dask.dataframe._compat import PANDAS_GE_210
 from dask.dataframe.utils import assert_eq
 
 
@@ -230,7 +230,7 @@ def test_merge_known_to_double_bcast_left(
     result.head(1)
 
 
-@pytest.mark.skipif(PANDAS_GE_210 and not PANDAS_GE_211, reason="breaks on 2.1.0")
+@pytest.mark.skipif(PANDAS_GE_210, reason="breaks with pandas=2.1.0+")
 @pytest.mark.parametrize("repartition", [None, 4])
 def test_merge_column_with_nulls(repartition):
     # See: https://github.com/dask/dask/issues/7558

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -14,7 +14,6 @@ from dask.dataframe._compat import (
     PANDAS_GE_150,
     PANDAS_GE_200,
     PANDAS_GE_210,
-    PANDAS_GE_211,
     tm,
 )
 from dask.dataframe.core import _Frame
@@ -1365,7 +1364,7 @@ def test_merge_by_index_patterns(how, shuffle_method):
             )
 
 
-@pytest.mark.skipif(PANDAS_GE_210 and not PANDAS_GE_211, reason="breaks on 2.1.0")
+@pytest.mark.skipif(PANDAS_GE_210, reason="breaks with pandas=2.1.0+")
 @pytest.mark.slow
 @pytest.mark.parametrize("how", ["inner", "outer", "left", "right"])
 def test_join_by_index_patterns(how, shuffle_method):


### PR DESCRIPTION
`pandas` recently reverted this deprecations (xref https://github.com/pandas-dev/pandas/pull/55189). We do the same thing here to match behavior with `pandas` and fix test that are currently failing in CI

cc @phofl 