### PR TITLE
Add ~/.dask to list of directories to search for config

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -28,6 +28,7 @@ def _get_paths():
         os.path.join(sys.prefix, "etc", "dask"),
         *[os.path.join(prefix, "etc", "dask") for prefix in site.PREFIXES],
         os.path.join(os.path.expanduser("~"), ".config", "dask"),
+        os.path.join(os.path.expanduser("~"), ".dask"),
     ]
     if "DASK_CONFIG" in os.environ:
         paths.append(os.environ["DASK_CONFIG"])


### PR DESCRIPTION
I've run into a class of users for which `~/.config` is locked down. Falling back to `~/.dask` seems harmless.