### PR TITLE
Remove double slash in ``fsspec`` tests

### DIFF
--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -165,7 +165,7 @@ def test_files(dir_server):
 
 def test_open_glob(dir_server):
     root = "http://localhost:8999/"
-    fs = open_files(root + "/*")
+    fs = open_files(root + "*")
     assert fs[0].path == "http://localhost:8999/a"
     assert fs[1].path == "http://localhost:8999/b"
 


### PR DESCRIPTION
Remove `//` (invalid path separator) in the `fsspec` tests to avoid an error once https://github.com/fsspec/filesystem_spec/pull/1382 is merged.