### PR TITLE
Use new Xarray logo

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -158,7 +158,7 @@ Dask provides several APIs.  Choose one that works best for you:
             .. grid-item::
                 :columns: 12 12 5 5
 
-                .. figure:: https://docs.xarray.dev/en/stable/_static/dataset-diagram-logo.png
+                .. figure:: https://docs.xarray.dev/en/stable/_static/logos/Xarray_Logo_RGB_Final.png
                    :align: center
 
     .. tab-item:: Bags


### PR DESCRIPTION
Xarray updated their logo recently (xref https://github.com/xarray-contrib/xarray.dev/issues/66). This PR makes it so the logo on our landing page is the new logo (currently this link is broken). 

cc @mrocklin 