### PR TITLE
Fix bug in map_overlap when after creates an empty partition

### DIFF
--- a/dask/dataframe/rolling.py
+++ b/dask/dataframe/rolling.py
@@ -89,6 +89,8 @@ def overlap_chunk(func, before, after, *args, **kwargs):
         after = next_part_length
     if after and expansion:
         after *= expansion
+    if after == 0:
+        return out.iloc[before:None]
     return out.iloc[before:-after]
 
 
@@ -342,7 +344,7 @@ def _get_nexts_partitions(df, after):
         nexts = []
         for i in range(1, df.npartitions):
             key = (name_b, i)
-            dsk[key] = (_head_timedelta, (df_name, i - 0), (df_name, i), after)
+            dsk[key] = (_head_timedelta, (df_name, i - 1), (df_name, i), after)
             nexts.append(key)
         nexts.append(None)
     else:

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -248,6 +248,20 @@ def test_map_overlap_provide_meta():
     assert_eq(res, sol)
 
 
+def test_map_overlap_empty_partition_after():
+    def func(x):
+        x = x + x.sum()
+        return x
+
+    idx = pd.date_range("2020-01-01", periods=5, freq="D")
+    pdf = pd.DataFrame(1, index=idx, columns=["a"])
+    df = dd.from_pandas(pdf, npartitions=2)
+
+    result = df.map_overlap(func, before=0, after="1D")
+    expected = pd.DataFrame([4, 4, 4, 3, 3], index=idx, columns=["a"])
+    assert_eq(result, expected)
+
+
 def mad(x):
     return np.fabs(x - x.mean()).mean()
 


### PR DESCRIPTION
Found in dask-expr development
