### PR TITLE
Add pickleshare to docs builds

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -19,3 +19,4 @@ pytest-check-links
 requests-cache
 ipython
 ipykernel<6.22.0
+pickleshare==0.7.5


### PR DESCRIPTION
Apparently this is just failing everywhere and this fixes it.

Failure here: https://readthedocs.org/projects/dask/builds/22784168/

Looks like

```python-traceback
/home/docs/checkouts/readthedocs.org/user_builds/dask/envs/10679/lib/python3.11/site-packages/IPython/core/magics/osm.py:761: UserWarning: using bookmarks requires you to install the `pickleshare` library.
  bkms = self.shell.db.get('bookmarks',{})
/home/docs/checkouts/readthedocs.org/user_builds/dask/envs/10679/lib/python3.11/site-packages/IPython/core/magics/osm.py:795: UserWarning: using bookmarks requires you to install the `pickleshare` library.
  self.shell.db['bookmarks'] = bkms
/home/docs/checkouts/readthedocs.org/user_builds/dask/envs/10679/lib/python3.11/site-packages/IPython/core/magics/osm.py:761: UserWarning: using bookmarks requires you to install the `pickleshare` library.
  bkms = self.shell.db.get('bookmarks',{})
UsageError: %bookmark -d: Can't delete bookmark 'ipy_savedir'
/home/docs/checkouts/readthedocs.org/user_builds/dask/envs/10679/lib/python3.11/site-packages/IPython/core/magics/osm.py:795: UserWarning: using bookmarks requires you to install the `pickleshare` library.
  self.shell.db['bookmarks'] = bkms
/home/docs/checkouts/readthedocs.org/user_builds/dask/envs/10679/lib/python3.11/site-packages/IPython/core/magics/osm.py:761: UserWarning: using bookmarks requires you to install the `pickleshare` library.
  bkms = self.shell.db.get('bookmarks',{})
UsageError: %bookmark -d: Can't delete bookmark 'ipy_savedir'
```

Thanks https://github.com/pystatgen/sgkit/issues/1140