### PR TITLE
Avoid splitting parquet files to row groups as aggressively

### DIFF
--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -315,7 +315,7 @@ def read_parquet(
         set the default value of ``split_row_groups`` (using row-group metadata
         from a single file), and will be ignored if ``split_row_groups`` is not
         set to 'infer' or 'adaptive'. Default may be engine-dependant, but is
-        128 MiB for the 'pyarrow' and 'fastparquet' engines.
+        256 MiB for the 'pyarrow' and 'fastparquet' engines.
     aggregate_files : bool or str, default None
         WARNING: Passing a string argument to ``aggregate_files`` will result
         in experimental behavior. This behavior may change in the future.

--- a/dask/dataframe/io/parquet/utils.py
+++ b/dask/dataframe/io/parquet/utils.py
@@ -174,7 +174,7 @@ class Engine:
 
     @classmethod
     def default_blocksize(cls):
-        return "128 MiB"
+        return "256 MiB"
 
     @classmethod
     def read_partition(
@@ -907,7 +907,7 @@ def _infer_split_row_groups(row_group_sizes, blocksize, aggregate_files=False):
     # Use blocksize to choose an appropriate split_row_groups value
     if row_group_sizes:
         blocksize = parse_bytes(blocksize)
-        if aggregate_files or np.sum(row_group_sizes) > blocksize:
+        if aggregate_files or np.sum(row_group_sizes) > 2 * blocksize:
             # If we are aggregating files, or the file is larger
             # than `blocksize`, set split_row_groups to "adaptive"
             return "adaptive"

--- a/docs/source/dataframe-parquet.rst
+++ b/docs/source/dataframe-parquet.rst
@@ -110,7 +110,7 @@ Partition Size
 By default, Dask will use metadata from the first parquet file in the dataset
 to infer whether or not it is safe load each file individually as a partition
 in the Dask dataframe. If the uncompressed byte size of the parquet data
-exceeds ``blocksize`` (which is 128 MiB by default), then each partition will
+exceeds ``blocksize`` (which is 256 MiB by default), then each partition will
 correspond to a range of parquet row-groups instead of the entire file.
 
 For best performance, use files that can be individually mapped to good


### PR DESCRIPTION
This makes it less likely that we'll split up parquet files.  It does so in two changes:

1.  Change the default blocksize from 128 MIB to 256 MiB
2.  Only trigger this check if we double the optimal blocksize (512 MiB)

    (but then presumably we'll target 256)

Additionally, for follow-up work it would be excellent to make this sensitive to only reading certain columns.  Right now I think we do this even if we read only a single column.

There's plenty more that can be done here, but hopefully this is easy to agree on as a first step.