### PR TITLE
Avoid warning for fragmented DataFrame

### DIFF
--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -6,6 +6,7 @@ from functools import partial
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_extension_array_dtype
+from pandas.errors import PerformanceWarning
 from tlz import partition
 
 from dask.dataframe._compat import (
@@ -353,8 +354,14 @@ def assign(df, *pairs):
     pairs = dict(partition(2, pairs))
     deep = bool(set(pairs) & set(df.columns)) and not PANDAS_GE_140
     df = df.copy(deep=bool(deep))
-    for name, val in pairs.items():
-        df[name] = val
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="DataFrames highly fragmented *",
+            category=PerformanceWarning,
+        )
+        for name, val in pairs.items():
+            df[name] = val
     return df
 
 

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -357,7 +357,7 @@ def assign(df, *pairs):
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
-            message="DataFrames highly fragmented *",
+            message="DataFrame is highly fragmented *",
             category=PerformanceWarning,
         )
         for name, val in pairs.items():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -5724,6 +5724,15 @@ def test_assign_na_float_columns():
     assert df.compute()["new_col"].dtypes == "Float64"
 
 
+def test_assign_no_warning_fragmented():
+    df = pd.DataFrame({"a": [1, 2, 3, 4, 5] * 10})
+    df = dd.from_pandas(df, npartitions=50)
+    with warnings.catch_warnings(record=True) as w:
+        for i in range(105):
+            df[str(i)] = 5
+        assert len(w) == 0
+
+
 def test_dot():
     s1 = pd.Series([1, 2, 3, 4])
     s2 = pd.Series([4, 5, 6, 6])


### PR DESCRIPTION
- [x] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

This is not really helpful for Dask users and impact of this warning is questionable anyway