### PR TITLE
[Dask.order] Remove non-runnable leaf nodes from ordering

### DIFF
--- a/dask/order.py
+++ b/dask/order.py
@@ -106,6 +106,7 @@ def order(
         return {}  # type: ignore
 
     dsk = dict(dsk)
+    expected_len = len(dsk)
 
     if dependencies is None:
         dependencies = {k: get_dependencies(dsk, k) for k in dsk}
@@ -508,7 +509,7 @@ def order(
         scpath_discard(item)
         return item
 
-    while len(result) < len(dsk):
+    while len(result) < expected_len:
         crit_path_counter += 1
         assert not critical_path
         assert not scrit_path
@@ -564,6 +565,7 @@ def order(
                 add_to_result(item)
         process_runnables()
 
+    assert len(result) == expected_len
     return result  # type: ignore
 
 

--- a/dask/order.py
+++ b/dask/order.py
@@ -129,7 +129,7 @@ def order(
     # for instance da.store where the task is merely an alias
     # to multiple keys, i.e. [key1, key2, ...,]
     all_tasks = False
-    j = 0
+    n_removed_leaves = 0
     while not all_tasks:
         all_tasks = True
         for leaf in list(leaf_nodes):
@@ -139,11 +139,14 @@ def order(
                 and len(dependencies[leaf]) > 1
             ):
                 all_tasks = False
+                # Put non-tasks at the very end since they are merely aliases
+                # and have no impact on performance at all
+                prio = len(dsk) - 1 - n_removed_leaves
                 if return_stats:
-                    result[leaf] = Order(len(dsk) - 1 - j, -1)
+                    result[leaf] = Order(prio, -1)
                 else:
-                    result[leaf] = len(dsk) - 1 - j
-                j += 1
+                    result[leaf] = prio
+                n_removed_leaves += 1
                 leaf_nodes.remove(leaf)
                 del dsk[leaf]
                 del dependents[leaf]

--- a/dask/order.py
+++ b/dask/order.py
@@ -74,7 +74,7 @@ def order(
     dsk: Mapping[Key, Any],
     dependencies: Mapping[Key, set[Key]] | None = None,
     *,
-    return_stats: Literal[False],
+    return_stats: Literal[False] = False,
 ) -> dict[Key, int]:
     ...
 

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -2128,8 +2128,8 @@ def test_connecting_to_roots_asym():
     }
 
 
-def test_donot_mutate_input():
-    # Internally we may modify the graph but we don't want to mutatet the
+def test_do_not_mutate_input():
+    # Internally we may modify the graph but we don't want to mutate the
     # external dsk
     np = pytest.importorskip("numpy")
     dsk = {

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -1792,7 +1792,6 @@ def test_reduce_with_many_common_dependents(optimize, keep_self, ndeps, n_reduce
     # Verify assumptions (specifically that the reducers are sum-aggregate)
     assert ({"object", "sum", "sum-aggregate"}).issubset({key_split(k) for k in o})
     reducers = {k for k in o if key_split(k) == "sum-aggregate"}
-    drift = dict()
     assert (p := max(diagnostics(dsk)[1])) <= n_reducers + ndeps, p
     # With optimize the metrics below change since there are many layers that
     # are being fused but the pressure above should already be a strong
@@ -1802,7 +1801,6 @@ def test_reduce_with_many_common_dependents(optimize, keep_self, ndeps, n_reduce
             prios_deps = []
             for dep in dependencies[r]:
                 prios_deps.append(o[dep])
-            drift[r] = (min(prios_deps), max(prios_deps))
             assert max(prios_deps) - min(prios_deps) == (len(dependencies[r]) - 1) * (
                 2 if keep_self else 1
             )

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -2128,3 +2128,19 @@ def test_connecting_to_roots_asym():
         k: max((len(dependents[r]) for r in v), default=len(dependents[k]))
         for k, v in connected_roots.items()
     }
+
+
+def test_donot_mutate_input():
+    # Internally we may modify the graph but we don't want to mutatet the
+    # external dsk
+    np = pytest.importorskip("numpy")
+    dsk = {
+        "a": "data",
+        "b": (f, 1),
+        "c": np.array([[1, 2], [3, 4]]),
+        "d": ["a", "b", "c"],
+    }
+    dsk_copy = dsk.copy()
+    o = order(dsk)
+    assert o["d"] == len(dsk) - 1
+    assert len(dsk) == len(dsk_copy)

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -269,7 +269,7 @@ def test_break_ties_by_str(abcde):
     a, b, c, d, e = abcde
     dsk = {("x", i): (inc, i) for i in range(10)}
     x_keys = sorted(dsk)
-    dsk["y"] = list(x_keys)
+    dsk["y"] = (f, list(x_keys))
 
     o = order(dsk)
     expected = {"y": 10}
@@ -866,6 +866,7 @@ def test_array_store_final_order(tmpdir):
     root = zarr.group(store, overwrite=True)
     dest = root.empty_like(name="dest", data=x, chunks=x.chunksize, overwrite=True)
     d = x.store(dest, lock=False, compute=False)
+    visualize(dict(d.dask))
     o = order(d.dask)
     # Find the lowest store. Dask starts here.
     stores = [k for k in o if isinstance(k, tuple) and k[0].startswith("store-map-")]
@@ -1757,9 +1758,11 @@ def test_flox_reduction(abcde):
     assert max(of1) < min(of2) or max(of2) < min(of1)
 
 
+@pytest.mark.parametrize("optimize", [True, False])
+@pytest.mark.parametrize("keep_self", [True, False])
 @pytest.mark.parametrize("ndeps", [2, 5])
 @pytest.mark.parametrize("n_reducers", [4, 7])
-def test_reduce_with_many_common_dependents(ndeps, n_reducers):
+def test_reduce_with_many_common_dependents(optimize, keep_self, ndeps, n_reducers):
     da = pytest.importorskip("dask.array")
     import numpy as np
 
@@ -1780,21 +1783,31 @@ def test_reduce_with_many_common_dependents(ndeps, n_reducers):
     graph = x.sum(axis=1, split_every=20)
     from dask.order import order
 
-    dsk = collections_to_dsk([graph])
+    if keep_self:
+        # Keeping self adds a layer that cannot be fused
+        dsk = collections_to_dsk([x, graph], optimize_graph=optimize)
+    else:
+        dsk = collections_to_dsk([graph], optimize_graph=optimize)
     dependencies, dependents = get_deps(dsk)
     # Verify assumptions
     o = order(dsk)
     # Verify assumptions (specifically that the reducers are sum-aggregate)
-    assert {key_split(k) for k in o} == {"object", "sum", "sum-aggregate"}
-
+    assert ({"object", "sum", "sum-aggregate"}).issubset({key_split(k) for k in o})
     reducers = {k for k in o if key_split(k) == "sum-aggregate"}
     drift = dict()
-    for r in reducers:
-        prios_deps = []
-        for dep in dependencies[r]:
-            prios_deps.append(o[dep])
-        drift[r] = (min(prios_deps), max(prios_deps))
-        assert max(prios_deps) - min(prios_deps) == len(dependencies[r]) - 1
+    assert (p := max(diagnostics(dsk)[1])) <= n_reducers + ndeps, p
+    # With optimize the metrics below change since there are many layers that
+    # are being fused but the pressure above should already be a strong
+    # indicator if something is wrong
+    if optimize:
+        for r in reducers:
+            prios_deps = []
+            for dep in dependencies[r]:
+                prios_deps.append(o[dep])
+            drift[r] = (min(prios_deps), max(prios_deps))
+            assert max(prios_deps) - min(prios_deps) == (len(dependencies[r]) - 1) * (
+                2 if keep_self else 1
+            )
 
 
 def test_doublediff(abcde):
@@ -1921,7 +1934,7 @@ def test_gh_3055_explicit(abcde):
     assert o[(a, 2)] < o[(a, 3)] < o[(a, 4)]
 
 
-def test_order_flux_reduction_2(abcde):
+def test_order_flox_reduction_2(abcde):
     # https://github.com/dask/dask/issues/10618
     a, b, c, d, e = abcde
     dsk = {
@@ -1949,7 +1962,7 @@ def test_order_flux_reduction_2(abcde):
         (d, 1, 0): (c, 1, 0),
         (d, 1, 1): (c, 1, 1),
     }
-
+    # visualize(dsk)
     o = order(dsk)
     final_nodes = sorted(
         [(d, ix, jx) for ix in range(2) for jx in range(2)], key=o.__getitem__

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -866,7 +866,6 @@ def test_array_store_final_order(tmpdir):
     root = zarr.group(store, overwrite=True)
     dest = root.empty_like(name="dest", data=x, chunks=x.chunksize, overwrite=True)
     d = x.store(dest, lock=False, compute=False)
-    visualize(dict(d.dask))
     o = order(d.dask)
     # Find the lowest store. Dask starts here.
     stores = [k for k in o if isinstance(k, tuple) and k[0].startswith("store-map-")]
@@ -1221,7 +1220,6 @@ def test_anom_mean():
     # `mean_chunk` which is the primary reducer in this graph. Therefore we want
     # to run those as quickly as possible.
     # This is difficult to assert on but the pressure is an ok-ish proxy
-    # visualize(graph)
     assert max(pressure) <= 177
     from collections import defaultdict
 
@@ -1962,7 +1960,6 @@ def test_order_flox_reduction_2(abcde):
         (d, 1, 0): (c, 1, 0),
         (d, 1, 1): (c, 1, 1),
     }
-    # visualize(dsk)
     o = order(dsk)
     final_nodes = sorted(
         [(d, ix, jx) for ix in range(2) for jx in range(2)], key=o.__getitem__


### PR DESCRIPTION
This is a follow up to https://github.com/dask/dask/pull/10660 and addresses the still failing test in https://github.com/dask/distributed/issues/8255

Most notably, this removes a special case in the `process_runnable` code path that caused this kind of graph to be executed too eagerly. The special code path was not hit in the specific unit test I added in `test_order.py`. I extended the test logic to cover this now.

This special branch was added to enable eager execution of some dangling code branches as observed in `test_array_store_final_order`

![image](https://github.com/dask/dask/assets/8629629/c5e7093b-9639-4a64-b5d8-6ea37ba59941)

(The image shows the correct order)

The dangling branches I was referring to are those linear branches ending in P51 and P15. Without that special casing, those two branches would not have been executed causing the root to be left in memory until the end.

What this visualization is not showing is what causes the problem. This graph is actually reducing to a single task `"store-12345": ["store-map-1", "store-map-2", ...]` that is effectively an alias. This alias is throwing off the critical path algorithm such that those thin, small branches are effectively ignored and deemed as not valuable. Without that final reducer, the algorithm is forced to finish the connected graph first.
This weird alias is actually something that is not even properly understood by the visualization code. It's rendered as the box in the lower right corner but it doesn't know what to do with it.