### PR TITLE
Deprecate automatic argument inference in ``df.repartition``. Specify argument explicitly instead

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -1712,9 +1712,23 @@ Dask Name: {name}, {layers}"""
         pandas.DataFrame.memory_usage
         """
         if isinstance(divisions, int):
+            warnings.warn(
+                "divisions is an integer and will be inferred as npartitions instead. "
+                "This automatic inference is deprecated and will change in the future. "
+                f"Please set npartitions={divisions} instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
             npartitions = divisions
             divisions = None
         if isinstance(divisions, str):
+            warnings.warn(
+                "divisions is a string and will be inferred as partition_size instead. "
+                "This automatic inference is deprecated and will change in the future. "
+                f"Please set partition_size={divisions} instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
             partition_size = divisions
             divisions = None
         if (

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2271,7 +2271,7 @@ def test_repartition_npartitions(use_index, n, k, dtype, transform):
     )
     df = transform(df)
     a = dd.from_pandas(df, npartitions=n, sort=use_index)
-    b = a.repartition(k)
+    b = a.repartition(npartitions=k)
     assert_eq(a, b)
     assert b.npartitions == k
     assert all(map(len, b.partitions))
@@ -2298,7 +2298,7 @@ def test_repartition_partition_size(use_index, n, partition_size, transform):
 def test_repartition_partition_size_arg():
     df = pd.DataFrame({"x": range(10)})
     a = dd.from_pandas(df, npartitions=2)
-    b = a.repartition("1 MiB")
+    b = a.repartition(partition_size="1 MiB")
     assert b.npartitions == 1
 
 
@@ -2352,7 +2352,7 @@ def test_repartition_datetime_tz_index():
     ds = dd.from_pandas(s, npartitions=2)
     assert ds.npartitions == 2
     assert_eq(s, ds)
-    result = ds.repartition(5)
+    result = ds.repartition(npartitions=5)
     assert result.npartitions == 5
     assert_eq(s, result)
 

--- a/dask/dataframe/tests/test_merge_column_and_index.py
+++ b/dask/dataframe/tests/test_merge_column_and_index.py
@@ -240,7 +240,7 @@ def test_merge_column_with_nulls(repartition):
     df1_d = dd.from_pandas(df1, npartitions=4)
     df2_d = dd.from_pandas(df2, npartitions=3).set_index("b")
     if repartition:
-        df2_d = df2_d.repartition(repartition)
+        df2_d = df2_d.repartition(npartitions=repartition)
 
     pandas_result = df1.merge(
         df2.set_index("b"), how="left", left_on="a", right_index=True

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1230,7 +1230,9 @@ def test_set_index_overlap_2():
         )
     )
     ddf = dd.from_pandas(df, npartitions=2)
-    result = ddf.reset_index().repartition(8).set_index("index", sorted=True)
+    result = (
+        ddf.reset_index().repartition(npartitions=8).set_index("index", sorted=True)
+    )
     expected = df.reset_index().set_index("index")
     assert_eq(result, expected)
     assert result.npartitions == 8
@@ -1281,7 +1283,7 @@ def test_compute_current_divisions_overlap_2():
         )
     )
     ddf1 = dd.from_pandas(data, npartitions=2)
-    ddf2 = ddf1.clear_divisions().repartition(8)
+    ddf2 = ddf1.clear_divisions().repartition(npartitions=8)
     with pytest.warns(UserWarning, match="Partitions have overlapping values"):
         ddf2.compute_current_divisions()
 


### PR DESCRIPTION
I really don't want to add the same stuff in dask-expr as well...