### PR TITLE
switch to PyTables HEAD [test-upstream]

### DIFF
--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -31,7 +31,7 @@ if [[ ${UPSTREAM_DEV} ]]; then
         git+https://github.com/dask/distributed \
         git+https://github.com/dask/fastparquet \
         git+https://github.com/zarr-developers/zarr-python \
-        git+https://github.com/PyTables/PyTables@ab565af10250922f2778204fd62b42ee12087d12  # numpy 2 support
+        git+https://github.com/PyTables/PyTables  # numpy 2 support
 
     # FIXME https://github.com/mamba-org/mamba/issues/412
     # mamba uninstall --force ...


### PR DESCRIPTION
https://github.com/PyTables/PyTables/pull/1068 got merged so now PyTables HEAD supports numpy v2

- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
