### PR TITLE
Python bool meta always `numpy.bool_`

### DIFF
--- a/dask/dataframe/_dtypes.py
+++ b/dask/dataframe/_dtypes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import date, time
 from decimal import Decimal
 
+import numpy as np
 import pandas as pd
 
 from dask.dataframe._compat import PANDAS_GE_150
@@ -71,4 +72,4 @@ def _(dtype):
 
 @make_scalar.register(bool)
 def _(x):
-    return True
+    return np.bool_(True)

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -173,8 +173,10 @@ def test_make_meta():
     assert isinstance(meta, np.float64)
 
     meta = make_meta(True)
-    assert meta
     assert isinstance(meta, np.bool_)
+
+    meta = make_meta(1)
+    assert isinstance(meta, np.int64)
 
     # Timestamp
     x = pd.Timestamp(2000, 1, 1)

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -191,6 +191,10 @@ def test_make_meta():
     assert isinstance(meta, np.bool_)
     assert pytest.raises(TypeError, lambda: make_meta(None))
 
+    meta = make_meta(True)
+    assert meta
+    assert isinstance(meta, np.bool_)
+
 
 def test_meta_nonempty():
     df1 = pd.DataFrame(

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -172,6 +172,10 @@ def test_make_meta():
     meta = make_meta(1.0, parent_meta=df)
     assert isinstance(meta, np.float64)
 
+    meta = make_meta(True)
+    assert meta
+    assert isinstance(meta, np.bool_)
+
     # Timestamp
     x = pd.Timestamp(2000, 1, 1)
     meta = make_meta(x, parent_meta=df)
@@ -190,10 +194,6 @@ def test_make_meta():
     meta = make_meta(np.dtype("bool"), parent_meta=df)
     assert isinstance(meta, np.bool_)
     assert pytest.raises(TypeError, lambda: make_meta(None))
-
-    meta = make_meta(True)
-    assert meta
-    assert isinstance(meta, np.bool_)
 
 
 def test_meta_nonempty():


### PR DESCRIPTION
we're doing the same thing for floats and integers so bool should not be different


xref https://github.com/dask-contrib/dask-expr/pull/477