### PR TITLE
Generalize computation of `NEW_*_VER` in GPU CI updating workflow

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -42,8 +42,8 @@ jobs:
         run: |
           echo RAPIDS_VER=${{ steps.rapids_current.outputs.RAPIDS_VER_0 }} >> $GITHUB_ENV
           echo UCX_PY_VER=$(curl -sL https://version.gpuci.io/rapids/${{ steps.rapids_current.outputs.RAPIDS_VER_0 }}) >> $GITHUB_ENV
-          echo NEW_RAPIDS_VER=${FULL_RAPIDS_VER::-4} >> $GITHUB_ENV
-          echo NEW_UCX_PY_VER=${FULL_UCX_PY_VER::-4} >> $GITHUB_ENV
+          echo NEW_RAPIDS_VER=$(echo $FULL_RAPIDS_VER | cut -d'.' -f1,2) >> $GITHUB_ENV
+          echo NEW_UCX_PY_VER=$(echo $FULL_UCX_PY_VER | cut -d'.' -f1,2) >> $GITHUB_ENV
 
       - name: Update RAPIDS version
         uses: jacobtomlinson/gha-find-replace@v3


### PR DESCRIPTION
This PR fixes some flimsy logic in the GPU CI updating workflow that broke with [recent changes to RAPIDS nightly versions](https://github.com/rapidsai/rmm/pull/1347).

- [ ] Closes #10609
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
