### PR TITLE
Use the inferred filesystem/region by default when ``filesystem='arrow'``

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -454,9 +454,13 @@ class ArrowDatasetEngine(Engine):
                 urlpath = [stringify_path(urlpath)]
 
             if fs in ("arrow", "pyarrow"):
-                fs = type(pa_fs.FileSystem.from_uri(urlpath[0])[0])(
-                    **(storage_options or {})
-                )
+                fs = pa_fs.FileSystem.from_uri(urlpath[0])[0]
+                if storage_options:
+                    # Use inferred region as the deafult
+                    region = (
+                        {} if "region" in storage_options else {"region": fs.region}
+                    )
+                    fs = type(fs)(**region, **storage_options)
 
             fsspec_fs = ArrowFSWrapper(fs)
             if urlpath[0].startswith("C:") and isinstance(fs, pa_fs.LocalFileSystem):

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4740,6 +4740,17 @@ def test_pyarrow_filesystem_option(tmp_path, fs):
     assert_eq(ddf, df)
 
 
+@pytest.mark.slow
+def test_pyarrow_filesystem_option_real_data():
+    # See: https://github.com/dask/dask/pull/10590
+    dd.read_parquet(
+        "s3://coiled-data/uber/part.0.parquet",
+        filesystem="pyarrow",
+        storage_options={"anonymous": True},
+        blocksize=None,
+    )
+
+
 @PYARROW_MARK
 def test_fsspec_to_parquet_filesystem_option(tmp_path):
     from fsspec import get_filesystem_class

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4740,6 +4740,7 @@ def test_pyarrow_filesystem_option(tmp_path, fs):
     assert_eq(ddf, df)
 
 
+@PYARROW_MARK
 @pytest.mark.slow
 def test_pyarrow_filesystem_option_real_data():
     # See: https://github.com/dask/dask/pull/10590


### PR DESCRIPTION
- [x] Closes https://github.com/dask/dask/issues/10585
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
