### PR TITLE
Add warning for ``pyarrow<14.0.1`` usage

### DIFF
--- a/dask/dataframe/_pyarrow_compat.py
+++ b/dask/dataframe/_pyarrow_compat.py
@@ -1,11 +1,31 @@
 from __future__ import annotations
 
 import copyreg
+import warnings
 
 import pandas as pd
+from packaging.version import Version
 
 try:
     import pyarrow as pa
+
+    pa_version = pa.__version__
+    if Version(pa_version) < Version("14.0.1"):
+        try:
+            import pyarrow_hotfix  # noqa: F401
+
+            warnings.warn(
+                "Minimal version of pyarrow will soon be increased to 14.0.1. "
+                f"You are using {pa_version}. Please consider upgrading.",
+                FutureWarning,
+            )
+        except ImportError:
+            warnings.warn(
+                f"You are using pyarrow version {pa_version} which is "
+                "known to be insecure. See https://www.cve.org/CVERecord?id=CVE-2023-47248 "
+                "for further details. Please upgrade to pyarrow>=14.0.1 "
+                "or install pyarrow-hotfix to patch your current version."
+            )
 except ImportError:
     pa = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ filterwarnings = [
     'ignore:Passing a BlockManager to DataFrame is deprecated and will raise in a future version. Use public APIs instead:DeprecationWarning',  # https://github.com/apache/arrow/issues/35081
     'ignore:The previous implementation of stack is deprecated and will be removed in a future version of pandas\.:FutureWarning',
     "ignore:Minimal version of pyarrow will soon be increased to 14.0.1",
-    "ignore:You are using pyarrow version (\d+\.){2}\d which is known to be insecure",
+    "ignore:pyarrow-hotfix",
 ]
 xfail_strict = true
 # pytest-timeout settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ filterwarnings = [
     'ignore:Passing a BlockManager to DataFrame is deprecated and will raise in a future version. Use public APIs instead:DeprecationWarning',  # https://github.com/apache/arrow/issues/35081
     'ignore:The previous implementation of stack is deprecated and will be removed in a future version of pandas\.:FutureWarning',
     "ignore:Minimal version of pyarrow will soon be increased to 14.0.1",
-    "ignore:pyarrow-hotfix",
+    "ignore:You are using pyarrow version .* pyarrow-hotfix",
 ]
 xfail_strict = true
 # pytest-timeout settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ filterwarnings = [
     'ignore:Passing a BlockManager to DataFrame is deprecated and will raise in a future version. Use public APIs instead:DeprecationWarning',  # https://github.com/apache/arrow/issues/35081
     'ignore:The previous implementation of stack is deprecated and will be removed in a future version of pandas\.:FutureWarning',
     "ignore:Minimal version of pyarrow will soon be increased to 14.0.1",
+    "ignore:You are using pyarrow version (\d+\.){2}\d which is known to be insecure",
 ]
 xfail_strict = true
 # pytest-timeout settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,7 @@ filterwarnings = [
     'ignore:DataFrameGroupBy\.apply operated on the grouping columns\. This behavior is deprecated, and in a future version of pandas the grouping columns will be excluded from the operation\. Either pass `include_groups=False` to exclude the groupings or explicitly select the grouping columns after groupby to silence this warning\.:FutureWarning',
     'ignore:Passing a BlockManager to DataFrame is deprecated and will raise in a future version. Use public APIs instead:DeprecationWarning',  # https://github.com/apache/arrow/issues/35081
     'ignore:The previous implementation of stack is deprecated and will be removed in a future version of pandas\.:FutureWarning',
-    "ignore:"Minimal version of pyarrow will soon be increased to 14.0.1",
+    "ignore:Minimal version of pyarrow will soon be increased to 14.0.1",
 ]
 xfail_strict = true
 # pytest-timeout settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ delayed = []
 complete = [
     "dask[array,dataframe,distributed,diagnostics]",
     "pyarrow >= 7.0",
+    # Can be removed once minimal pyarrow version is >14.0.1
+    # https://lists.apache.org/thread/yhy7tdfjf9hrl9vfrtzo8p2cyjq87v7n
+    "pyarrow_hotfix",
     "lz4 >= 4.3.2",
 ]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ filterwarnings = [
     'ignore:DataFrameGroupBy\.apply operated on the grouping columns\. This behavior is deprecated, and in a future version of pandas the grouping columns will be excluded from the operation\. Either pass `include_groups=False` to exclude the groupings or explicitly select the grouping columns after groupby to silence this warning\.:FutureWarning',
     'ignore:Passing a BlockManager to DataFrame is deprecated and will raise in a future version. Use public APIs instead:DeprecationWarning',  # https://github.com/apache/arrow/issues/35081
     'ignore:The previous implementation of stack is deprecated and will be removed in a future version of pandas\.:FutureWarning',
+    "ignore:"Minimal version of pyarrow will soon be increased to 14.0.1",
 ]
 xfail_strict = true
 # pytest-timeout settings


### PR DESCRIPTION
Pyarrow has a vulnerability to arbitrary code execution embedded in parquet, feather or arrow IPC. Dask users are potentially affected by this through our parquet reader.

The hotfix package raises if the read file has the _potential_ to be harmful which is not ideal but I believe this is still the best approach for most users.
We can install this package whenever somebody installs `dask[complete]` (we should do the same for our conda package) and raise appropriate warnings.
Increasing the minimal version to 14.0.1 was also brought up in another context for P2P shuffling so going through this deprecation cycle is beneficial for us either way.

Context
-  https://lists.apache.org/thread/yhy7tdfjf9hrl9vfrtzo8p2cyjq87v7n
- https://www.cve.org/CVERecord?id=CVE-2023-47248