### PR TITLE
Update environment file upload step in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,9 +102,9 @@ jobs:
       # This environment file is created in continuous_integration/scripts/install.sh
       # and can be useful when debugging locally
       - name: Upload environment file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: env-${{ matrix.os }}-${{ matrix.environment }}
+          name: env-${{ matrix.os }}-${{ matrix.environment }}-${{ matrix.extra }}
           path: env.yaml
 
       - name: Run tests


### PR DESCRIPTION
Looks like https://github.com/dask/dask/pull/10719 is failing due to the name of this artifact not being unique. This PR updates the action version and makes the name unique. 