### PR TITLE
Avoid converting non-strings to arrow strings for read_parquet

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -421,7 +421,9 @@ class _Frame(DaskMethodsMixin, OperatorMethodMixin):
         # Optionally cast object dtypes to `pyarrow` strings.
         # By default, if `pyarrow` and `pandas>=2` are installed,
         # we convert to pyarrow strings.
-        if pyarrow_strings_enabled():
+        # Disable for read_parquet since the reader takes care of this
+        # conversion
+        if pyarrow_strings_enabled() and "read-parquet" not in name:
             from dask.dataframe._pyarrow import check_pyarrow_string_supported
 
             check_pyarrow_string_supported()

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -4834,9 +4834,7 @@ def test_read_parquet_convert_string(tmp_path, convert_string, engine):
     else:
         expected = df
     assert_eq(ddf, expected)
-    # pyarrow engine has a specialized implementation
-    n_layers = 2 if convert_string and engine == "fastparquet" else 1
-    assert len(ddf.dask.layers) == n_layers
+    assert len(ddf.dask.layers) == 1
 
     # Test collection name takes into account `dataframe.convert-string`
     with dask.config.set({"dataframe.convert-string": convert_string}):


### PR DESCRIPTION
- [x] ref #10631
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

This disables the conversion for read_parquet (unfortunately also for fast parquet).

This is a minimal solution for a problem that we can solve with dask-expr and the pandas option infer_string in the future. This is aimed at solving the biggest pain for most users out there without too much effort on our side.
cc @fjetter 