### PR TITLE
scikit-image v0.22.0 merged numpy v2 support [test-upstream]

### DIFF
--- a/dask/array/tests/test_image.py
+++ b/dask/array/tests/test_image.py
@@ -5,13 +5,6 @@ from contextlib import contextmanager
 
 import pytest
 
-from dask.array.numpy_compat import _numpy_200
-
-if _numpy_200:
-    # `import skimage` fails with `numpy=2`
-    # xref https://github.com/scikit-image/scikit-image/pull/7118
-    pytest.skip("skimage doesn't yet support numpy=2", allow_module_level=True)
-
 pytest.importorskip("skimage")
 import numpy as np
 from skimage.io import imsave


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
