### PR TITLE
Handle `split_out=None` deprecation warning to `drop_duplicates`

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -961,6 +961,13 @@ Dask Name: {name}, {layers}"""
         # Check if we should use a shuffle-based algorithm,
         # which is typically faster when we are not reducing
         # to a small number of partitions
+        if split_out is None:
+            warnings.warn(
+                "split_out=None is deprecated, please use a positive integer, "
+                "or allow the default of 1",
+                category=FutureWarning,
+            )
+            split_out = 1
         shuffle = _determine_split_out_shuffle(shuffle, split_out)
         if shuffle:
             return self._drop_duplicates_shuffle(


### PR DESCRIPTION
Looks like we didn't add handling for `split_out=None` with #10542, causing us to get an error like:

```python-traceback
shuffle = None, split_out = None

    def _determine_split_out_shuffle(shuffle, split_out):
        """Determine the default shuffle behavior based on split_out"""
        if shuffle is None:
>           if split_out > 1:
E           TypeError: '>' not supported between instances of 'NoneType' and 'int'

/datasets/charlesb/micromamba/envs/dask-sql-py39/lib/python3.9/site-packages/dask/dataframe/core.py:202: TypeError
```

This PR adds a warning for the deprecated use and falls back to the default of `split_out=1`

cc @rjzamora

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
