### PR TITLE
Fix 'tokenize' for pd.DateOffset

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -1200,7 +1200,7 @@ def register_pandas():
 
     @normalize_token.register(pd.offsets.BaseOffset)
     def normalize_offset(offset):
-        return [offset.n, offset.name]
+        return offset.freqstr
 
 
 @normalize_token.register_lazy("numpy")

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -366,6 +366,9 @@ def test_tokenize_offset():
         pd.offsets.MonthBegin(2),
         pd.offsets.Day(1),
         pd.offsets.BQuarterEnd(2),
+        pd.DateOffset(years=1),
+        pd.DateOffset(months=7),
+        pd.DateOffset(days=10),
     ]:
         assert tokenize(offset) == tokenize(offset)
 


### PR DESCRIPTION
The [`normalize_token` function recently added of `pd.offsets.BaseOffset`](https://github.com/dask/dask/pull/10643) is broken for some values of pandas offsets, in particular if creating them directly via calls like `pd.DateOffset(days=10)`, since these instances just raise a `NotImplementedError` when accessing `.name`.

This fixes this issue.

- [X] Tests added / passed
- [X] Passes `pre-commit run --all-files`
