### PR TITLE
Move ``register_assert_rewrite`` earlier in ``conftest`` to fix warnings

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import pytest
 
+pytest.register_assert_rewrite(
+    "dask.array.utils", "dask.dataframe.utils", "dask.bag.utils"
+)
+
 import dask
 
 # The doctests in these files fail due to either:
@@ -85,11 +89,6 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip_with_pyarrow_strings)
         if "xfail_with_pyarrow_strings" in item.keywords:
             item.add_marker(xfail_with_pyarrow_strings)
-
-
-pytest.register_assert_rewrite(
-    "dask.array.utils", "dask.dataframe.utils", "dask.bag.utils"
-)
 
 
 @pytest.fixture(params=["disk", "tasks"])


### PR DESCRIPTION
I get the following warnings when running pytest:
```
conftest.py:90
  /home/graingert/projects/dask/conftest.py:90: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: dask.dataframe.utils
    pytest.register_assert_rewrite(

conftest.py:90
  /home/graingert/projects/dask/conftest.py:90: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: dask.bag.utils
    pytest.register_assert_rewrite(

conftest.py:90
  /home/graingert/projects/dask/conftest.py:90: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: dask.array.utils
    pytest.register_assert_rewrite(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

moving the register_assert_rewrite earlier fixes these warnings

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
