### PR TITLE
Avoid substituting keys that occur multiple times

### DIFF
--- a/dask/optimization.py
+++ b/dask/optimization.py
@@ -571,7 +571,10 @@ def fuse(
     if dependencies is None:
         deps = {k: get_dependencies(dsk, k, as_list=True) for k in dsk}
     else:
-        deps = dict(dependencies)
+        deps = {
+            k: v if isinstance(v, list) else get_dependencies(dsk, k, as_list=True)
+            for k, v in dependencies.items()
+        }
 
     rdeps = {}
     for k, vals in deps.items():


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/10645

I haven't run any widespread tests, yet. However, for the cases that are affected, this triggers the computation of a task twice and apparently also prohibits some kind of numpy optimization as reported in #10645

The graph topology here doesn't strike me as rare or very special

![image](https://github.com/dask/dask/assets/8629629/cbb932af-d41b-4ecd-8d6d-0b962e96039f)

so the `add` in this graph is basically fused into a fused into a `matmul-transpose` blob / subgraphcallable that accepts two inputs that are identical. I would argue that it is a bug of blockwise_fusion that generates such a blob in the first place since by rewriting that subgraph callable it would be possible to accept just a single dependency, restoring this fusion again.

I'm not very familiar with the blockwise fusion code and was able to find this first.


With this PR the above graph optimizes to 
![image](https://github.com/dask/dask/assets/8629629/dd841811-b02c-4089-9e7c-8d7982c3fe55)

This change effectively stops fusing because it detects this situation. If the blockwise fusion bug is fixed, it would fuse into one task (again) but without recomputing the intermediate result twice


cc @rjzamora 