### PR TITLE
Bump minimum click to >=8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ requires-python = ">=3.9"
 dependencies = [
     # NOTE: These are tested in `continuous_integration/test_imports.sh` If
     # you modify these, make sure to change the corresponding line there.
-    "click >= 8.0",
+    "click >= 8.1",
     "cloudpickle >= 1.5.0",
     "fsspec >= 2021.09.0",
     "packaging >= 20.0",


### PR DESCRIPTION
In a Dask subproject, I've been running into an issue with registering commands via the `dask_cli` entrypoint if that command uses a `click.Group` on versions less than `click==8.1`.

When running the `dask` CLI I see a warning like `AttributeError: 'function' object has no attribute 'command'` and the subcommand doesn't get registered.

It looks like this was fixed in `click>=8.1`. How do folks feel about bumping the minimum version?