### PR TITLE
Catch deprecation warning about unobserved categories

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -766,18 +766,16 @@ def _nunique_df_chunk(df, *by, **kwargs):
 
 
 def _nunique_df_combine(df, levels, sort=False):
-    with check_observed_deprecation():
-        result = (
-            df.groupby(level=levels, sort=sort)
-            .apply(_drop_duplicates_reindex)
-            .reset_index(level=-1, drop=True)
-        )
+    result = (
+        df.groupby(level=levels, sort=sort, observed=True)
+        .apply(_drop_duplicates_reindex)
+        .reset_index(level=-1, drop=True)
+    )
     return result
 
 
 def _nunique_df_aggregate(df, levels, name, sort=False):
-    with check_observed_deprecation():
-        return df.groupby(level=levels, sort=sort)[name].nunique()
+    return df.groupby(level=levels, sort=sort, observed=True)[name].nunique()
 
 
 def _nunique_series_chunk(df, *by, **_ignored_):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -750,8 +750,11 @@ def _drop_duplicates_reindex(df):
 
 def _nunique_df_chunk(df, *by, **kwargs):
     name = kwargs.pop("name")
+    group_keys = {}
+    if PANDAS_GE_150:
+        group_keys["group_keys"] = True
 
-    g = _groupby_raise_unaligned(df, by=by)
+    g = _groupby_raise_unaligned(df, by=by, **group_keys)
     if len(df) > 0:
         grouped = (
             g[[name]].apply(_drop_duplicates_reindex).reset_index(level=-1, drop=True)
@@ -771,11 +774,17 @@ def _nunique_df_combine(df, levels, sort=False):
         .apply(_drop_duplicates_reindex)
         .reset_index(level=-1, drop=True)
     )
+    if result.index.dtype == "O":
+        print()
+    # print(result.index)
+    # print(df)
     return result
 
 
 def _nunique_df_aggregate(df, levels, name, sort=False):
-    return df.groupby(level=levels, sort=sort, observed=True)[name].nunique()
+    result = df.groupby(level=levels, sort=sort, observed=True)[name].nunique()
+    # print(result.index)
+    return result
 
 
 def _nunique_series_chunk(df, *by, **_ignored_):

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -766,11 +766,12 @@ def _nunique_df_chunk(df, *by, **kwargs):
 
 
 def _nunique_df_combine(df, levels, sort=False):
-    result = (
-        df.groupby(level=levels, sort=sort)
-        .apply(_drop_duplicates_reindex)
-        .reset_index(level=-1, drop=True)
-    )
+    with check_observed_deprecation():
+        result = (
+            df.groupby(level=levels, sort=sort)
+            .apply(_drop_duplicates_reindex)
+            .reset_index(level=-1, drop=True)
+        )
     return result
 
 

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -146,9 +146,10 @@ def test_concat_unions_categoricals():
         ),
     ],
 )
+@pytest.mark.parametrize("npartitions", [None, 10])
 @pytest.mark.filterwarnings("ignore:The default value of numeric_only")
 @pytest.mark.filterwarnings("ignore:Dropping")
-def test_unknown_categoricals(shuffle_method, numeric_only):
+def test_unknown_categoricals(shuffle_method, numeric_only, npartitions):
     ddf = dd.DataFrame(
         {("unknown", i): df for (i, df) in enumerate(frames)},
         "unknown",
@@ -158,6 +159,8 @@ def test_unknown_categoricals(shuffle_method, numeric_only):
         ),
         [None] * 4,
     )
+    if npartitions is not None:
+        ddf = ddf.repartition(npartitions=npartitions)
     # Compute
     df = ddf.compute()
 

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -160,6 +160,8 @@ def test_unknown_categoricals(shuffle_method, numeric_only, npartitions, split_o
         ),
         [None] * 4,
     )
+    if npartitions == 10 and not PANDAS_GE_150:
+        pytest.mark.xfail(reason="group_keys not supported")
     if npartitions is not None:
         ddf = ddf.repartition(npartitions=npartitions)
     # Compute

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -147,9 +147,10 @@ def test_concat_unions_categoricals():
     ],
 )
 @pytest.mark.parametrize("npartitions", [None, 10])
+@pytest.mark.parametrize("split_out", [1, 4])
 @pytest.mark.filterwarnings("ignore:The default value of numeric_only")
 @pytest.mark.filterwarnings("ignore:Dropping")
-def test_unknown_categoricals(shuffle_method, numeric_only, npartitions):
+def test_unknown_categoricals(shuffle_method, numeric_only, npartitions, split_out):
     ddf = dd.DataFrame(
         {("unknown", i): df for (i, df) in enumerate(frames)},
         "unknown",
@@ -182,7 +183,7 @@ def test_unknown_categoricals(shuffle_method, numeric_only, npartitions):
     with ctx:
         expected = df.groupby(df.w).y.nunique()
     with ctx:
-        result = ddf.groupby(ddf.w).y.nunique()
+        result = ddf.groupby(ddf.w).y.nunique(split_out=split_out)
     assert_eq(result, expected)
 
     with ctx:

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -150,7 +150,9 @@ def test_concat_unions_categoricals():
 @pytest.mark.parametrize("split_out", [1, 4])
 @pytest.mark.filterwarnings("ignore:The default value of numeric_only")
 @pytest.mark.filterwarnings("ignore:Dropping")
-def test_unknown_categoricals(shuffle_method, numeric_only, npartitions, split_out):
+def test_unknown_categoricals(
+    shuffle_method, numeric_only, npartitions, split_out, request
+):
     ddf = dd.DataFrame(
         {("unknown", i): df for (i, df) in enumerate(frames)},
         "unknown",
@@ -161,7 +163,7 @@ def test_unknown_categoricals(shuffle_method, numeric_only, npartitions, split_o
         [None] * 4,
     )
     if npartitions == 10 and not PANDAS_GE_150:
-        pytest.mark.xfail(reason="group_keys not supported")
+        request.applymarker(pytest.mark.xfail(reason="group_keys not supported"))
     if npartitions is not None:
         ddf = ddf.repartition(npartitions=npartitions)
     # Compute

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -183,7 +183,7 @@ def test_unknown_categoricals(shuffle_method, numeric_only, npartitions, split_o
     with ctx:
         expected = df.groupby(df.w).y.nunique()
     with ctx:
-        result = ddf.groupby(ddf.w).y.nunique(split_out=split_out)
+        result = ddf.groupby(ddf.w, sort=False).y.nunique(split_out=split_out)
     assert_eq(result, expected)
 
     with ctx:


### PR DESCRIPTION
Our test config led to us never executing the combine step with unobserved categories, so we didn't fail because of the warnings

Actually, there is a bug In there as well If split_out > 1, that's fixed now