### PR TITLE
Ensure ``is_monotonic_*`` returns Python ``bool``

### DIFF
--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -484,7 +484,7 @@ def assign_index(df, ind):
     return df
 
 
-def _monotonic_chunk(x, prop):
+def _monotonic_chunk(x: pd.DataFrame, prop: str) -> pd.DataFrame:
     if x.empty:
         # if input is empty, return empty df for chunk
         data = None
@@ -494,7 +494,7 @@ def _monotonic_chunk(x, prop):
     return pd.DataFrame(data=data, columns=["monotonic", "first", "last"])
 
 
-def _monotonic_combine(concatenated, prop):
+def _monotonic_combine(concatenated: pd.DataFrame, prop: str) -> pd.DataFrame:
     if concatenated.empty:
         data = None
     else:
@@ -504,9 +504,9 @@ def _monotonic_combine(concatenated, prop):
     return pd.DataFrame(data, columns=["monotonic", "first", "last"])
 
 
-def _monotonic_aggregate(concatenated, prop):
+def _monotonic_aggregate(concatenated: pd.DataFrame, prop: str) -> bool:
     s = pd.Series(concatenated[["first", "last"]].to_numpy().ravel())
-    return concatenated["monotonic"].all() and getattr(s, prop)
+    return bool(concatenated["monotonic"].all() and getattr(s, prop))
 
 
 monotonic_increasing_chunk = partial(_monotonic_chunk, prop="is_monotonic_increasing")

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -5874,12 +5874,8 @@ def test_monotonic():
     df = dd.from_pandas(pdf, 4)
 
     for c in df.columns:
-        assert assert_eq(
-            df[c].is_monotonic_increasing(), pdf[c].is_monotonic_increasing
-        )
-        assert assert_eq(
-            df[c].is_monotonic_decreasing(), pdf[c].is_monotonic_decreasing
-        )
+        assert assert_eq(df[c].is_monotonic_increasing, pdf[c].is_monotonic_increasing)
+        assert assert_eq(df[c].is_monotonic_decreasing, pdf[c].is_monotonic_decreasing)
 
 
 def test_is_monotonic_dt64():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -5862,6 +5862,26 @@ def test_is_monotonic_deprecated():
     assert_eq(expected, result)
 
 
+def test_monotonic():
+    pdf = pd.DataFrame(
+        {
+            "a": range(20),
+            "b": list(range(20))[::-1],
+            "c": [0] * 20,
+            "d": [0] * 5 + [1] * 5 + [0] * 10,
+        }
+    )
+    df = dd.from_pandas(pdf, 4)
+
+    for c in df.columns:
+        assert assert_eq(
+            df[c].is_monotonic_increasing(), pdf[c].is_monotonic_increasing
+        )
+        assert assert_eq(
+            df[c].is_monotonic_decreasing(), pdf[c].is_monotonic_decreasing
+        )
+
+
 def test_is_monotonic_dt64():
     s = pd.Series(pd.date_range("20130101", periods=10))
     ds = dd.from_pandas(s, npartitions=5)


### PR DESCRIPTION
The `concatenated["monotonic"].all()` returns a `numpy.bool_` object and if this is `False` the `and` condition is never evaluated such that we'll return the numpy bool. If the bool is True, we're evaluating the `and` expression which is then returning a python bool. This ensure the implementation is consistently returning a python bool