### PR TITLE
bump approx threshold for test_quantile

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1485,13 +1485,13 @@ def test_quantile(method, quantile):
     assert isinstance(result, dd.Series)
     result = result.compute()
     assert isinstance(result, pd.Series)
-    assert result.iloc[0] == pytest.approx(exp, rel=0.1)
+    assert result.iloc[0] == pytest.approx(exp, rel=0.15)
 
     # series / single
     result = df.x.quantile(quantile, method=method)
     assert isinstance(result, dd.core.Scalar)
     result = result.compute()
-    assert result == pytest.approx(exp, rel=0.1)
+    assert result == pytest.approx(exp, rel=0.15)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This failed on main, see https://github.com/dask/dask/actions/runs/7250252918/job/19750018247

```
E       assert 0.3946495992341462 == 0.35667494393873245 � 3.6e-02
E         comparison failed
E         Obtained: 0.3946495992341462
E         Expected: 0.35667494393873245 � 3.6e-02
```

The 10% threshold is at `0.39234243833260574` so very close. I think we can be more forgiving here.