### PR TITLE
Deprecate fastparquet

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -27,7 +27,7 @@ dependencies:
   - numpy=1.23
   - pandas=1.5
   - flask
-  - fastparquet>=0.8.0
+  - fastparquet
   - h5py
   - pytables
   - zarr

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -27,7 +27,7 @@ dependencies:
   - numpy
   - pandas
   - flask
-  - fastparquet>=0.8.0
+  - fastparquet
   - h5py
   - pytables
   - zarr

--- a/continuous_integration/environment-3.12.yaml
+++ b/continuous_integration/environment-3.12.yaml
@@ -27,7 +27,7 @@ dependencies:
   - numpy
   - pandas
   - flask
-  - fastparquet>=0.8.0
+  - fastparquet
   - h5py
   - pytables
   - zarr

--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -176,14 +176,19 @@ def test_parquet(engine):
     pytest.importorskip("requests", minversion="2.21.0")
     dd = pytest.importorskip("dask.dataframe")
     pytest.importorskip(engine)
-    df = dd.read_parquet(
-        [
-            "https://github.com/Parquet/parquet-compatibility/raw/"
-            "master/parquet-testdata/impala/1.1.1-NONE/"
-            "nation.impala.parquet"
-        ],
-        engine=engine,
-    ).compute()
+
+    url = [
+        "https://github.com/Parquet/parquet-compatibility/raw/"
+        "master/parquet-testdata/impala/1.1.1-NONE/"
+        "nation.impala.parquet"
+    ]
+    if engine == "fastparquet":
+        with pytest.warns(FutureWarning):
+            df = dd.read_parquet(url, engine="fastparquet")
+    else:
+        df = dd.read_parquet(url)
+
+    df = df.compute()
     assert df.n_nationkey.tolist() == list(range(25))
     assert df.columns.tolist() == ["n_nationkey", "n_name", "n_regionkey", "n_comment"]
 

--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -171,24 +171,27 @@ def test_open_glob(dir_server):
 
 
 @pytest.mark.network
-@pytest.mark.parametrize("engine", ["pyarrow", "fastparquet"])
+@pytest.mark.parametrize(
+    "engine",
+    [
+        "pyarrow",
+        pytest.param(
+            "fastparquet", marks=pytest.mark.filterwarnings("ignore::FutureWarning")
+        ),
+    ],
+)
 def test_parquet(engine):
     pytest.importorskip("requests", minversion="2.21.0")
     dd = pytest.importorskip("dask.dataframe")
     pytest.importorskip(engine)
-
-    url = [
-        "https://github.com/Parquet/parquet-compatibility/raw/"
-        "master/parquet-testdata/impala/1.1.1-NONE/"
-        "nation.impala.parquet"
-    ]
-    if engine == "fastparquet":
-        with pytest.warns(FutureWarning):
-            df = dd.read_parquet(url, engine="fastparquet")
-    else:
-        df = dd.read_parquet(url)
-
-    df = df.compute()
+    df = dd.read_parquet(
+        [
+            "https://github.com/Parquet/parquet-compatibility/raw/"
+            "master/parquet-testdata/impala/1.1.1-NONE/"
+            "nation.impala.parquet"
+        ],
+        engine=engine,
+    ).compute()
     assert df.n_nationkey.tolist() == list(range(25))
     assert df.columns.tolist() == ["n_nationkey", "n_name", "n_regionkey", "n_comment"]
 

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -1706,7 +1706,7 @@ class ArrowDatasetEngine(Engine):
             frag = None
 
             # Check if we have partitioning information.
-            # Will only have this if the engine="pyarrow-dataset"
+            # Not supported with fastparquet.
             partitioning = kwargs.get("dataset", {}).get("partitioning", None)
 
             # Check if we need to generate a fragment.

--- a/dask/dataframe/io/parquet/core.py
+++ b/dask/dataframe/io/parquet/core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import math
 import warnings
+from typing import Literal
 
 import pandas as pd
 import tlz as toolz
@@ -186,7 +187,7 @@ def read_parquet(
     categories=None,
     index=None,
     storage_options=None,
-    engine="auto",
+    engine=None,  # Deprecated
     use_nullable_dtypes: bool | None = None,
     dtype_backend=None,
     calculate_divisions=None,
@@ -220,23 +221,16 @@ def read_parquet(
         read in the data as a Series.
     filters : Union[List[Tuple[str, str, Any]], List[List[Tuple[str, str, Any]]]], default None
         List of filters to apply, like ``[[('col1', '==', 0), ...], ...]``.
-        Using this argument will NOT result in row-wise filtering of the final
-        partitions unless ``engine="pyarrow"`` is also specified.  For
-        other engines, filtering is only performed at the partition level, that is,
-        to prevent the loading of some row-groups and/or files.
+        Using this argument will result in row-wise filtering of the final partitions.
 
-        For the "pyarrow" engine, predicates can be expressed in disjunctive
-        normal form (DNF). This means that the inner-most tuple describes a single
-        column predicate. These inner predicates are combined with an AND
-        conjunction into a larger predicate. The outer-most list then combines all
-        of the combined filters with an OR disjunction.
+        Predicates can be expressed in disjunctive normal form (DNF). This means that
+        the inner-most tuple describes a single column predicate. These inner predicates
+        are combined with an AND conjunction into a larger predicate. The outer-most
+        list then combines all of the combined filters with an OR disjunction.
 
         Predicates can also be expressed as a ``List[Tuple]``. These are evaluated
         as an AND conjunction. To express OR in predicates, one must use the
         (preferred for "pyarrow") ``List[List[Tuple]]`` notation.
-
-        Note that the "fastparquet" engine does not currently support DNF for
-        the filtering of partitioned columns (``List[Tuple]`` is required).
     index : str, list or False, default None
         Field name(s) to use as the output frame index. By default will be
         inferred from the pandas parquet file metadata, if present. Use ``False``
@@ -247,7 +241,7 @@ def read_parquet(
         guaranteed that the column is encoded as dictionary in all row-groups.
         If a list, assumes up to 2**16-1 labels; if a dict, specify the number
         of labels expected; if None, will load categories automatically for
-        data written by dask/fastparquet, not otherwise.
+        data written by dask, not otherwise.
     storage_options : dict, default None
         Key/value pairs to be passed on to the file-system backend, if any.
         Note that the default file-system backend can be configured with the
@@ -260,12 +254,8 @@ def read_parquet(
         ``"precache_options"`` key. Also, a custom file-open function can be
         used (instead of ``AbstractFileSystem.open``), by specifying the
         desired function under the ``"open_file_func"`` key.
-    engine : {'auto', 'pyarrow', 'fastparquet'}, default 'auto'
-        Parquet library to use. Defaults to 'auto', which uses ``pyarrow`` if
-        it is installed, and falls back to ``fastparquet`` otherwise.
     use_nullable_dtypes : {False, True}
         Whether to use extension dtypes for the resulting ``DataFrame``.
-        ``use_nullable_dtypes=True`` is only supported when ``engine="pyarrow"``.
 
         .. note::
 
@@ -314,8 +304,7 @@ def read_parquet(
         (uncompressed) parquet storage space. This argument is currenlty used to
         set the default value of ``split_row_groups`` (using row-group metadata
         from a single file), and will be ignored if ``split_row_groups`` is not
-        set to 'infer' or 'adaptive'. Default may be engine-dependant, but is
-        256 MiB for the 'pyarrow' and 'fastparquet' engines.
+        set to 'infer' or 'adaptive'. Default is 256 MiB.
     aggregate_files : bool or str, default None
         WARNING: Passing a string argument to ``aggregate_files`` will result
         in experimental behavior. This behavior may change in the future.
@@ -361,17 +350,14 @@ def read_parquet(
         It may be necessary to change this argument if the data files in your
         parquet dataset do not end in ".parq", ".parquet", or ".pq".
     filesystem: "fsspec", "arrow", or fsspec.AbstractFileSystem backend to use.
-        Note that the "fastparquet" engine only supports "fsspec" or an explicit
-        ``pyarrow.fs.AbstractFileSystem`` object. Default is "fsspec".
     dataset: dict, default None
-        Dictionary of options to use when creating a ``pyarrow.dataset.Dataset``
-        or ``fastparquet.ParquetFile`` object. These options may include a
-        "filesystem" key (or "fs" for the "fastparquet" engine) to configure
-        the desired file-system backend. However, the top-level ``filesystem``
-        argument will always take precedence.
+        Dictionary of options to use when creating a ``pyarrow.dataset.Dataset`` object.
+        These options may include a "filesystem" key to configure the desired
+        file-system backend. However, the top-level ``filesystem`` argument will always
+        take precedence.
 
-        NOTE: For the "pyarrow" engine, the ``dataset`` options may include a
-        "partitioning" key. However, since ``pyarrow.dataset.Partitioning``
+        **Note**: The ``dataset`` options may include a "partitioning" key.
+        However, since ``pyarrow.dataset.Partitioning``
         objects cannot be serialized, the value can be a dict of key-word
         arguments for the ``pyarrow.dataset.partitioning`` API
         (e.g. ``dataset={"partitioning": {"flavor": "hive", "schema": ...}}``).
@@ -493,8 +479,7 @@ def read_parquet(
     if columns is not None:
         columns = list(columns)
 
-    if isinstance(engine, str):
-        engine = get_engine(engine)
+    engine = get_engine(engine)
 
     if hasattr(path, "name"):
         path = stringify_path(path)
@@ -697,7 +682,7 @@ def read_parquet_part(fs, engine, meta, part, columns, index, kwargs):
 def to_parquet(
     df,
     path,
-    engine="auto",
+    engine=None,  # Deprecated
     compression="snappy",
     write_index=True,
     append=False,
@@ -726,9 +711,6 @@ def to_parquet(
     path : string or pathlib.Path
         Destination directory for data.  Prepend with protocol like ``s3://``
         or ``hdfs://`` for remote data.
-    engine : {'auto', 'pyarrow', 'fastparquet'}, default 'auto'
-        Parquet library to use. Defaults to 'auto', which uses ``pyarrow`` if
-        it is installed, and falls back to ``fastparquet`` otherwise.
     compression : string or dict, default 'snappy'
         Either a string like ``"snappy"`` or a dictionary mapping column names
         to compressors like ``{"name": "gzip", "values": "snappy"}``. Defaults
@@ -782,8 +764,7 @@ def to_parquet(
         no schema inference will be done. Passing in ``schema=None`` will
         disable the use of a global file schema - each written file may use a
         different schema dependent on the dtypes of the corresponding
-        partition. Note that this argument is ignored by the "fastparquet"
-        engine.
+        partition.
     name_function : callable, default None
         Function to generate the filename for each output partition.
         The function should accept an integer (partition index) as input and
@@ -793,8 +774,6 @@ def to_parquet(
         ``part.0.parquet``, ``part.1.parquet``, ``part.2.parquet``, ...
         and so on for each partition in the DataFrame.
     filesystem: "fsspec", "arrow", or fsspec.AbstractFileSystem backend to use.
-        Note that the "fastparquet" engine only supports "fsspec" or an explicit
-        ``pyarrow.fs.AbstractFileSystem`` object. Default is "fsspec".
     **kwargs :
         Extra options to be passed on to the specific backend.
 
@@ -845,8 +824,7 @@ def to_parquet(
     if df.columns.inferred_type not in {"string", "empty"}:
         raise ValueError("parquet doesn't support non-string column names")
 
-    if isinstance(engine, str):
-        engine = get_engine(engine)
+    engine = get_engine(engine)
 
     if hasattr(path, "name"):
         path = stringify_path(path)
@@ -1068,7 +1046,7 @@ def create_metadata_file(
     paths,
     root_dir=None,
     out_dir=None,
-    engine="pyarrow",
+    engine=None,  # Deprecated
     storage_options=None,
     split_every=32,
     compute=True,
@@ -1084,8 +1062,6 @@ def create_metadata_file(
     utility provides a mechanism to generate a _metadata file from a
     list of existing parquet files.
 
-    NOTE: This utility is not yet supported for the "fastparquet" engine.
-
     Parameters
     ----------
     paths : list(string)
@@ -1099,9 +1075,6 @@ def create_metadata_file(
         this will be set to `root_dir`.  If False is specified, the global
         metadata will be returned as an in-memory object (and will not be
         written to disk).
-    engine : str or Engine, default 'pyarrow'
-        Parquet Engine to use. Only 'pyarrow' is supported if a string
-        is passed.
     storage_options : dict, optional
         Key/value pairs to be passed on to the file-system backend, if any.
     split_every : int, optional
@@ -1122,16 +1095,12 @@ def create_metadata_file(
         behavior on remote file systems ("naked" paths cannot be used
         to infer file-system information).
     """
-
-    # Get engine.
-    # Note that "fastparquet" is not yet supported
-    if isinstance(engine, str):
-        if engine not in ("pyarrow", "arrow"):
-            raise ValueError(
-                f"{engine} is not a supported engine for create_metadata_file "
-                "Try engine='pyarrow'."
-            )
-        engine = get_engine(engine)
+    engine = get_engine(engine)
+    if engine is not _ENGINES.get("pyarrow"):
+        raise ValueError(
+            "fastparquet is not a supported engine for create_metadata_file."
+            "Please install pyarrow."
+        )
 
     # Process input path list
     if fs is None:
@@ -1206,60 +1175,83 @@ def create_metadata_file(
     return out
 
 
-_ENGINES: dict[str, Engine] = {}
+_ENGINES: dict[str, type[Engine]] = {}
 
 
-def get_engine(engine):
+def get_engine(
+    engine: None | Literal["auto", "pyarrow", "fastparquet"]
+) -> type[Engine]:
     """Get the parquet engine backend implementation.
+
+    This is deprecated. In the future, only pyarrow will be available and the 'engine'
+    parameter will be removed.
 
     Parameters
     ----------
-    engine : {'auto', 'pyarrow', 'fastparquet'}, default 'auto'
+    engine : {'auto', 'pyarrow', 'fastparquet'}
         Parquet library to use. Defaults to 'auto', which uses ``pyarrow`` if
         it is installed, and falls back to ``fastparquet`` otherwise.
-
-    Returns
-    -------
-    A dict containing a ``'read'`` and ``'write'`` function.
     """
-    if engine in _ENGINES:
-        return _ENGINES[engine]
+    if engine is not None:
+        warnings.warn(
+            "The `engine=` parameter is deprecated and will be removed "
+            "in a future release.",
+            category=FutureWarning,
+        )
 
-    if engine == "auto":
+    if engine in (None, "auto", "pyarrow", "arrow", "pyarrow-dataset"):
+        if "pyarrow" in _ENGINES:
+            return _ENGINES["pyarrow"]
+
         try:
-            return get_engine("pyarrow")
+            import_required("pyarrow", "`pyarrow` not installed")
         except RuntimeError:
-            pass
-
-        try:
-            return get_engine("fastparquet")
-        except RuntimeError:
-            raise RuntimeError("Please install either pyarrow or fastparquet") from None
-
-    elif engine == "fastparquet":
-        import_required("fastparquet", "`fastparquet` not installed")
-        from dask.dataframe.io.parquet.fastparquet import FastParquetEngine
-
-        _ENGINES["fastparquet"] = eng = FastParquetEngine
-        return eng
-
-    elif engine in ("pyarrow", "arrow", "pyarrow-dataset"):
-        import_required("pyarrow", "`pyarrow` not installed")
-
-        if engine in ("pyarrow-dataset", "arrow"):
-            engine = "pyarrow"
-
-        if engine == "pyarrow":
+            if engine not in (None, "auto"):
+                raise
+        else:
             from dask.dataframe.io.parquet.arrow import ArrowDatasetEngine
 
-            _ENGINES[engine] = eng = ArrowDatasetEngine
-        return eng
+            _ENGINES["pyarrow"] = eng = ArrowDatasetEngine
+            return eng
 
-    else:
-        raise ValueError(
-            f'Unsupported engine: "{engine}".'
-            '  Valid choices include "pyarrow" and "fastparquet".'
-        )
+    if engine in (None, "auto", "fastparquet"):
+
+        def warn_fastparquet():
+            if engine == "fastparquet":
+                warnings.warn(
+                    "The fastparquet engine is deprecated and will be removed "
+                    "in a future release. Please install pyarrow.",
+                    category=FutureWarning,
+                )
+            else:
+                warnings.warn(
+                    "Could not find pyarrow; falling back to fastparquet, which "
+                    "is deprecated and will be removed in a future release.",
+                    category=FutureWarning,
+                )
+
+        if "fastparquet" in _ENGINES:
+            warn_fastparquet()
+            return _ENGINES["fastparquet"]
+
+        try:
+            import_required("fastparquet", "`fastparquet` not installed")
+        except RuntimeError:
+            if engine in (None, "auto"):
+                raise RuntimeError("`pyarrow` not installed")
+            else:
+                raise
+        else:
+            from dask.dataframe.io.parquet.fastparquet import FastParquetEngine
+
+            _ENGINES["fastparquet"] = fpq_eng = FastParquetEngine
+            warn_fastparquet()
+            return fpq_eng
+
+    raise ValueError(
+        f'Unsupported engine: "{engine}".'
+        '  Valid choices include "pyarrow" and "fastparquet".'
+    )
 
 
 #####################

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -72,70 +72,90 @@ df = pd.DataFrame(
 
 ddf = dd.from_pandas(df, npartitions=npartitions)
 
-
-@pytest.fixture(
+_engine_fixture = pytest.fixture(
     params=[
-        pytest.param("fastparquet", marks=FASTPARQUET_MARK),
-        pytest.param("pyarrow", marks=PYARROW_MARK),
+        pytest.param(
+            {"engine": "fastparquet"},
+            id="fastparquet",
+            marks=[
+                FASTPARQUET_MARK,
+                pytest.mark.filterwarnings("ignore::FutureWarning"),
+            ],
+        ),
+        pytest.param({}, id="pyarrow", marks=[PYARROW_MARK]),
     ]
 )
+
+
+@_engine_fixture
 def engine(request):
     return request.param
 
 
-def write_read_engines(**kwargs):
-    """Product of both engines for write/read:
-
-    To add custom marks, pass keyword of the form: `mark_writer_reader=reason`,
-    or `mark_engine=reason` to apply to all parameters with that engine."""
-    backends = {"pyarrow", "fastparquet"}
-
-    # Skip if uninstalled
-    skip_marks = {
-        "fastparquet": FASTPARQUET_MARK,
-        "pyarrow": PYARROW_MARK,
-    }
-    marks = {(w, r): [skip_marks[w], skip_marks[r]] for w in backends for r in backends}
-
-    # Custom marks
-    for kw, val in kwargs.items():
-        kind, rest = kw.split("_", 1)
-        key = tuple(rest.split("_"))
-        if kind not in ("xfail", "skip") or len(key) > 2 or set(key) - backends:
-            raise ValueError("unknown keyword %r" % kw)
-        val = getattr(pytest.mark, kind)(reason=val)
-        if len(key) == 2:
-            marks[key].append(val)
-        else:
-            for k in marks:
-                if key in k:
-                    marks[k].append(val)
-
-    return pytest.mark.parametrize(
-        ("write_engine", "read_engine"),
-        [pytest.param(*k, marks=tuple(v)) for (k, v) in sorted(marks.items())],
-    )
+@_engine_fixture
+def write_engine(request):
+    return request.param
 
 
-fp_pandas_xfail = write_read_engines()
+@_engine_fixture
+def read_engine(request):
+    return request.param
 
 
 @PYARROW_MARK
 def test_get_engine_pyarrow():
     from dask.dataframe.io.parquet.arrow import ArrowDatasetEngine
 
-    assert get_engine("pyarrow") == ArrowDatasetEngine
-    assert get_engine("arrow") == ArrowDatasetEngine
+    assert get_engine(None) is ArrowDatasetEngine
+    for engine in ("auto", "pyarrow", "pyarrow-dataset", "arrow"):
+        with pytest.warns(FutureWarning, match="The `engine=` parameter is deprecated"):
+            assert get_engine(engine) is ArrowDatasetEngine
 
 
 @FASTPARQUET_MARK
 def test_get_engine_fastparquet():
     from dask.dataframe.io.parquet.fastparquet import FastParquetEngine
 
-    assert get_engine("fastparquet") == FastParquetEngine
+    with pytest.warns(FutureWarning) as warns:
+        assert get_engine("fastparquet") is FastParquetEngine
+
+    assert len(warns) == 2
+    assert "The `engine=` parameter is deprecated" in str(warns[0])
+    assert "The fastparquet engine is deprecated" in str(warns[1])
 
 
-@write_read_engines()
+@pytest.mark.skipif(
+    pa or not fastparquet, reason="Must have fastparquet but not pyarrow installed"
+)
+def test_get_engine_fastparquet_only():
+    from dask.dataframe.io.parquet.fastparquet import FastParquetEngine
+
+    with pytest.warns(
+        FutureWarning, match="Could not find pyarrow; falling back to fastparquet"
+    ):
+        assert get_engine(None) is FastParquetEngine
+
+
+@pytest.mark.skipif(pa or fastparquet, reason="fastparquet or pyarrow are installed")
+def test_get_engine_no_engine():
+    with pytest.raises(RuntimeError, match="`pyarrow` not installed"):
+        get_engine(None)
+
+    with (
+        pytest.warns(FutureWarning, match="The `engine=` parameter is deprecated"),
+        pytest.raises(RuntimeError, match="`pyarrow` not installed"),
+    ):
+        get_engine("auto")
+
+
+def test_get_engine_invalid():
+    with (
+        pytest.warns(FutureWarning, match="The `engine=` parameter is deprecated"),
+        pytest.raises(ValueError),
+    ):
+        get_engine(123)
+
+
 @pytest.mark.parametrize("has_metadata", [False, True])
 def test_local(tmpdir, write_engine, read_engine, has_metadata):
     tmp = str(tmpdir)
@@ -152,14 +172,14 @@ def test_local(tmpdir, write_engine, read_engine, has_metadata):
     df = dd.from_pandas(data, chunksize=500)
 
     kwargs = {"write_metadata_file": True} if has_metadata else {}
-    df.to_parquet(tmp, write_index=False, engine=write_engine, **kwargs)
+    df.to_parquet(tmp, write_index=False, **write_engine, **kwargs)
 
     files = os.listdir(tmp)
     assert ("_common_metadata" in files) == has_metadata
     assert ("_metadata" in files) == has_metadata
     assert "part.0.parquet" in files
 
-    df2 = dd.read_parquet(tmp, index=False, engine=read_engine)
+    df2 = dd.read_parquet(tmp, index=False, **read_engine)
 
     assert len(df2.divisions) > 1
 
@@ -170,7 +190,6 @@ def test_local(tmpdir, write_engine, read_engine, has_metadata):
 
 
 @pytest.mark.parametrize("index", [False, True])
-@write_read_engines()
 def test_empty(tmpdir, write_engine, read_engine, index):
     fn = str(tmpdir)
     df = pd.DataFrame({"a": ["a", "b", "b"], "b": [4, 5, 6]})[:0]
@@ -178,32 +197,28 @@ def test_empty(tmpdir, write_engine, read_engine, index):
         df = df.set_index("a", drop=True)
     ddf = dd.from_pandas(df, npartitions=2)
 
-    ddf.to_parquet(fn, write_index=index, engine=write_engine, write_metadata_file=True)
-    read_df = dd.read_parquet(fn, engine=read_engine)
+    ddf.to_parquet(fn, write_index=index, write_metadata_file=True, **write_engine)
+    read_df = dd.read_parquet(fn, **read_engine)
     assert_eq(ddf, read_df)
 
 
-@write_read_engines()
 def test_simple(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
     df = pd.DataFrame({"a": ["a", "b", "b"], "b": [4, 5, 6]})
     df = df.set_index("a", drop=True)
     ddf = dd.from_pandas(df, npartitions=2)
-    ddf.to_parquet(fn, engine=write_engine)
-    read_df = dd.read_parquet(
-        fn, index=["a"], engine=read_engine, calculate_divisions=True
-    )
+    ddf.to_parquet(fn, **write_engine)
+    read_df = dd.read_parquet(fn, index=["a"], calculate_divisions=True, **read_engine)
     assert_eq(ddf, read_df)
 
 
-@write_read_engines()
 def test_delayed_no_metadata(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
     df = pd.DataFrame({"a": ["a", "b", "b"], "b": [4, 5, 6]})
     df = df.set_index("a", drop=True)
     ddf = dd.from_pandas(df, npartitions=2)
     ddf.to_parquet(
-        fn, engine=write_engine, compute=False, write_metadata_file=False
+        fn, compute=False, write_metadata_file=False, **write_engine
     ).compute()
     files = os.listdir(fn)
     assert "_metadata" not in files
@@ -211,16 +226,15 @@ def test_delayed_no_metadata(tmpdir, write_engine, read_engine):
     read_df = dd.read_parquet(
         os.path.join(fn, "*.parquet"),
         index=["a"],
-        engine=read_engine,
         calculate_divisions=True,
+        **read_engine,
     )
     assert_eq(ddf, read_df)
 
 
-@write_read_engines()
 def test_read_glob(tmpdir, write_engine, read_engine):
     tmp_path = str(tmpdir)
-    ddf.to_parquet(tmp_path, engine=write_engine)
+    ddf.to_parquet(tmp_path, **write_engine)
     if os.path.exists(os.path.join(tmp_path, "_metadata")):
         os.unlink(os.path.join(tmp_path, "_metadata"))
     files = os.listdir(tmp_path)
@@ -228,36 +242,34 @@ def test_read_glob(tmpdir, write_engine, read_engine):
 
     ddf2 = dd.read_parquet(
         os.path.join(tmp_path, "*.parquet"),
-        engine=read_engine,
         index="myindex",  # Must specify index without _metadata
         calculate_divisions=True,
+        **read_engine,
     )
     assert_eq(ddf, ddf2)
 
 
-@write_read_engines()
 def test_calculate_divisions_false(tmpdir, write_engine, read_engine):
     tmp_path = str(tmpdir)
-    ddf.to_parquet(tmp_path, write_index=False, engine=write_engine)
+    ddf.to_parquet(tmp_path, write_index=False, **write_engine)
 
     ddf2 = dd.read_parquet(
         tmp_path,
-        engine=read_engine,
         index=False,
         calculate_divisions=False,
+        **read_engine,
     )
     assert_eq(ddf, ddf2, check_index=False, check_divisions=False)
 
 
-@write_read_engines()
 def test_read_list(tmpdir, write_engine, read_engine):
-    if write_engine == read_engine == "fastparquet" and os.name == "nt":
+    if write_engine == read_engine == {"engine": "fastparquet"} and os.name == "nt":
         # fastparquet or dask is not normalizing filepaths correctly on
         # windows.
         pytest.skip("filepath bug.")
 
     tmpdir = str(tmpdir)
-    ddf.to_parquet(tmpdir, engine=write_engine)
+    ddf.to_parquet(tmpdir, **write_engine)
     files = sorted(
         (
             os.path.join(tmpdir, f)
@@ -268,26 +280,25 @@ def test_read_list(tmpdir, write_engine, read_engine):
     )
 
     ddf2 = dd.read_parquet(
-        files, engine=read_engine, index="myindex", calculate_divisions=True
+        files, index="myindex", calculate_divisions=True, **read_engine
     )
     assert_eq(ddf, ddf2)
 
 
-@write_read_engines()
 def test_columns_auto_index(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
-    ddf.to_parquet(fn, engine=write_engine)
+    ddf.to_parquet(fn, **write_engine)
 
     # ### Empty columns ###
     # With divisions if supported
     assert_eq(
-        dd.read_parquet(fn, columns=[], engine=read_engine, calculate_divisions=True),
+        dd.read_parquet(fn, columns=[], calculate_divisions=True, **read_engine),
         ddf[[]],
     )
 
     # No divisions
     assert_eq(
-        dd.read_parquet(fn, columns=[], engine=read_engine, calculate_divisions=False),
+        dd.read_parquet(fn, columns=[], calculate_divisions=False, **read_engine),
         ddf[[]].clear_divisions(),
         check_divisions=True,
     )
@@ -295,26 +306,21 @@ def test_columns_auto_index(tmpdir, write_engine, read_engine):
     # ### Single column, auto select index ###
     # With divisions if supported
     assert_eq(
-        dd.read_parquet(
-            fn, columns=["x"], engine=read_engine, calculate_divisions=True
-        ),
+        dd.read_parquet(fn, columns=["x"], calculate_divisions=True, **read_engine),
         ddf[["x"]],
     )
 
     # No divisions
     assert_eq(
-        dd.read_parquet(
-            fn, columns=["x"], engine=read_engine, calculate_divisions=False
-        ),
+        dd.read_parquet(fn, columns=["x"], calculate_divisions=False, **read_engine),
         ddf[["x"]].clear_divisions(),
         check_divisions=True,
     )
 
 
-@write_read_engines()
 def test_columns_index(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
-    ddf.to_parquet(fn, engine=write_engine)
+    ddf.to_parquet(fn, **write_engine)
 
     # With Index
     # ----------
@@ -324,9 +330,9 @@ def test_columns_index(tmpdir, write_engine, read_engine):
         dd.read_parquet(
             fn,
             columns=[],
-            engine=read_engine,
             index="myindex",
             calculate_divisions=True,
+            **read_engine,
         ),
         ddf[[]],
     )
@@ -336,9 +342,9 @@ def test_columns_index(tmpdir, write_engine, read_engine):
         dd.read_parquet(
             fn,
             columns=[],
-            engine=read_engine,
             index="myindex",
             calculate_divisions=False,
+            **read_engine,
         ),
         ddf[[]].clear_divisions(),
         check_divisions=True,
@@ -351,8 +357,8 @@ def test_columns_index(tmpdir, write_engine, read_engine):
             fn,
             index="myindex",
             columns=["x"],
-            engine=read_engine,
             calculate_divisions=True,
+            **read_engine,
         ),
         ddf[["x"]],
     )
@@ -363,8 +369,8 @@ def test_columns_index(tmpdir, write_engine, read_engine):
             fn,
             index="myindex",
             columns=["x"],
-            engine=read_engine,
             calculate_divisions=False,
+            **read_engine,
         ),
         ddf[["x"]].clear_divisions(),
         check_divisions=True,
@@ -377,8 +383,8 @@ def test_columns_index(tmpdir, write_engine, read_engine):
             fn,
             index="myindex",
             columns=["x", "y"],
-            engine=read_engine,
             calculate_divisions=True,
+            **read_engine,
         ),
         ddf,
     )
@@ -389,8 +395,8 @@ def test_columns_index(tmpdir, write_engine, read_engine):
             fn,
             index="myindex",
             columns=["x", "y"],
-            engine=read_engine,
             calculate_divisions=False,
+            **read_engine,
         ),
         ddf.clear_divisions(),
         check_divisions=True,
@@ -399,24 +405,23 @@ def test_columns_index(tmpdir, write_engine, read_engine):
 
 def test_nonsense_column(tmpdir, engine):
     fn = str(tmpdir)
-    ddf.to_parquet(fn, engine=engine)
+    ddf.to_parquet(fn, **engine)
     with pytest.raises((ValueError, KeyError)):
-        dd.read_parquet(fn, columns=["nonesense"], engine=engine)
+        dd.read_parquet(fn, columns=["nonsense"], **engine)
     with pytest.raises((Exception, KeyError)):
-        dd.read_parquet(fn, columns=["nonesense"] + list(ddf.columns), engine=engine)
+        dd.read_parquet(fn, columns=["nonsense"] + list(ddf.columns), **engine)
 
 
-@write_read_engines()
 def test_columns_no_index(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
-    ddf.to_parquet(fn, engine=write_engine)
+    ddf.to_parquet(fn, **write_engine)
     ddf2 = ddf.reset_index()
 
     # No Index
     # --------
     # All columns, none as index
     assert_eq(
-        dd.read_parquet(fn, index=False, engine=read_engine, calculate_divisions=True),
+        dd.read_parquet(fn, index=False, calculate_divisions=True, **read_engine),
         ddf2,
         check_index=False,
         check_divisions=True,
@@ -428,8 +433,8 @@ def test_columns_no_index(tmpdir, write_engine, read_engine):
             fn,
             index=False,
             columns=["x", "y"],
-            engine=read_engine,
             calculate_divisions=True,
+            **read_engine,
         ),
         ddf2[["x", "y"]],
         check_index=False,
@@ -442,8 +447,8 @@ def test_columns_no_index(tmpdir, write_engine, read_engine):
             fn,
             index=False,
             columns=["myindex", "x"],
-            engine=read_engine,
             calculate_divisions=True,
+            **read_engine,
         ),
         ddf2[["myindex", "x"]],
         check_index=False,
@@ -451,12 +456,11 @@ def test_columns_no_index(tmpdir, write_engine, read_engine):
     )
 
 
-@write_read_engines()
 def test_calculate_divisions_no_index(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
-    ddf.to_parquet(fn, engine=write_engine, write_index=False)
+    ddf.to_parquet(fn, write_index=False, **write_engine)
 
-    df = dd.read_parquet(fn, engine=read_engine, index=False)
+    df = dd.read_parquet(fn, index=False, **read_engine)
     assert df.index.name is None
     assert not df.known_divisions
 
@@ -469,47 +473,47 @@ def test_columns_index_with_multi_index(tmpdir, engine):
     df = pd.DataFrame(np.random.randn(10, 2), columns=["a", "b"], index=index)
     df2 = df.reset_index(drop=False)
 
-    if engine == "fastparquet":
+    if engine == {"engine": "fastparquet"}:
         fastparquet.write(fn, df.reset_index(), write_index=False)
 
     else:
         pq.write_table(pa.Table.from_pandas(df.reset_index(), preserve_index=False), fn)
 
-    ddf = dd.read_parquet(fn, engine=engine, index=index.names)
+    ddf = dd.read_parquet(fn, index=index.names, **engine)
     assert_eq(ddf, df)
 
-    d = dd.read_parquet(fn, columns="a", engine=engine, index=index.names)
+    d = dd.read_parquet(fn, columns="a", index=index.names, **engine)
     assert_eq(d, df["a"])
 
-    d = dd.read_parquet(fn, index=["a", "b"], columns=["x0", "x1"], engine=engine)
+    d = dd.read_parquet(fn, index=["a", "b"], columns=["x0", "x1"], **engine)
     assert_eq(d, df2.set_index(["a", "b"])[["x0", "x1"]])
 
     # Just index
-    d = dd.read_parquet(fn, index=False, engine=engine)
+    d = dd.read_parquet(fn, index=False, **engine)
     assert_eq(d, df2)
 
-    d = dd.read_parquet(fn, columns=["b"], index=["a"], engine=engine)
+    d = dd.read_parquet(fn, columns=["b"], index=["a"], **engine)
     assert_eq(d, df2.set_index("a")[["b"]])
 
-    d = dd.read_parquet(fn, columns=["a", "b"], index=["x0"], engine=engine)
+    d = dd.read_parquet(fn, columns=["a", "b"], index=["x0"], **engine)
     assert_eq(d, df2.set_index("x0")[["a", "b"]])
 
     # Just columns
-    d = dd.read_parquet(fn, columns=["x0", "a"], index=["x1"], engine=engine)
+    d = dd.read_parquet(fn, columns=["x0", "a"], index=["x1"], **engine)
     assert_eq(d, df2.set_index("x1")[["x0", "a"]])
 
     # Both index and columns
-    d = dd.read_parquet(fn, index=False, columns=["x0", "b"], engine=engine)
+    d = dd.read_parquet(fn, index=False, columns=["x0", "b"], **engine)
     assert_eq(d, df2[["x0", "b"]])
 
     for index in ["x1", "b"]:
-        d = dd.read_parquet(fn, index=index, columns=["x0", "a"], engine=engine)
+        d = dd.read_parquet(fn, index=index, columns=["x0", "a"], **engine)
         assert_eq(d, df2.set_index(index)[["x0", "a"]])
 
     # Columns and index intersect
     for index in ["a", "x0"]:
         with pytest.raises(ValueError):
-            d = dd.read_parquet(fn, index=index, columns=["x0", "a"], engine=engine)
+            d = dd.read_parquet(fn, index=index, columns=["x0", "a"], **engine)
 
     # Series output
     for ind, col, sol_df in [
@@ -519,40 +523,39 @@ def test_columns_index_with_multi_index(tmpdir, engine):
         ("a", "x0", df2.set_index("a")[["x0"]]),
         ("a", "b", df2.set_index("a")),
     ]:
-        d = dd.read_parquet(fn, index=ind, columns=col, engine=engine)
+        d = dd.read_parquet(fn, index=ind, columns=col, **engine)
         assert_eq(d, sol_df[col])
 
 
-@write_read_engines()
 def test_no_index(tmpdir, write_engine, read_engine):
     fn = str(tmpdir)
     df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     ddf = dd.from_pandas(df, npartitions=2)
-    ddf.to_parquet(fn, engine=write_engine)
-    ddf2 = dd.read_parquet(fn, engine=read_engine)
+    ddf.to_parquet(fn, **write_engine)
+    ddf2 = dd.read_parquet(fn, **read_engine)
     assert_eq(df, ddf2, check_index=False)
 
 
 def test_read_series(tmpdir, engine):
     fn = str(tmpdir)
-    ddf.to_parquet(fn, engine=engine)
+    ddf.to_parquet(fn, **engine)
     ddf2 = dd.read_parquet(
-        fn, columns=["x"], index="myindex", engine=engine, calculate_divisions=True
+        fn, columns=["x"], index="myindex", calculate_divisions=True, **engine
     )
     assert_eq(ddf[["x"]], ddf2)
 
     ddf2 = dd.read_parquet(
-        fn, columns="x", index="myindex", engine=engine, calculate_divisions=True
+        fn, columns="x", index="myindex", calculate_divisions=True, **engine
     )
     assert_eq(ddf.x, ddf2)
 
 
 def test_names(tmpdir, engine):
     fn = str(tmpdir)
-    ddf.to_parquet(fn, engine=engine)
+    ddf.to_parquet(fn, **engine)
 
     def read(fn, **kwargs):
-        return dd.read_parquet(fn, engine=engine, **kwargs)
+        return dd.read_parquet(fn, **engine, **kwargs)
 
     assert set(read(fn).dask) == set(read(fn).dask)
 
@@ -561,27 +564,20 @@ def test_names(tmpdir, engine):
     assert set(read(fn, columns=("x",)).dask) == set(read(fn, columns=["x"]).dask)
 
 
-@write_read_engines()
 def test_roundtrip_from_pandas(tmpdir, write_engine, read_engine):
     fn = str(tmpdir.join("test.parquet"))
     dfp = df.copy()
     dfp.index.name = "index"
-    dfp.to_parquet(
-        fn, engine="pyarrow" if write_engine.startswith("pyarrow") else "fastparquet"
-    )
-    ddf = dd.read_parquet(fn, index="index", engine=read_engine)
+    dfp.to_parquet(fn, **write_engine)
+    ddf = dd.read_parquet(fn, index="index", **read_engine)
     assert_eq(dfp, ddf)
 
 
-@write_read_engines()
-def test_roundtrip_nullable_dtypes(tmp_path, write_engine, read_engine):
-    """
-    Test round-tripping nullable extension dtypes. Parquet engines will
+@PYARROW_MARK
+def test_roundtrip_nullable_dtypes(tmp_path):
+    """Test round-tripping nullable extension dtypes. Parquet engines will
     typically add dtype metadata for this.
     """
-    if read_engine == "fastparquet" or write_engine == "fastparquet":
-        pytest.xfail("https://github.com/dask/fastparquet/issues/465")
-
     df = pd.DataFrame(
         {
             "a": pd.Series([1, 2, pd.NA, 3, 4], dtype="Int64"),
@@ -591,8 +587,8 @@ def test_roundtrip_nullable_dtypes(tmp_path, write_engine, read_engine):
         }
     )
     ddf = dd.from_pandas(df, npartitions=2)
-    ddf.to_parquet(tmp_path, engine=write_engine)
-    ddf2 = dd.read_parquet(tmp_path, engine=read_engine)
+    ddf.to_parquet(tmp_path)
+    ddf2 = dd.read_parquet(tmp_path)
     assert_eq(df, ddf2)
 
 
@@ -639,23 +635,21 @@ def test_use_nullable_dtypes(tmp_path, dtype_backend, engine):
     dask.compute([write_partition(p, i) for i, p in enumerate(partitions)])
 
     # Not supported by fastparquet
-    if engine == "fastparquet":
+    if engine == {"engine": "fastparquet"}:
         with pytest.raises(ValueError, match="`use_nullable_dtypes` is not supported"):
-            dd.read_parquet(tmp_path, engine=engine, use_nullable_dtypes=True)
+            dd.read_parquet(tmp_path, use_nullable_dtypes=True, **engine)
 
     # Works in pyarrow
     else:
         # Doesn't round-trip by default when we aren't using nullable dtypes
         with dask.config.set({"dataframe.dtype_backend": dtype_backend}):
             with pytest.raises(AssertionError):
-                ddf2 = dd.read_parquet(tmp_path, engine=engine)
+                ddf2 = dd.read_parquet(tmp_path, **engine)
                 assert_eq(df, ddf2)
 
             # Round trip works when we use nullable dtypes
             with pytest.warns(FutureWarning, match="use_nullable_dtypes"):
-                ddf2 = dd.read_parquet(
-                    tmp_path, engine=engine, use_nullable_dtypes=True
-                )
+                ddf2 = dd.read_parquet(tmp_path, use_nullable_dtypes=True, **engine)
                 assert_eq(df, ddf2, check_index=False)
 
 
@@ -672,14 +666,13 @@ def test_use_nullable_dtypes_with_types_mapper(tmp_path, engine):
         }
     )
     ddf = dd.from_pandas(df, npartitions=3)
-    ddf.to_parquet(tmp_path, engine=engine)
+    ddf.to_parquet(tmp_path, **engine)
 
     types_mapper = {
         pa.int64(): pd.Float32Dtype(),
     }
     result = dd.read_parquet(
         tmp_path,
-        engine="pyarrow",
         dtype_backend="numpy_nullable",
         arrow_to_pandas={"types_mapper": types_mapper.get},
     )
@@ -691,31 +684,31 @@ def test_use_nullable_dtypes_with_types_mapper(tmp_path, engine):
     assert_eq(result, expected)
 
 
-@write_read_engines()
 def test_categorical(tmpdir, write_engine, read_engine):
-    if write_engine == "fastparquet" and read_engine == "pyarrow":
+    if write_engine == {"engine": "fastparquet"} and read_engine == {}:
         pytest.xfail("Known limitation")
+
     tmp = str(tmpdir)
     df = pd.DataFrame({"x": ["a", "b", "c"] * 100}, dtype="category")
     ddf = dd.from_pandas(df, npartitions=3)
-    dd.to_parquet(ddf, tmp, engine=write_engine)
+    dd.to_parquet(ddf, tmp, **write_engine)
 
-    ddf2 = dd.read_parquet(tmp, categories="x", engine=read_engine)
+    ddf2 = dd.read_parquet(tmp, categories="x", **read_engine)
     assert ddf2.compute().x.cat.categories.tolist() == ["a", "b", "c"]
 
-    ddf2 = dd.read_parquet(tmp, categories=["x"], engine=read_engine)
+    ddf2 = dd.read_parquet(tmp, categories=["x"], **read_engine)
     assert ddf2.compute().x.cat.categories.tolist() == ["a", "b", "c"]
 
     # autocat
-    if read_engine == "fastparquet":
-        ddf2 = dd.read_parquet(tmp, engine=read_engine)
+    if read_engine == {"engine": "fastparquet"}:
+        ddf2 = dd.read_parquet(tmp, **read_engine)
         assert ddf2.compute().x.cat.categories.tolist() == ["a", "b", "c"]
 
         ddf2.loc[:1000].compute()
         assert assert_eq(df, ddf2)
 
     # dereference cats
-    ddf2 = dd.read_parquet(tmp, categories=[], engine=read_engine)
+    ddf2 = dd.read_parquet(tmp, categories=[], **read_engine)
 
     ddf2.loc[:1000].compute()
     assert (df.x == ddf2.x.compute()).all()
@@ -740,17 +733,17 @@ def test_append(tmpdir, engine, metadata_file):
     half = len(df) // 2
     ddf1 = dd.from_pandas(df.iloc[:half], chunksize=100)
     ddf2 = dd.from_pandas(df.iloc[half:], chunksize=100)
-    ddf1.to_parquet(tmp, engine=engine, write_metadata_file=metadata_file)
+    ddf1.to_parquet(tmp, write_metadata_file=metadata_file, **engine)
     if metadata_file:
         with open(str(tmpdir.join("_metadata")), "rb") as f:
             metadata1 = f.read()
-    ddf2.to_parquet(tmp, append=True, engine=engine)
+    ddf2.to_parquet(tmp, append=True, **engine)
     if metadata_file:
         with open(str(tmpdir.join("_metadata")), "rb") as f:
             metadata2 = f.read()
         assert metadata2 != metadata1  # 2nd write updated the metadata file
 
-    ddf3 = dd.read_parquet(tmp, engine=engine)
+    ddf3 = dd.read_parquet(tmp, **engine)
     assert_eq(df, ddf3)
 
 
@@ -772,10 +765,10 @@ def test_append_create(tmpdir, engine):
     half = len(df) // 2
     ddf1 = dd.from_pandas(df.iloc[:half], chunksize=100)
     ddf2 = dd.from_pandas(df.iloc[half:], chunksize=100)
-    ddf1.to_parquet(tmp_path, append=True, engine=engine)
-    ddf2.to_parquet(tmp_path, append=True, engine=engine)
+    ddf1.to_parquet(tmp_path, append=True, **engine)
+    ddf2.to_parquet(tmp_path, append=True, **engine)
 
-    ddf3 = dd.read_parquet(tmp_path, engine=engine)
+    ddf3 = dd.read_parquet(tmp_path, **engine)
     assert_eq(df, ddf3)
 
 
@@ -806,18 +799,18 @@ def test_append_with_partition(tmpdir, engine):
 
     dd_df0 = dd.from_pandas(df0, npartitions=1)
     dd_df1 = dd.from_pandas(df1, npartitions=1)
-    dd.to_parquet(dd_df0, tmp, partition_on=["lon"], engine=engine)
+    dd.to_parquet(dd_df0, tmp, partition_on=["lon"], **engine)
     dd.to_parquet(
         dd_df1,
         tmp,
         partition_on=["lon"],
         append=True,
         ignore_divisions=True,
-        engine=engine,
+        **engine,
     )
 
     out = dd.read_parquet(
-        tmp, engine=engine, index="index", calculate_divisions=True
+        tmp, index="index", calculate_divisions=True, **engine
     ).compute()
     # convert categorical to plain int just to pass assert
     out["lon"] = out.lon.astype("int64")
@@ -837,8 +830,8 @@ def test_partition_on_cats(tmpdir, engine):
         }
     )
     d = dd.from_pandas(d, 2)
-    d.to_parquet(tmp, partition_on=["b"], engine=engine)
-    df = dd.read_parquet(tmp, engine=engine)
+    d.to_parquet(tmp, partition_on=["b"], **engine)
+    df = dd.read_parquet(tmp, **engine)
     assert set(df.b.cat.categories) == {"x", "y", "z"}
 
 
@@ -855,8 +848,8 @@ def test_partition_on_cats_pyarrow(tmpdir, stats, meta):
         }
     )
     d = dd.from_pandas(d, 2)
-    d.to_parquet(tmp, partition_on=["b"], engine="pyarrow", write_metadata_file=meta)
-    df = dd.read_parquet(tmp, engine="pyarrow", calculate_divisions=stats)
+    d.to_parquet(tmp, partition_on=["b"], write_metadata_file=meta)
+    df = dd.read_parquet(tmp, calculate_divisions=stats)
     assert set(df.b.cat.categories) == {"x", "y", "z"}
 
 
@@ -872,10 +865,8 @@ def test_partition_parallel_metadata(tmpdir, engine):
         }
     )
     d = dd.from_pandas(d, 2)
-    d.to_parquet(tmp, partition_on=["b"], engine=engine, write_metadata_file=False)
-    df = dd.read_parquet(
-        tmp, engine=engine, calculate_divisions=True, metadata_task_size=1
-    )
+    d.to_parquet(tmp, partition_on=["b"], write_metadata_file=False, **engine)
+    df = dd.read_parquet(tmp, calculate_divisions=True, metadata_task_size=1, **engine)
     assert set(df.b.cat.categories) == {"x", "y", "z"}
 
 
@@ -889,20 +880,20 @@ def test_partition_on_cats_2(tmpdir, engine):
         }
     )
     d = dd.from_pandas(d, 2)
-    d.to_parquet(tmp, partition_on=["b", "c"], engine=engine)
-    df = dd.read_parquet(tmp, engine=engine)
+    d.to_parquet(tmp, partition_on=["b", "c"], **engine)
+    df = dd.read_parquet(tmp, **engine)
     assert set(df.b.cat.categories) == {"x", "y", "z"}
     assert set(df.c.cat.categories) == {"x", "y", "z"}
 
-    df = dd.read_parquet(tmp, columns=["a", "c"], engine=engine)
+    df = dd.read_parquet(tmp, columns=["a", "c"], **engine)
     assert set(df.c.cat.categories) == {"x", "y", "z"}
     assert "b" not in df.columns
     assert_eq(df, df.compute())
-    df = dd.read_parquet(tmp, index="c", engine=engine)
+    df = dd.read_parquet(tmp, index="c", **engine)
     assert set(df.index.categories) == {"x", "y", "z"}
     assert "c" not in df.columns
     # series
-    df = dd.read_parquet(tmp, columns="b", engine=engine)
+    df = dd.read_parquet(tmp, columns="b", **engine)
     assert set(df.cat.categories) == {"x", "y", "z"}
 
 
@@ -923,19 +914,17 @@ def test_append_wo_index(tmpdir, engine, metadata_file):
     half = len(df) // 2
     ddf1 = dd.from_pandas(df.iloc[:half], chunksize=100)
     ddf2 = dd.from_pandas(df.iloc[half:], chunksize=100)
-    ddf1.to_parquet(tmp, engine=engine, write_metadata_file=metadata_file)
+    ddf1.to_parquet(tmp, write_metadata_file=metadata_file, **engine)
 
     with pytest.raises(ValueError) as excinfo:
-        ddf2.to_parquet(tmp, write_index=False, append=True, engine=engine)
+        ddf2.to_parquet(tmp, write_index=False, append=True, **engine)
     assert "Appended columns" in str(excinfo.value)
 
     tmp = str(tmpdir.join("tmp2.parquet"))
-    ddf1.to_parquet(
-        tmp, write_index=False, engine=engine, write_metadata_file=metadata_file
-    )
-    ddf2.to_parquet(tmp, write_index=False, append=True, engine=engine)
+    ddf1.to_parquet(tmp, write_index=False, write_metadata_file=metadata_file, **engine)
+    ddf2.to_parquet(tmp, write_index=False, append=True, **engine)
 
-    ddf3 = dd.read_parquet(tmp, index="f", engine=engine)
+    ddf3 = dd.read_parquet(tmp, index="f", **engine)
     assert_eq(df.set_index("f"), ddf3)
 
 
@@ -969,12 +958,12 @@ def test_append_overlapping_divisions(tmpdir, engine, metadata_file, index, offs
     )
     ddf1 = dd.from_pandas(df, chunksize=100)
     ddf2 = dd.from_pandas(df.set_index(df.index + offset), chunksize=100)
-    ddf1.to_parquet(tmp, engine=engine, write_metadata_file=metadata_file)
+    ddf1.to_parquet(tmp, write_metadata_file=metadata_file, **engine)
 
     with pytest.raises(ValueError, match="overlap with previously written divisions"):
-        ddf2.to_parquet(tmp, engine=engine, append=True)
+        ddf2.to_parquet(tmp, append=True, **engine)
 
-    ddf2.to_parquet(tmp, engine=engine, append=True, ignore_divisions=True)
+    ddf2.to_parquet(tmp, append=True, ignore_divisions=True, **engine)
 
 
 def test_append_known_divisions_to_unknown_divisions_works(tmpdir, engine):
@@ -997,10 +986,10 @@ def test_append_known_divisions_to_unknown_divisions_works(tmpdir, engine):
     # sorted, then we want to skip erroring for overlapping divisions. Setting
     # `write_metadata_file=True` ensures this test works the same across both
     # engines.
-    ddf1.to_parquet(tmp, engine=engine, write_metadata_file=True)
-    ddf2.to_parquet(tmp, engine=engine, append=True)
+    ddf1.to_parquet(tmp, write_metadata_file=True, **engine)
+    ddf2.to_parquet(tmp, append=True, **engine)
 
-    res = dd.read_parquet(tmp, engine=engine)
+    res = dd.read_parquet(tmp, **engine)
     sol = pd.concat([df1, df2])
     assert_eq(res, sol)
 
@@ -1017,24 +1006,23 @@ def test_append_different_columns(tmpdir, engine, metadata_file):
     ddf2 = dd.from_pandas(df2, chunksize=2)
     ddf3 = dd.from_pandas(df3, chunksize=2)
 
-    ddf1.to_parquet(tmp, engine=engine, write_metadata_file=metadata_file)
+    ddf1.to_parquet(tmp, write_metadata_file=metadata_file, **engine)
 
     with pytest.raises(ValueError) as excinfo:
-        ddf2.to_parquet(tmp, engine=engine, append=True)
+        ddf2.to_parquet(tmp, append=True, **engine)
     assert "Appended columns" in str(excinfo.value)
 
     with pytest.raises(ValueError) as excinfo:
-        ddf3.to_parquet(tmp, engine=engine, append=True)
+        ddf3.to_parquet(tmp, append=True, **engine)
     assert "Appended dtypes" in str(excinfo.value)
 
 
+@PYARROW_MARK
 @pytest.mark.skip_with_pyarrow_strings  # need an object to store a dict
-def test_append_dict_column(tmpdir, engine):
-    # See: https://github.com/dask/dask/issues/7492
-
-    if engine == "fastparquet":
-        pytest.xfail("Fastparquet engine is missing dict-column support")
-
+def test_append_dict_column(tmpdir):
+    """See: https://github.com/dask/dask/issues/7492
+    Note: fastparquet engine is missing dict-column support
+    """
     tmp = str(tmpdir)
     dts = pd.date_range("2020-01-01", "2021-01-01")
     df = pd.DataFrame(
@@ -1046,13 +1034,11 @@ def test_append_dict_column(tmpdir, engine):
     schema = {"value": pa.struct([("x", pa.int32())])}
 
     # Write ddf1 to tmp, and then append it again
-    ddf1.to_parquet(tmp, append=True, engine=engine, schema=schema)
-    ddf1.to_parquet(
-        tmp, append=True, engine=engine, schema=schema, ignore_divisions=True
-    )
+    ddf1.to_parquet(tmp, append=True, schema=schema)
+    ddf1.to_parquet(tmp, append=True, schema=schema, ignore_divisions=True)
 
     # Read back all data (ddf1 + ddf1)
-    ddf2 = dd.read_parquet(tmp, engine=engine)
+    ddf2 = dd.read_parquet(tmp)
 
     # Check computed result
     expect = pd.concat([df, df])
@@ -1060,7 +1046,6 @@ def test_append_dict_column(tmpdir, engine):
     assert_eq(expect, result)
 
 
-@write_read_engines()
 def test_ordering(tmpdir, write_engine, read_engine):
     tmp = str(tmpdir)
     df = pd.DataFrame(
@@ -1069,9 +1054,9 @@ def test_ordering(tmpdir, write_engine, read_engine):
         columns=["c", "a", "b"],
     )
     ddf = dd.from_pandas(df, npartitions=2)
-    dd.to_parquet(ddf, tmp, engine=write_engine)
+    dd.to_parquet(ddf, tmp, **write_engine)
 
-    ddf2 = dd.read_parquet(tmp, index="myindex", engine=read_engine)
+    ddf2 = dd.read_parquet(tmp, index="myindex", **read_engine)
     assert_eq(ddf, ddf2, check_divisions=False)
 
 
@@ -1081,21 +1066,17 @@ def test_read_parquet_custom_columns(tmpdir, engine):
         {"i32": np.arange(1000, dtype=np.int32), "f": np.arange(1000, dtype=np.float64)}
     )
     df = dd.from_pandas(data, chunksize=50)
-    df.to_parquet(tmp, engine=engine)
+    df.to_parquet(tmp, **engine)
 
-    df2 = dd.read_parquet(
-        tmp, columns=["i32", "f"], engine=engine, calculate_divisions=True
-    )
+    df2 = dd.read_parquet(tmp, columns=["i32", "f"], calculate_divisions=True, **engine)
     assert_eq(df[["i32", "f"]], df2, check_index=False)
 
     fns = glob.glob(os.path.join(tmp, "*.parquet"))
-    df2 = dd.read_parquet(fns, columns=["i32"], engine=engine).compute()
+    df2 = dd.read_parquet(fns, columns=["i32"], **engine).compute()
     df2.sort_values("i32", inplace=True)
     assert_eq(df[["i32"]], df2, check_index=False, check_divisions=False)
 
-    df3 = dd.read_parquet(
-        tmp, columns=["f", "i32"], engine=engine, calculate_divisions=True
-    )
+    df3 = dd.read_parquet(tmp, columns=["f", "i32"], calculate_divisions=True, **engine)
     assert_eq(df[["f", "i32"]], df3, check_index=False)
 
 
@@ -1139,12 +1120,12 @@ def test_read_parquet_custom_columns(tmpdir, engine):
 )
 @pytest.mark.skip_with_pyarrow_strings  # don't want to convert binary data to pyarrow strings
 def test_roundtrip(tmpdir, df, write_kwargs, read_kwargs, engine):
-    if "x" in df and df.x.dtype == "M8[ns]" and "arrow" in engine:
+    if "x" in df and df.x.dtype == "M8[ns]" and engine == {}:
         pytest.xfail(reason="Parquet pyarrow v1 doesn't support nanosecond precision")
     if (
         "x" in df
         and df.x.dtype == "M8[ns]"
-        and engine == "fastparquet"
+        and engine == {"engine": "fastparquet"}
         and fastparquet_version <= parse_version("0.6.3")
     ):
         pytest.xfail(reason="fastparquet doesn't support nanosecond precision yet")
@@ -1154,16 +1135,16 @@ def test_roundtrip(tmpdir, df, write_kwargs, read_kwargs, engine):
         and "x" in df
         and (df.x.dtype == "M8[ms]" or df.x.dtype == "M8[us]")
     ):
-        if engine == "pyarrow":
+        if engine == {}:  # pyarrow
             pytest.xfail("https://github.com/apache/arrow/issues/15079")
-        elif engine == "fastparquet" and fastparquet_version <= parse_version(
-            "2022.12.0"
-        ):
+        elif engine == {
+            "engine": "fastparquet"
+        } and fastparquet_version <= parse_version("2022.12.0"):
             pytest.xfail(reason="https://github.com/dask/fastparquet/issues/837")
 
     if (
         read_kwargs.get("categories", None)
-        and engine == "fastparquet"
+        and engine == {"engine": "fastparquet"}
         and fastparquet_version <= parse_version("0.6.3")
     ):
         pytest.xfail("https://github.com/dask/fastparquet/issues/577")
@@ -1174,14 +1155,14 @@ def test_roundtrip(tmpdir, df, write_kwargs, read_kwargs, engine):
     ddf = dd.from_pandas(df, npartitions=2)
 
     oe = write_kwargs.pop("object_encoding", None)
-    if oe and engine == "fastparquet":
-        dd.to_parquet(ddf, tmp, engine=engine, object_encoding=oe, **write_kwargs)
+    if oe and engine == {"engine": "fastparquet"}:
+        dd.to_parquet(ddf, tmp, object_encoding=oe, **engine, **write_kwargs)
     else:
-        dd.to_parquet(ddf, tmp, engine=engine, **write_kwargs)
+        dd.to_parquet(ddf, tmp, **engine, **write_kwargs)
     ddf2 = dd.read_parquet(
-        tmp, index=df.index.name, engine=engine, calculate_divisions=True, **read_kwargs
+        tmp, index=df.index.name, calculate_divisions=True, **engine, **read_kwargs
     )
-    if str(ddf2.dtypes.get("x")) == "UInt16" and engine == "fastparquet":
+    if str(ddf2.dtypes.get("x")) == "UInt16" and engine == {"engine": "fastparquet"}:
         # fastparquet choooses to use masked type to be able to get true repr of
         # 16-bit int
         assert_eq(ddf.astype("UInt16"), ddf2, check_divisions=False)
@@ -1197,20 +1178,19 @@ def test_categories(tmpdir, engine):
     fn = str(tmpdir)
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": list("caaab")})
 
-    ctx = contextlib.nullcontext
-    if engine == "fastparquet":
-        ctx = dask.config.set
-    with ctx({"dataframe.convert-string": False}):
+    if engine == {"engine": "fastparquet"}:
+        with dask.config.set({"dataframe.convert-string": False}):
+            ddf = dd.from_pandas(df, npartitions=2)
+            ddf["y"] = ddf.y.astype("category")
+    else:
         ddf = dd.from_pandas(df, npartitions=2)
         ddf["y"] = ddf.y.astype("category")
 
-    ddf.to_parquet(fn, engine=engine)
-    ddf2 = dd.read_parquet(
-        fn, categories=["y"], engine=engine, calculate_divisions=True
-    )
+    ddf.to_parquet(fn, **engine)
+    ddf2 = dd.read_parquet(fn, categories=["y"], calculate_divisions=True, **engine)
 
     # Shouldn't need to specify categories explicitly
-    ddf3 = dd.read_parquet(fn, engine=engine, calculate_divisions=True)
+    ddf3 = dd.read_parquet(fn, calculate_divisions=True, **engine)
     assert_eq(ddf3, ddf2)
 
     with pytest.raises(NotImplementedError):
@@ -1219,15 +1199,15 @@ def test_categories(tmpdir, engine):
     cats_set = ddf2.map_partitions(lambda x: x.y.cat.categories.sort_values()).compute()
     assert cats_set.tolist() == ["a", "c", "a", "b"]
 
-    if engine == "fastparquet":
+    if engine == {"engine": "fastparquet"}:
         assert_eq(ddf.y, ddf2.y, check_names=False)
         with pytest.raises(TypeError):
             # attempt to load as category that which is not so encoded
-            dd.read_parquet(fn, categories=["x"], engine=engine).compute()
+            dd.read_parquet(fn, categories=["x"], **engine).compute()
 
     with pytest.raises((ValueError, FutureWarning)):
         # attempt to load as category unknown column
-        dd.read_parquet(fn, categories=["foo"], engine=engine)
+        dd.read_parquet(fn, categories=["foo"], **engine)
 
 
 @pytest.mark.xfail_with_pyarrow_strings  # https://github.com/apache/arrow/issues/33727
@@ -1243,8 +1223,8 @@ def test_categories_unnamed_index(tmpdir, engine):
     ddf = dd.from_pandas(df, npartitions=1)
     ddf = ddf.categorize(columns=["B"])
 
-    ddf.to_parquet(tmpdir, engine=engine)
-    ddf2 = dd.read_parquet(tmpdir, engine=engine)
+    ddf.to_parquet(tmpdir, **engine)
+    ddf2 = dd.read_parquet(tmpdir, **engine)
 
     assert_eq(ddf.index, ddf2.index, check_divisions=False)
 
@@ -1255,11 +1235,11 @@ def test_empty_partition(tmpdir, engine):
     ddf = dd.from_pandas(df, npartitions=5)
 
     ddf2 = ddf[ddf.a <= 5]
-    ddf2.to_parquet(fn, engine=engine)
+    ddf2.to_parquet(fn, **engine)
 
     # Pyarrow engine will not filter out emtpy
     # partitions unless calculate_divisions=True
-    ddf3 = dd.read_parquet(fn, engine=engine, calculate_divisions=True)
+    ddf3 = dd.read_parquet(fn, calculate_divisions=True, **engine)
     assert ddf3.npartitions < 5
     sol = ddf2.compute()
     assert_eq(sol, ddf3, check_names=False, check_index=False)
@@ -1271,8 +1251,8 @@ def test_timestamp_index(tmpdir, engine, write_metadata):
     df = dd._compat.makeTimeDataFrame()
     df.index.name = "foo"
     ddf = dd.from_pandas(df, npartitions=5)
-    ddf.to_parquet(fn, engine=engine, write_metadata_file=write_metadata)
-    ddf2 = dd.read_parquet(fn, engine=engine, calculate_divisions=True)
+    ddf.to_parquet(fn, write_metadata_file=write_metadata, **engine)
+    ddf2 = dd.read_parquet(fn, calculate_divisions=True, **engine)
     assert_eq(ddf, ddf2)
 
 
@@ -1284,7 +1264,8 @@ def test_to_parquet_fastparquet_default_writes_nulls(tmpdir):
     df = pd.DataFrame({"c1": [1.0, np.nan, 2, np.nan, 3]})
     ddf = dd.from_pandas(df, npartitions=1)
 
-    ddf.to_parquet(fn, engine="fastparquet")
+    with pytest.warns(FutureWarning):
+        ddf.to_parquet(fn, engine="fastparquet")
     table = pq.read_table(fn)
     assert table[1].null_count == 2
 
@@ -1339,11 +1320,9 @@ def test_to_parquet_pyarrow_w_inconsistent_schema_by_partition_succeeds_w_manual
             ("partition_column", pa.int64()),
         ]
     )
-    ddf.to_parquet(
-        str(tmpdir), engine="pyarrow", partition_on="partition_column", schema=schema
-    )
+    ddf.to_parquet(str(tmpdir), partition_on="partition_column", schema=schema)
     ddf_after_write = (
-        dd.read_parquet(str(tmpdir), engine="pyarrow", calculate_divisions=False)
+        dd.read_parquet(str(tmpdir), calculate_divisions=False)
         .compute()
         .reset_index(drop=True)
     )
@@ -1409,8 +1388,8 @@ def test_pyarrow_schema_inference(tmpdir, index, schema):
     else:
         df = dd.from_pandas(df, npartitions=2)
 
-    df.to_parquet(tmpdir, engine="pyarrow", schema=schema)
-    df_out = dd.read_parquet(tmpdir, engine="pyarrow", calculate_divisions=True)
+    df.to_parquet(tmpdir, schema=schema)
+    df_out = dd.read_parquet(tmpdir, calculate_divisions=True)
     assert_eq(df, df_out)
 
 
@@ -1424,7 +1403,7 @@ def test_pyarrow_schema_mismatch_error(tmpdir):
     )
 
     with pytest.raises(ValueError) as rec:
-        ddf.to_parquet(str(tmpdir), engine="pyarrow")
+        ddf.to_parquet(str(tmpdir))
 
     msg = str(rec.value)
     assert "Failed to convert partition to expected pyarrow schema" in msg
@@ -1439,8 +1418,8 @@ def test_pyarrow_schema_mismatch_explicit_schema_none(tmpdir):
     ddf = dd.from_delayed(
         [dask.delayed(df1), dask.delayed(df2)], meta=df1, verify_meta=False
     )
-    ddf.to_parquet(str(tmpdir), engine="pyarrow", schema=None)
-    res = dd.read_parquet(tmpdir, engine="pyarrow")
+    ddf.to_parquet(str(tmpdir), schema=None)
+    res = dd.read_parquet(tmpdir)
     sol = pd.concat([df1, df2])
     # Only checking that the data was written correctly, we don't care about
     # the incorrect _meta from read_parquet
@@ -1459,17 +1438,17 @@ def test_partition_on(tmpdir, engine):
         }
     )
     d = dd.from_pandas(df, npartitions=2)
-    d.to_parquet(tmpdir, partition_on=["a1", "a2"], engine=engine)
+    d.to_parquet(tmpdir, partition_on=["a1", "a2"], **engine)
     # Note #1: Cross-engine functionality is missing
     # Note #2: The index is not preserved in pyarrow when partition_on is used
     out = dd.read_parquet(
-        tmpdir, engine=engine, index=False, calculate_divisions=False
+        tmpdir, index=False, calculate_divisions=False, **engine
     ).compute()
     for val in df.a1.unique():
         assert set(df.d[df.a1 == val]) == set(out.d[out.a1 == val])
 
     # Now specify the columns and allow auto-index detection
-    out = dd.read_parquet(tmpdir, engine=engine, columns=["d", "a2"]).compute()
+    out = dd.read_parquet(tmpdir, columns=["d", "a2"], **engine).compute()
     for val in df.a2.unique():
         assert set(df.d[df.a2 == val]) == set(out.d[out.a2 == val])
 
@@ -1487,9 +1466,9 @@ def test_partition_on_duplicates(tmpdir, engine):
     d = dd.from_pandas(df, npartitions=2)
 
     for _ in range(2):
-        d.to_parquet(tmpdir, partition_on=["a1", "a2"], engine=engine)
+        d.to_parquet(tmpdir, partition_on=["a1", "a2"], **engine)
 
-    out = dd.read_parquet(tmpdir, engine=engine).compute()
+    out = dd.read_parquet(tmpdir, **engine).compute()
 
     assert len(df) == len(out)
     for _, _, files in os.walk(tmpdir):
@@ -1516,18 +1495,14 @@ def test_partition_on_string(tmpdir, partition_on):
             }
         )
         d = dd.from_pandas(df, npartitions=2)
-        d.to_parquet(
-            tmpdir, partition_on=partition_on, write_index=False, engine="pyarrow"
-        )
-        out = dd.read_parquet(
-            tmpdir, index=False, calculate_divisions=False, engine="pyarrow"
-        )
+        d.to_parquet(tmpdir, partition_on=partition_on, write_index=False)
+        out = dd.read_parquet(tmpdir, index=False, calculate_divisions=False)
+
     out = out.compute()
     for val in df.aa.unique():
         assert set(df.bb[df.aa == val]) == set(out.bb[out.aa == val])
 
 
-@write_read_engines()
 def test_filters_categorical(tmpdir, write_engine, read_engine):
     tmpdir = str(tmpdir)
     cats = ["2018-01-01", "2018-01-02", "2018-01-03", "2018-01-04"]
@@ -1538,36 +1513,35 @@ def test_filters_categorical(tmpdir, write_engine, read_engine):
         }
     )
     ddftest = dd.from_pandas(dftest, npartitions=4).set_index("dummy")
-    ddftest.to_parquet(tmpdir, partition_on="DatePart", engine=write_engine)
+    ddftest.to_parquet(tmpdir, partition_on="DatePart", **write_engine)
     ddftest_read = dd.read_parquet(
         tmpdir,
         index="dummy",
-        engine=read_engine,
         filters=[(("DatePart", "<=", "2018-01-02"))],
         calculate_divisions=True,
+        **read_engine,
     )
     assert len(ddftest_read) == 2
 
 
-@write_read_engines()
 def test_filters(tmpdir, write_engine, read_engine):
     tmp_path = str(tmpdir)
     df = pd.DataFrame({"x": range(10), "y": list("aabbccddee")})
     ddf = dd.from_pandas(df, npartitions=5)
     assert ddf.npartitions == 5
 
-    ddf.to_parquet(tmp_path, engine=write_engine, write_metadata_file=True)
+    ddf.to_parquet(tmp_path, write_metadata_file=True, **write_engine)
 
-    a = dd.read_parquet(tmp_path, engine=read_engine, filters=[("x", ">", 4)])
+    a = dd.read_parquet(tmp_path, filters=[("x", ">", 4)], **read_engine)
     assert a.npartitions == 3
     assert (a.x > 3).all().compute()
 
-    b = dd.read_parquet(tmp_path, engine=read_engine, filters=[("y", "==", "c")])
+    b = dd.read_parquet(tmp_path, filters=[("y", "==", "c")], **read_engine)
     assert b.npartitions == 1
     assert (b.y == "c").all().compute()
 
     c = dd.read_parquet(
-        tmp_path, engine=read_engine, filters=[("y", "==", "c"), ("x", ">", 6)]
+        tmp_path, filters=[("y", "==", "c"), ("x", ">", 6)], **read_engine
     )
     assert c.npartitions <= 1
     assert not len(c)
@@ -1575,53 +1549,48 @@ def test_filters(tmpdir, write_engine, read_engine):
 
     d = dd.read_parquet(
         tmp_path,
-        engine=read_engine,
         filters=[
             # Select two overlapping ranges
             [("x", ">", 1), ("x", "<", 6)],
             [("x", ">", 3), ("x", "<", 8)],
         ],
+        **read_engine,
     )
     assert d.npartitions == 3
     assert ((d.x > 1) & (d.x < 8)).all().compute()
 
-    e = dd.read_parquet(tmp_path, engine=read_engine, filters=[("x", "in", (0, 9))])
+    e = dd.read_parquet(tmp_path, filters=[("x", "in", (0, 9))], **read_engine)
     assert e.npartitions == 2
     assert ((e.x < 2) | (e.x > 7)).all().compute()
 
-    f = dd.read_parquet(tmp_path, engine=read_engine, filters=[("y", "=", "c")])
+    f = dd.read_parquet(tmp_path, filters=[("y", "=", "c")], **read_engine)
     assert f.npartitions == 1
     assert len(f)
     assert (f.y == "c").all().compute()
 
-    g = dd.read_parquet(tmp_path, engine=read_engine, filters=[("x", "!=", 1)])
+    g = dd.read_parquet(tmp_path, filters=[("x", "!=", 1)], **read_engine)
     assert g.npartitions == 5
 
 
-@write_read_engines()
 def test_filters_v0(tmpdir, write_engine, read_engine):
-    if write_engine == "fastparquet" or read_engine == "fastparquet":
-        pytest.importorskip("fastparquet", minversion="0.3.1")
-
-    # Recent versions of pyarrow support full row-wise filtering
-    # (fastparquet and older pyarrow versions do not)
-    pyarrow_row_filtering = read_engine == "pyarrow"
-
     fn = str(tmpdir)
     df = pd.DataFrame({"at": ["ab", "aa", "ba", "da", "bb"]})
     ddf = dd.from_pandas(df, npartitions=1)
 
     # Ok with 1 partition and filters
     ddf.repartition(npartitions=1, force=True).to_parquet(
-        fn, write_index=False, engine=write_engine
+        fn, write_index=False, **write_engine
     )
     ddf2 = dd.read_parquet(
-        fn, index=False, engine=read_engine, filters=[("at", "==", "aa")]
+        fn, index=False, filters=[("at", "==", "aa")], **read_engine
     ).compute()
     ddf3 = dd.read_parquet(
-        fn, index=False, engine=read_engine, filters=[("at", "=", "aa")]
+        fn, index=False, filters=[("at", "=", "aa")], **read_engine
     ).compute()
-    if pyarrow_row_filtering:
+
+    # Recent versions of pyarrow support full row-wise filtering
+    # (fastparquet and older pyarrow versions do not)
+    if read_engine == {}:  # pyarrow
         assert_eq(ddf2, ddf[ddf["at"] == "aa"], check_index=False)
         assert_eq(ddf3, ddf[ddf["at"] == "aa"], check_index=False)
     else:
@@ -1629,44 +1598,39 @@ def test_filters_v0(tmpdir, write_engine, read_engine):
         assert_eq(ddf3, ddf)
 
     # with >1 partition and no filters
-    ddf.repartition(npartitions=2, force=True).to_parquet(fn, engine=write_engine)
-    ddf2 = dd.read_parquet(fn, engine=read_engine).compute()
+    ddf.repartition(npartitions=2, force=True).to_parquet(fn, **write_engine)
+    ddf2 = dd.read_parquet(fn, **read_engine).compute()
     assert_eq(ddf2, ddf)
 
     # with >1 partition and filters using base fastparquet
-    if read_engine == "fastparquet":
-        ddf.repartition(npartitions=2, force=True).to_parquet(fn, engine=write_engine)
+    if read_engine == {"engine": "fastparquet"}:
+        ddf.repartition(npartitions=2, force=True).to_parquet(fn, **write_engine)
         df2 = fastparquet.ParquetFile(fn).to_pandas(filters=[("at", "==", "aa")])
         df3 = fastparquet.ParquetFile(fn).to_pandas(filters=[("at", "=", "aa")])
         assert len(df2) > 0
         assert len(df3) > 0
 
     # with >1 partition and filters
-    ddf.repartition(npartitions=2, force=True).to_parquet(fn, engine=write_engine)
-    ddf2 = dd.read_parquet(
-        fn, engine=read_engine, filters=[("at", "==", "aa")]
-    ).compute()
-    ddf3 = dd.read_parquet(
-        fn, engine=read_engine, filters=[("at", "=", "aa")]
-    ).compute()
+    ddf.repartition(npartitions=2, force=True).to_parquet(fn, **write_engine)
+    ddf2 = dd.read_parquet(fn, filters=[("at", "==", "aa")], **read_engine).compute()
+    ddf3 = dd.read_parquet(fn, filters=[("at", "=", "aa")], **read_engine).compute()
     assert len(ddf2) > 0
     assert len(ddf3) > 0
     assert_eq(ddf2, ddf3)
 
 
+@PYARROW_MARK
 def test_filtering_pyarrow_dataset(tmpdir, engine):
-    pytest.importorskip("pyarrow", minversion="1.0.0")
-
     fn = str(tmpdir)
     df = pd.DataFrame({"aa": range(100), "bb": ["cat", "dog"] * 50})
     ddf = dd.from_pandas(df, npartitions=10)
-    ddf.to_parquet(fn, write_index=False, engine=engine, write_metadata_file=True)
+    ddf.to_parquet(fn, write_index=False, write_metadata_file=True, **engine)
 
     # Filtered read
     aa_lim = 40
     bb_val = "dog"
     filters = [[("aa", "<", aa_lim), ("bb", "==", bb_val)]]
-    ddf2 = dd.read_parquet(fn, index=False, engine="pyarrow", filters=filters)
+    ddf2 = dd.read_parquet(fn, index=False, filters=filters)
 
     # Check that partitions are filtered for "aa" filter
     nonempty = 0
@@ -1684,10 +1648,10 @@ def test_filters_file_list(tmpdir, engine):
     df = pd.DataFrame({"x": range(10), "y": list("aabbccddee")})
     ddf = dd.from_pandas(df, npartitions=5)
 
-    ddf.to_parquet(str(tmpdir), engine=engine)
+    ddf.to_parquet(str(tmpdir), **engine)
     files = str(tmpdir.join("*.parquet"))
     ddf_out = dd.read_parquet(
-        files, calculate_divisions=True, engine=engine, filters=[("x", ">", 3)]
+        files, calculate_divisions=True, filters=[("x", ">", 3)], **engine
     )
 
     assert ddf_out.npartitions == 3
@@ -1697,46 +1661,40 @@ def test_filters_file_list(tmpdir, engine):
     ddf2 = dd.read_parquet(
         str(tmpdir.join("part.0.parquet")),
         calculate_divisions=True,
-        engine=engine,
         filters=[("x", ">", 3)],
+        **engine,
     )
     assert len(ddf2) == 0
 
     # Make sure files list can be read with filters when they don't have the same columns order
-    pd.read_parquet(os.path.join(tmpdir, "part.4.parquet"), engine=engine)[
+    pd.read_parquet(os.path.join(tmpdir, "part.4.parquet"), **engine)[
         reversed(df.columns)
-    ].to_parquet(os.path.join(tmpdir, "part.4.parquet"), engine=engine)
+    ].to_parquet(os.path.join(tmpdir, "part.4.parquet"), **engine)
     ddf3 = dd.read_parquet(
         str(tmpdir.join("*.parquet")),
         calculate_divisions=True,
-        engine=engine,
         filters=[("x", ">", 3)],
+        **engine,
     )
     assert ddf3.npartitions == 3
     assert_eq(df[df["x"] > 3], ddf3, check_index=False)
 
 
+@PYARROW_MARK
 def test_pyarrow_filter_divisions(tmpdir):
-    pytest.importorskip("pyarrow")
-
     # Write simple dataset with an index that will only
     # have a sorted index if certain row-groups are filtered out.
     # In this case, we filter "a" <= 3 to get a sorted
     # index. Otherwise, "a" is NOT monotonically increasing.
     df = pd.DataFrame({"a": [0, 1, 10, 12, 2, 3, 8, 9], "b": range(8)}).set_index("a")
-    df.iloc[:4].to_parquet(
-        str(tmpdir.join("file.0.parquet")), engine="pyarrow", row_group_size=2
-    )
-    df.iloc[4:].to_parquet(
-        str(tmpdir.join("file.1.parquet")), engine="pyarrow", row_group_size=2
-    )
+    df.iloc[:4].to_parquet(str(tmpdir.join("file.0.parquet")), row_group_size=2)
+    df.iloc[4:].to_parquet(str(tmpdir.join("file.1.parquet")), row_group_size=2)
 
     # Only works for ArrowDatasetEngine.
     # Legacy code will not apply filters on individual row-groups
     # when `split_row_groups=False`.
     ddf = dd.read_parquet(
         str(tmpdir),
-        engine="pyarrow",
         split_row_groups=False,
         calculate_divisions=True,
         filters=[("a", "<=", 3)],
@@ -1745,7 +1703,6 @@ def test_pyarrow_filter_divisions(tmpdir):
 
     ddf = dd.read_parquet(
         str(tmpdir),
-        engine="pyarrow",
         split_row_groups=True,
         calculate_divisions=True,
         filters=[("a", "<=", 3)],
@@ -1754,8 +1711,8 @@ def test_pyarrow_filter_divisions(tmpdir):
 
 
 @FASTPARQUET_MARK
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_divisions_read_with_filters(tmpdir):
-    pytest.importorskip("fastparquet", minversion="0.3.1")
     tmpdir = str(tmpdir)
     # generate dataframe
     size = 100
@@ -1785,8 +1742,8 @@ def test_divisions_read_with_filters(tmpdir):
 
 
 @FASTPARQUET_MARK
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_divisions_are_known_read_with_filters(tmpdir):
-    pytest.importorskip("fastparquet", minversion="0.3.1")
     tmpdir = str(tmpdir)
     # generate dataframe
     df = pd.DataFrame(
@@ -1812,50 +1769,19 @@ def test_divisions_are_known_read_with_filters(tmpdir):
     assert out.divisions == expected_divisions
 
 
-@FASTPARQUET_MARK
-@pytest.mark.xfail(reason="No longer accept ParquetFile objects")
-def test_read_from_fastparquet_parquetfile(tmpdir):
-    fn = str(tmpdir)
-
-    df = pd.DataFrame(
-        {
-            "a": np.random.choice(["A", "B", "C"], size=100),
-            "b": np.random.random(size=100),
-            "c": np.random.randint(1, 5, size=100),
-        }
-    )
-    d = dd.from_pandas(df, npartitions=2)
-    d.to_parquet(fn, partition_on=["a"], engine="fastparquet")
-
-    pq_f = fastparquet.ParquetFile(fn)
-
-    # OK with no filters
-    out = dd.read_parquet(pq_f).compute()
-    for val in df.a.unique():
-        assert set(df.b[df.a == val]) == set(out.b[out.a == val])
-
-    # OK with  filters
-    out = dd.read_parquet(pq_f, filters=[("a", "==", "B")]).compute()
-    assert set(df.b[df.a == "B"]) == set(out.b)
-
-    # Engine should not be set to 'pyarrow'
-    with pytest.raises(AssertionError):
-        out = dd.read_parquet(pq_f, engine="pyarrow")
-
-
 @pytest.mark.parametrize("scheduler", ["threads", "processes"])
 def test_to_parquet_lazy(tmpdir, scheduler, engine):
     tmpdir = str(tmpdir)
     df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [1.0, 2.0, 3.0, 4.0]})
     df.index.name = "index"
     ddf = dd.from_pandas(df, npartitions=2)
-    value = ddf.to_parquet(tmpdir, compute=False, engine=engine)
+    value = ddf.to_parquet(tmpdir, compute=False, **engine)
 
     assert hasattr(value, "dask")
     value.compute(scheduler=scheduler)
     assert os.path.exists(tmpdir)
 
-    ddf2 = dd.read_parquet(tmpdir, engine=engine, calculate_divisions=True)
+    ddf2 = dd.read_parquet(tmpdir, calculate_divisions=True, **engine)
 
     assert_eq(ddf, ddf2, check_divisions=False)
 
@@ -1867,13 +1793,14 @@ def test_to_parquet_calls_invalidate_cache(tmpdir, monkeypatch, compute):
 
     invalidate_cache = MagicMock()
     monkeypatch.setattr(LocalFileSystem, "invalidate_cache", invalidate_cache)
-    ddf.to_parquet(tmpdir, compute=compute, engine="pyarrow")
+    ddf.to_parquet(tmpdir, compute=compute)
     path = LocalFileSystem._strip_protocol(str(tmpdir))
     assert invalidate_cache.called
     assert invalidate_cache.call_args.args[0] == path
 
 
 @FASTPARQUET_MARK
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_timestamp96(tmpdir):
     fn = str(tmpdir)
     df = pd.DataFrame({"a": [pd.to_datetime("now", utc=True)]})
@@ -1886,6 +1813,7 @@ def test_timestamp96(tmpdir):
 
 
 @FASTPARQUET_MARK
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_drill_scheme(tmpdir):
     fn = str(tmpdir)
     N = 5
@@ -1922,27 +1850,25 @@ def test_parquet_select_cats(tmpdir, engine):
     )
 
     ddf = dd.from_pandas(df, 1)
-    ddf.to_parquet(fn, engine=engine)
-    rddf = dd.read_parquet(fn, columns=["ints"], engine=engine)
+    ddf.to_parquet(fn, **engine)
+    rddf = dd.read_parquet(fn, columns=["ints"], **engine)
     assert list(rddf.columns) == ["ints"]
-    rddf = dd.read_parquet(fn, engine=engine)
+    rddf = dd.read_parquet(fn, **engine)
     assert list(rddf.columns) == list(df)
 
 
 def test_columns_name(tmpdir, engine):
-    if engine == "fastparquet" and fastparquet_version <= parse_version("0.3.1"):
-        pytest.skip("Fastparquet does not write column_indexes up to 0.3.1")
     tmp_path = str(tmpdir)
     df = pd.DataFrame({"A": [1, 2]}, index=pd.Index(["a", "b"], name="idx"))
     df.columns.name = "cols"
     ddf = dd.from_pandas(df, 2)
 
-    ddf.to_parquet(tmp_path, engine=engine)
-    result = dd.read_parquet(tmp_path, engine=engine, index=["idx"])
+    ddf.to_parquet(tmp_path, **engine)
+    result = dd.read_parquet(tmp_path, index=["idx"], **engine)
     assert_eq(result, df)
 
 
-def check_compression(engine, filename, compression):
+def check_compression(filename, compression, engine=None):
     if engine == "fastparquet":
         pf = fastparquet.ParquetFile(filename)
         md = pf.fmd.row_groups[0].columns[0].meta_data
@@ -1950,7 +1876,7 @@ def check_compression(engine, filename, compression):
             assert md.total_compressed_size == md.total_uncompressed_size
         else:
             assert md.total_compressed_size != md.total_uncompressed_size
-    else:
+    else:  # pyarrow
         metadata = pa.parquet.read_metadata(os.path.join(filename, "_metadata"))
         names = metadata.schema.names
         for i in range(metadata.num_row_groups):
@@ -1979,10 +1905,10 @@ def test_writing_parquet_with_compression(tmpdir, compression, engine):
     df.index.name = "index"
     ddf = dd.from_pandas(df, npartitions=3)
 
-    ddf.to_parquet(fn, compression=compression, engine=engine, write_metadata_file=True)
-    out = dd.read_parquet(fn, engine=engine, calculate_divisions=True)
+    ddf.to_parquet(fn, compression=compression, write_metadata_file=True, **engine)
+    out = dd.read_parquet(fn, calculate_divisions=True, **engine)
     assert_eq(out, ddf)
-    check_compression(engine, fn, compression)
+    check_compression(fn, compression, **engine)
 
 
 @pytest.mark.parametrize("compression,", [None, "gzip", "snappy"])
@@ -1996,11 +1922,11 @@ def test_writing_parquet_with_partition_on_and_compression(tmpdir, compression, 
     ddf.to_parquet(
         fn,
         compression=compression,
-        engine=engine,
         partition_on=["x"],
         write_metadata_file=True,
+        **engine,
     )
-    check_compression(engine, fn, compression)
+    check_compression(fn, compression, **engine)
 
 
 @pytest.fixture(
@@ -2175,7 +2101,7 @@ def test_read_no_metadata(tmpdir, engine):
         [pa.array([1, 2, 3]), pa.array([3, 4, 5])], names=["A", "B"]
     )
     pq.write_table(table, tmp)
-    result = dd.read_parquet(tmp, engine=engine)
+    result = dd.read_parquet(tmp, **engine)
     expected = pd.DataFrame({"A": [1, 2, 3], "B": [3, 4, 5]})
     assert_eq(result, expected)
 
@@ -2279,25 +2205,28 @@ def test_writing_parquet_with_kwargs(tmpdir, engine):
     df.index.name = "index"
     ddf = dd.from_pandas(df, npartitions=3)
 
-    engine_kwargs = {
-        "pyarrow": {
+    if engine == {}:  # pyarrow
+        write_kwargs = {
             "compression": "snappy",
             "coerce_timestamps": None,
             "use_dictionary": True,
-        },
-        "fastparquet": {"compression": "snappy", "times": "int64", "fixed_text": None},
-    }
+        }
+    else:  # fastparquet
+        write_kwargs = {
+            "compression": "snappy",
+            "times": "int64",
+            "fixed_text": None,
+            **engine,
+        }
 
-    ddf.to_parquet(path1, engine=engine, **engine_kwargs[engine])
-    out = dd.read_parquet(path1, engine=engine, calculate_divisions=True)
-    assert_eq(out, ddf, check_index=(engine != "fastparquet"))
+    ddf.to_parquet(path1, **write_kwargs)
+    out = dd.read_parquet(path1, calculate_divisions=True, **engine)
+    assert_eq(out, ddf, check_index=(engine == {}))
 
     # Avoid race condition in pyarrow 0.8.0 on writing partitioned datasets
     with dask.config.set(scheduler="sync"):
-        ddf.to_parquet(
-            path2, engine=engine, partition_on=["a"], **engine_kwargs[engine]
-        )
-    out = dd.read_parquet(path2, engine=engine).compute()
+        ddf.to_parquet(path2, partition_on=["a"], **write_kwargs)
+    out = dd.read_parquet(path2, **engine).compute()
     for val in df.a.unique():
         assert set(df.b[df.a == val]) == set(out.b[out.a == val])
 
@@ -2306,7 +2235,7 @@ def test_writing_parquet_with_unknown_kwargs(tmpdir, engine):
     fn = str(tmpdir)
 
     with pytest.raises(TypeError):
-        ddf.to_parquet(fn, engine=engine, unknown_key="unknown_value")
+        ddf.to_parquet(fn, unknown_key="unknown_value", **engine)
 
 
 def test_to_parquet_with_get(tmpdir, engine):
@@ -2323,10 +2252,10 @@ def test_to_parquet_with_get(tmpdir, engine):
     df = pd.DataFrame({"x": ["a", "b", "c", "d"], "y": [1, 2, 3, 4]})
     ddf = dd.from_pandas(df, npartitions=2)
 
-    ddf.to_parquet(tmpdir, engine=engine, compute_kwargs={"scheduler": my_get})
+    ddf.to_parquet(tmpdir, compute_kwargs={"scheduler": my_get}, **engine)
     assert flag[0]
 
-    result = dd.read_parquet(os.path.join(tmpdir, "*"), engine=engine)
+    result = dd.read_parquet(os.path.join(tmpdir, "*"), **engine)
     assert_eq(result, df, check_index=False)
 
 
@@ -2343,28 +2272,25 @@ def test_select_partitioned_column(tmpdir, engine):
         fn,
         compression="snappy",
         write_index=False,
-        engine=engine,
         partition_on=["fake_categorical1", "fake_categorical2"],
+        **engine,
     )
 
-    df_partitioned = dd.read_parquet(fn, engine=engine)
+    df_partitioned = dd.read_parquet(fn, **engine)
     df_partitioned[df_partitioned.fake_categorical1 == "A"].compute()
 
 
-def test_with_tz(tmpdir, engine):
-    if engine == "fastparquet" and fastparquet_version < parse_version("0.3.0"):
-        pytest.skip("fastparquet<0.3.0 did not support this")
-
+@FASTPARQUET_MARK
+def test_with_tz(tmpdir):
     with warnings.catch_warnings():
-        if engine == "fastparquet":
-            # fastparquet-442
-            warnings.simplefilter("ignore", FutureWarning)  # pandas 0.25
-            fn = str(tmpdir)
-            df = pd.DataFrame([[0]], columns=["a"], dtype="datetime64[ns, UTC]")
-            df = dd.from_pandas(df, 1)
-            df.to_parquet(fn, engine=engine)
-            df2 = dd.read_parquet(fn, engine=engine)
-            assert_eq(df, df2, check_divisions=False, check_index=False)
+        # fastparquet-442
+        warnings.simplefilter("ignore", FutureWarning)  # pandas 0.25
+        fn = str(tmpdir)
+        df = pd.DataFrame([[0]], columns=["a"], dtype="datetime64[ns, UTC]")
+        df = dd.from_pandas(df, 1)
+        df.to_parquet(fn, engine="fastparquet")
+        df2 = dd.read_parquet(fn, engine="fastparquet")
+        assert_eq(df, df2, check_divisions=False, check_index=False)
 
 
 @PYARROW_MARK
@@ -2379,20 +2305,19 @@ def test_arrow_partitioning(tmpdir):
     }
     pdf = pd.DataFrame(data)
     ddf = dd.from_pandas(pdf, npartitions=2)
-    ddf.to_parquet(path, engine="pyarrow", write_index=False, partition_on="p")
+    ddf.to_parquet(path, write_index=False, partition_on="p")
 
-    ddf = dd.read_parquet(path, index=False, engine="pyarrow")
+    ddf = dd.read_parquet(path, index=False)
 
     ddf.astype({"b": np.float32}).compute()
 
 
 def test_informative_error_messages():
-    with pytest.raises(ValueError) as info:
+    with (
+        pytest.warns(FutureWarning, match="The `engine=` parameter is deprecated"),
+        pytest.raises(ValueError, match=r"Unsupported engine: \"foo\""),
+    ):
         dd.read_parquet("foo", engine="foo")
-
-    assert "foo" in str(info.value)
-    assert "arrow" in str(info.value)
-    assert "fastparquet" in str(info.value)
 
 
 def test_append_cat_fp(tmpdir, engine):
@@ -2402,10 +2327,10 @@ def test_append_cat_fp(tmpdir, engine):
     df["x"] = df["x"].astype("category")
     ddf = dd.from_pandas(df, npartitions=1)
 
-    dd.to_parquet(ddf, path, engine=engine)
-    dd.to_parquet(ddf, path, append=True, ignore_divisions=True, engine=engine)
+    dd.to_parquet(ddf, path, **engine)
+    dd.to_parquet(ddf, path, append=True, ignore_divisions=True, **engine)
 
-    d = dd.read_parquet(path, engine=engine).compute()
+    d = dd.read_parquet(path, **engine).compute()
     assert d["x"].tolist() == ["a", "a", "b", "a", "b"] * 2
 
 
@@ -2457,8 +2382,8 @@ def test_roundtrip_arrow(tmpdir, df):
     if not df.index.name:
         df.index.name = "index"
     ddf = dd.from_pandas(df, npartitions=2)
-    dd.to_parquet(ddf, tmp_path, engine="pyarrow", write_index=True)
-    ddf2 = dd.read_parquet(tmp_path, engine="pyarrow", calculate_divisions=True)
+    dd.to_parquet(ddf, tmp_path, write_index=True)
+    ddf2 = dd.read_parquet(tmp_path, calculate_divisions=True)
     assert_eq(ddf, ddf2)
 
 
@@ -2467,9 +2392,9 @@ def test_datasets_timeseries(tmpdir, engine):
     df = dask.datasets.timeseries(
         start="2000-01-01", end="2000-01-10", freq="1d"
     ).persist()
-    df.to_parquet(tmp_path, engine=engine)
+    df.to_parquet(tmp_path, **engine)
 
-    df2 = dd.read_parquet(tmp_path, engine=engine, calculate_divisions=True)
+    df2 = dd.read_parquet(tmp_path, calculate_divisions=True, **engine)
     assert_eq(df, df2)
 
 
@@ -2480,12 +2405,13 @@ def test_pathlib_path(tmpdir, engine):
     df.index.name = "index"
     ddf = dd.from_pandas(df, npartitions=2)
     path = pathlib.Path(str(tmpdir))
-    ddf.to_parquet(path, engine=engine)
-    ddf2 = dd.read_parquet(path, engine=engine, calculate_divisions=True)
+    ddf.to_parquet(path, **engine)
+    ddf2 = dd.read_parquet(path, calculate_divisions=True, **engine)
     assert_eq(ddf, ddf2)
 
 
 @FASTPARQUET_MARK
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_categories_large(tmpdir, engine):
     # Issue #5112
     fn = str(tmpdir.join("parquet_int16.parq"))
@@ -2494,40 +2420,37 @@ def test_categories_large(tmpdir, engine):
     df.name = df.name.astype("category")
 
     df.to_parquet(fn, engine="fastparquet", compression="uncompressed")
-    ddf = dd.read_parquet(fn, engine=engine, categories={"name": 80000})
+    ddf = dd.read_parquet(fn, categories={"name": 80000}, **engine)
 
     assert_eq(sorted(df.name.cat.categories), sorted(ddf.compute().name.cat.categories))
 
 
-@write_read_engines()
 def test_read_glob_no_meta(tmpdir, write_engine, read_engine):
     tmp_path = str(tmpdir)
-    ddf.to_parquet(tmp_path, engine=write_engine)
+    ddf.to_parquet(tmp_path, **write_engine)
 
     ddf2 = dd.read_parquet(
         os.path.join(tmp_path, "*.parquet"),
-        engine=read_engine,
         calculate_divisions=False,
+        **read_engine,
     )
     assert_eq(ddf, ddf2, check_divisions=False)
 
 
-@write_read_engines()
 def test_read_glob_yes_meta(tmpdir, write_engine, read_engine):
     tmp_path = str(tmpdir)
-    ddf.to_parquet(tmp_path, engine=write_engine, write_metadata_file=True)
+    ddf.to_parquet(tmp_path, write_metadata_file=True, **write_engine)
     paths = glob.glob(os.path.join(tmp_path, "*.parquet"))
     paths.append(os.path.join(tmp_path, "_metadata"))
-    ddf2 = dd.read_parquet(paths, engine=read_engine, calculate_divisions=False)
+    ddf2 = dd.read_parquet(paths, calculate_divisions=False, **read_engine)
     assert_eq(ddf, ddf2, check_divisions=False)
 
 
 @pytest.mark.parametrize("divisions", [True, False])
 @pytest.mark.parametrize("remove_common", [True, False])
-@write_read_engines()
 def test_read_dir_nometa(tmpdir, write_engine, read_engine, divisions, remove_common):
     tmp_path = str(tmpdir)
-    ddf.to_parquet(tmp_path, engine=write_engine, write_metadata_file=True)
+    ddf.to_parquet(tmp_path, write_metadata_file=True, **write_engine)
     if os.path.exists(os.path.join(tmp_path, "_metadata")):
         os.unlink(os.path.join(tmp_path, "_metadata"))
     files = os.listdir(tmp_path)
@@ -2536,16 +2459,15 @@ def test_read_dir_nometa(tmpdir, write_engine, read_engine, divisions, remove_co
     if remove_common and os.path.exists(os.path.join(tmp_path, "_common_metadata")):
         os.unlink(os.path.join(tmp_path, "_common_metadata"))
 
-    ddf2 = dd.read_parquet(tmp_path, engine=read_engine, calculate_divisions=divisions)
+    ddf2 = dd.read_parquet(tmp_path, calculate_divisions=divisions, **read_engine)
     assert_eq(ddf, ddf2, check_divisions=divisions)
 
 
-@write_read_engines()
 def test_statistics_nometa(tmpdir, write_engine, read_engine):
     tmp_path = str(tmpdir)
-    ddf.to_parquet(tmp_path, engine=write_engine, write_metadata_file=False)
+    ddf.to_parquet(tmp_path, write_metadata_file=False, **write_engine)
 
-    ddf2 = dd.read_parquet(tmp_path, engine=read_engine, calculate_divisions=True)
+    ddf2 = dd.read_parquet(tmp_path, calculate_divisions=True, **read_engine)
     assert_eq(ddf, ddf2)
 
 
@@ -2564,8 +2486,8 @@ def test_timeseries_nulls_in_schema(tmpdir, engine, schema):
     ddf2.name = ddf2.name.where(ddf2.timestamp == "2000-01-01", None)
 
     # Note: `append_row_groups` will fail with pyarrow>0.17.1 for _metadata write
-    ddf2.to_parquet(tmp_path, engine=engine, write_metadata_file=False, schema=schema)
-    ddf_read = dd.read_parquet(tmp_path, engine=engine)
+    ddf2.to_parquet(tmp_path, write_metadata_file=False, schema=schema, **engine)
+    ddf_read = dd.read_parquet(tmp_path, **engine)
 
     assert_eq(ddf_read, ddf2, check_divisions=False, check_index=False)
 
@@ -2579,8 +2501,8 @@ def test_graph_size_pyarrow(tmpdir, engine):
         start="2000-01-01", end="2000-01-02", freq="60s", partition_freq="1h"
     )
 
-    ddf1.to_parquet(fn, engine=engine)
-    ddf2 = dd.read_parquet(fn, engine=engine)
+    ddf1.to_parquet(fn, **engine)
+    ddf2 = dd.read_parquet(fn, **engine)
 
     assert len(pickle.dumps(ddf2.__dask_graph__())) < 25000
 
@@ -2596,12 +2518,12 @@ def test_getitem_optimization(tmpdir, engine, preserve_index, index):
     df.index.name = "my_index"
     ddf = dd.from_pandas(df, 2, sort=False)
 
-    ddf.to_parquet(tmp_path_rd, engine=engine, write_index=preserve_index)
-    ddf = dd.read_parquet(tmp_path_rd, engine=engine)["B"]
+    ddf.to_parquet(tmp_path_rd, write_index=preserve_index, **engine)
+    ddf = dd.read_parquet(tmp_path_rd, **engine)["B"]
 
     # Write ddf back to disk to check that the round trip
     # preserves the getitem optimization
-    out = ddf.to_frame().to_parquet(tmp_path_wt, engine=engine, compute=False)
+    out = ddf.to_frame().to_parquet(tmp_path_wt, compute=False, **engine)
     dsk = optimize_dataframe_getitem(out.dask, keys=[out.key])
 
     subgraph_rd = hlg_layer(dsk, "read-parquet")
@@ -2619,9 +2541,9 @@ def test_getitem_optimization_empty(tmpdir, engine):
     df = pd.DataFrame({"A": [1] * 100, "B": [2] * 100, "C": [3] * 100, "D": [4] * 100})
     ddf = dd.from_pandas(df, 2, sort=False)
     fn = os.path.join(str(tmpdir))
-    ddf.to_parquet(fn, engine=engine)
+    ddf.to_parquet(fn, **engine)
 
-    ddf2 = dd.read_parquet(fn, engine=engine)[[]]
+    ddf2 = dd.read_parquet(fn, **engine)[[]]
     dsk = optimize_dataframe_getitem(ddf2.dask, keys=[ddf2._name])
 
     subgraph = next(l for l in dsk.layers.values() if isinstance(l, DataFrameIOLayer))
@@ -2634,11 +2556,11 @@ def test_getitem_optimization_multi(tmpdir, engine):
     df = pd.DataFrame({"A": [1] * 100, "B": [2] * 100, "C": [3] * 100, "D": [4] * 100})
     ddf = dd.from_pandas(df, 2)
     fn = os.path.join(str(tmpdir))
-    ddf.to_parquet(fn, engine=engine)
+    ddf.to_parquet(fn, **engine)
 
-    a = dd.read_parquet(fn, engine=engine)["B"]
-    b = dd.read_parquet(fn, engine=engine)[["C"]]
-    c = dd.read_parquet(fn, engine=engine)[["C", "A"]]
+    a = dd.read_parquet(fn, **engine)["B"]
+    b = dd.read_parquet(fn, **engine)[["C"]]
+    c = dd.read_parquet(fn, **engine)[["C", "A"]]
 
     a1, a2, a3 = dask.compute(a, b, c)
     b1, b2, b3 = dask.compute(a, b, c, optimize_graph=False)
@@ -2650,8 +2572,8 @@ def test_getitem_optimization_multi(tmpdir, engine):
 
 def test_getitem_optimization_after_filter(tmpdir, engine):
     df = pd.DataFrame({"a": [1, 2, 3] * 5, "b": range(15), "c": range(15)})
-    dd.from_pandas(df, npartitions=3).to_parquet(tmpdir, engine=engine)
-    ddf = dd.read_parquet(tmpdir, engine=engine)
+    dd.from_pandas(df, npartitions=3).to_parquet(tmpdir, **engine)
+    ddf = dd.read_parquet(tmpdir, **engine)
 
     df2 = df[df["b"] > 10][["a"]]
     ddf2 = ddf[ddf["b"] > 10][["a"]]
@@ -2666,8 +2588,8 @@ def test_getitem_optimization_after_filter(tmpdir, engine):
 
 def test_getitem_optimization_after_filter_complex(tmpdir, engine):
     df = pd.DataFrame({"a": [1, 2, 3] * 5, "b": range(15), "c": range(15)})
-    dd.from_pandas(df, npartitions=3).to_parquet(tmpdir, engine=engine)
-    ddf = dd.read_parquet(tmpdir, engine=engine)
+    dd.from_pandas(df, npartitions=3).to_parquet(tmpdir, **engine)
+    ddf = dd.read_parquet(tmpdir, **engine)
 
     df2 = df[["b"]]
     df2 = df2.assign(d=1)
@@ -2687,37 +2609,37 @@ def test_getitem_optimization_after_filter_complex(tmpdir, engine):
 
 def test_layer_creation_info(tmpdir, engine):
     df = pd.DataFrame({"a": range(10), "b": ["cat", "dog"] * 5})
-    dd.from_pandas(df, npartitions=1).to_parquet(
-        tmpdir, engine=engine, partition_on=["b"]
-    )
+    dd.from_pandas(df, npartitions=1).to_parquet(tmpdir, partition_on=["b"], **engine)
 
     # Apply filters directly in dd.read_parquet
     filters = [("b", "==", "cat")]
-    ddf1 = dd.read_parquet(tmpdir, engine=engine, filters=filters)
+    ddf1 = dd.read_parquet(tmpdir, filters=filters, **engine)
     assert "dog" not in ddf1["b"].compute()
 
     # Results will not match if we use dd.read_parquet
     # without filters
-    ddf2 = dd.read_parquet(tmpdir, engine=engine)
+    ddf2 = dd.read_parquet(tmpdir, **engine)
     with pytest.raises(AssertionError):
         assert_eq(ddf1, ddf2)
 
     # However, we can use `creation_info` to regenerate
     # the same collection with `filters` defined
     info = ddf2.dask.layers[ddf2._name].creation_info
-    kwargs = info.get("kwargs", {})
-    kwargs["filters"] = filters
-    ddf3 = info["func"](*info.get("args", []), **kwargs)
+    del info["kwargs"]["engine"]
+    info["kwargs"].update(engine)
+    info["kwargs"]["filters"] = filters
+
+    ddf3 = info["func"](*info["args"], **info["kwargs"])
     assert_eq(ddf1, ddf3)
 
 
 def test_blockwise_parquet_annotations(tmpdir, engine):
     df = pd.DataFrame({"a": np.arange(40, dtype=np.int32)})
     expect = dd.from_pandas(df, npartitions=2)
-    expect.to_parquet(str(tmpdir), engine=engine)
+    expect.to_parquet(str(tmpdir), **engine)
 
     with dask.annotate(foo="bar"):
-        ddf = dd.read_parquet(str(tmpdir), engine=engine)
+        ddf = dd.read_parquet(str(tmpdir), **engine)
 
     # `ddf` should now have ONE Blockwise layer
     layers = ddf.__dask_graph__().layers
@@ -2733,8 +2655,8 @@ def test_optimize_blockwise_parquet(tmpdir, engine):
     tmp = str(tmpdir)
     df = pd.DataFrame({"a": np.arange(size, dtype=np.int32)})
     expect = dd.from_pandas(df, npartitions=npartitions)
-    expect.to_parquet(tmp, engine=engine)
-    ddf = dd.read_parquet(tmp, engine=engine, calculate_divisions=True)
+    expect.to_parquet(tmp, **engine)
+    ddf = dd.read_parquet(tmp, calculate_divisions=True, **engine)
 
     # `ddf` should now have ONE Blockwise layer
     layers = ddf.__dask_graph__().layers
@@ -2780,32 +2702,30 @@ def test_split_row_groups(tmpdir, engine):
     df.index.name = "index"
 
     half = len(df) // 2
-    dd.from_pandas(df.iloc[:half], npartitions=2).to_parquet(
-        tmp, engine="pyarrow", row_group_size=100
-    )
+    dd.from_pandas(df.iloc[:half], npartitions=2).to_parquet(tmp, row_group_size=100)
 
-    ddf3 = dd.read_parquet(tmp, engine=engine, split_row_groups=True)
+    ddf3 = dd.read_parquet(tmp, split_row_groups=True, **engine)
     assert ddf3.npartitions == 4
 
     ddf3 = dd.read_parquet(
-        tmp, engine=engine, calculate_divisions=True, split_row_groups=False
+        tmp, calculate_divisions=True, split_row_groups=False, **engine
     )
     assert ddf3.npartitions == 2
 
     dd.from_pandas(df.iloc[half:], npartitions=2).to_parquet(
-        tmp, append=True, engine="pyarrow", row_group_size=50
+        tmp, append=True, row_group_size=50
     )
 
     ddf3 = dd.read_parquet(
         tmp,
-        engine=engine,
         calculate_divisions=True,
         split_row_groups=True,
+        **engine,
     )
     assert ddf3.npartitions == 12
 
     ddf3 = dd.read_parquet(
-        tmp, engine=engine, calculate_divisions=True, split_row_groups=False
+        tmp, calculate_divisions=True, split_row_groups=False, **engine
     )
     assert ddf3.npartitions == 4
 
@@ -2827,17 +2747,17 @@ def test_split_row_groups_int(tmpdir, split_row_groups, calculate_divisions, eng
     half = len(df) // 2
 
     dd.from_pandas(df.iloc[:half], npartitions=npartitions).to_parquet(
-        tmp, engine="pyarrow", row_group_size=row_group_size
+        tmp, row_group_size=row_group_size
     )
     dd.from_pandas(df.iloc[half:], npartitions=npartitions).to_parquet(
-        tmp, append=True, engine="pyarrow", row_group_size=row_group_size
+        tmp, append=True, row_group_size=row_group_size
     )
 
     ddf2 = dd.read_parquet(
         tmp,
-        engine=engine,
         split_row_groups=split_row_groups,
         calculate_divisions=calculate_divisions,
+        **engine,
     )
     expected_rg_cout = int(half_size / row_group_size)
     assert ddf2.npartitions == 2 * math.ceil(expected_rg_cout / split_row_groups)
@@ -2857,16 +2777,16 @@ def test_split_row_groups_int_aggregate_files(tmpdir, engine, split_row_groups):
         }
     )
     dd.from_pandas(df, npartitions=4).to_parquet(
-        str(tmpdir), engine="pyarrow", row_group_size=row_group_size, write_index=False
+        str(tmpdir), row_group_size=row_group_size, write_index=False
     )
 
     # Read back with both `split_row_groups>1` and
     # `aggregate_files=True`
     ddf2 = dd.read_parquet(
         str(tmpdir),
-        engine=engine,
         split_row_groups=split_row_groups,
         aggregate_files=True,
+        **engine,
     )
 
     # Check that we are aggregating files as expected
@@ -2891,7 +2811,7 @@ def test_split_row_groups_int_aggregate_files(tmpdir, engine, split_row_groups):
 )
 @pytest.mark.parametrize("split_row_groups", [True, False])
 def test_filter_nulls(tmpdir, filters, op, length, split_row_groups, engine):
-    if engine == "pyarrow" and parse_version(pa.__version__) < parse_version("8.0.0"):
+    if engine == {} and parse_version(pa.__version__) < parse_version("8.0.0"):
         # See: https://issues.apache.org/jira/browse/ARROW-15312
         pytest.skip("pyarrow>=8.0.0 needed for correct null filtering")
     path = tmpdir.join("test.parquet")
@@ -2902,13 +2822,13 @@ def test_filter_nulls(tmpdir, filters, op, length, split_row_groups, engine):
             "c": ["a", None] * 2 + [None] * 11,
         }
     )
-    df.to_parquet(path, engine="pyarrow", row_group_size=10)
+    df.to_parquet(path, row_group_size=10)
 
     result = dd.read_parquet(
         path,
-        engine=engine,
         filters=filters,
         split_row_groups=split_row_groups,
+        **engine,
     )
     assert len(op(result)) == length
     assert_eq(op(result), op(df), check_index=False)
@@ -2921,13 +2841,10 @@ def test_filter_isna(tmpdir, split_row_groups):
         # See: https://issues.apache.org/jira/browse/ARROW-15312
         pytest.skip("pyarrow>=8.0.0 needed for correct null filtering")
     path = tmpdir.join("test.parquet")
-    pd.DataFrame({"a": [1, None] * 5 + [None] * 5}).to_parquet(
-        path, engine="pyarrow", row_group_size=10
-    )
+    pd.DataFrame({"a": [1, None] * 5 + [None] * 5}).to_parquet(path, row_group_size=10)
 
     result_isna = dd.read_parquet(
         path,
-        engine="pyarrow",
         filters=[("a", "is", np.nan)],
         split_row_groups=split_row_groups,
     )
@@ -2936,7 +2853,6 @@ def test_filter_isna(tmpdir, split_row_groups):
 
     result_notna = dd.read_parquet(
         path,
-        engine="pyarrow",
         filters=[("a", "is not", np.nan)],
         split_row_groups=split_row_groups,
     )
@@ -2953,17 +2869,15 @@ def test_split_row_groups_filter(tmpdir, engine):
     search_val = 600
     filters = [("f", "==", search_val)]
 
-    dd.from_pandas(df, npartitions=4).to_parquet(
-        tmp, append=True, engine="pyarrow", row_group_size=50
-    )
+    dd.from_pandas(df, npartitions=4).to_parquet(tmp, append=True, row_group_size=50)
 
-    ddf2 = dd.read_parquet(tmp, engine=engine)
+    ddf2 = dd.read_parquet(tmp, **engine)
     ddf3 = dd.read_parquet(
         tmp,
-        engine=engine,
         calculate_divisions=True,
         split_row_groups=True,
         filters=filters,
+        **engine,
     )
 
     assert (ddf3["i32"] == search_val).any().compute()
@@ -2979,9 +2893,9 @@ def test_optimize_getitem_and_nonblockwise(tmpdir, engine):
         {"a": [3, 4, 2], "b": [1, 2, 4], "c": [5, 4, 2], "d": [1, 2, 3]},
         index=["a", "b", "c"],
     )
-    df.to_parquet(path, engine=engine)
+    df.to_parquet(path, **engine)
 
-    df2 = dd.read_parquet(path, engine=engine)
+    df2 = dd.read_parquet(path, **engine)
     df2[["a", "b"]].rolling(3).max().compute()
 
 
@@ -2991,9 +2905,9 @@ def test_optimize_and_not(tmpdir, engine):
         {"a": [3, 4, 2], "b": [1, 2, 4], "c": [5, 4, 2], "d": [1, 2, 3]},
         index=["a", "b", "c"],
     )
-    df.to_parquet(path, engine=engine)
+    df.to_parquet(path, **engine)
 
-    df2 = dd.read_parquet(path, engine=engine)
+    df2 = dd.read_parquet(path, **engine)
     df2a = df2["a"].groupby(df2["c"]).first().to_delayed()
     df2b = df2["b"].groupby(df2["c"]).first().to_delayed()
     df2c = df2[["a", "b"]].rolling(2).max().to_delayed()
@@ -3010,16 +2924,11 @@ def test_optimize_and_not(tmpdir, engine):
         assert_eq(a, b)
 
 
-@write_read_engines()
 def test_split_adaptive_empty(tmpdir, write_engine, read_engine):
     df = pd.DataFrame({"a": pd.Series(dtype="int"), "b": pd.Series(dtype="float")})
     ddf1 = dd.from_pandas(df, npartitions=1)
-    ddf1.to_parquet(tmpdir, engine=write_engine, write_metadata_file=True)
-    ddf2 = dd.read_parquet(
-        tmpdir,
-        engine=read_engine,
-        split_row_groups="adaptive",
-    )
+    ddf1.to_parquet(tmpdir, write_metadata_file=True, **write_engine)
+    ddf2 = dd.read_parquet(tmpdir, split_row_groups="adaptive", **read_engine)
     assert_eq(ddf1, ddf2, check_index=False)
 
 
@@ -3027,13 +2936,9 @@ def test_split_adaptive_empty(tmpdir, write_engine, read_engine):
 @pytest.mark.parametrize("metadata", [True, False])
 @pytest.mark.parametrize("partition_on", [None, "a"])
 @pytest.mark.parametrize("blocksize", [4096, "1MiB"])
-@write_read_engines()
 def test_split_adaptive_files(
     tmpdir, blocksize, partition_on, write_engine, read_engine, metadata
 ):
-    if partition_on and read_engine == "fastparquet" and not metadata:
-        pytest.skip("Fastparquet requires _metadata for partitioned data.")
-
     df_size = 100
     df1 = pd.DataFrame(
         {
@@ -3046,10 +2951,10 @@ def test_split_adaptive_files(
 
     ddf1.to_parquet(
         str(tmpdir),
-        engine=write_engine,
         partition_on=partition_on,
         write_metadata_file=metadata,
         write_index=False,
+        **write_engine,
     )
 
     aggregate_files = partition_on if partition_on else True
@@ -3057,18 +2962,18 @@ def test_split_adaptive_files(
         with pytest.warns(FutureWarning, match="Behavior may change"):
             ddf2 = dd.read_parquet(
                 str(tmpdir),
-                engine=read_engine,
                 blocksize=blocksize,
                 split_row_groups="adaptive",
                 aggregate_files=aggregate_files,
+                **read_engine,
             )
     else:
         ddf2 = dd.read_parquet(
             str(tmpdir),
-            engine=read_engine,
             blocksize=blocksize,
             split_row_groups="adaptive",
             aggregate_files=aggregate_files,
+            **read_engine,
         )
 
     # Check that files where aggregated as expected
@@ -3089,7 +2994,6 @@ def test_split_adaptive_files(
         assert_eq(ddf1, ddf2, check_divisions=False, check_index=False)
 
 
-@write_read_engines()
 @pytest.mark.parametrize("aggregate_files", ["a", "b"])
 def test_split_adaptive_aggregate_files(
     tmpdir, write_engine, read_engine, aggregate_files
@@ -3109,17 +3013,17 @@ def test_split_adaptive_aggregate_files(
 
     ddf1.to_parquet(
         str(tmpdir),
-        engine=write_engine,
         partition_on=partition_on,
         write_index=False,
+        **write_engine,
     )
     with pytest.warns(FutureWarning, match="Behavior may change"):
         ddf2 = dd.read_parquet(
             str(tmpdir),
-            engine=read_engine,
             blocksize=blocksize,
             split_row_groups="adaptive",
             aggregate_files=aggregate_files,
+            **read_engine,
         )
 
     # Check that files where aggregated as expected
@@ -3154,7 +3058,6 @@ def test_split_adaptive_blocksize(tmpdir, blocksize, engine, metadata):
     ddf1 = dd.from_pandas(df, npartitions=nparts)
     ddf1.to_parquet(
         str(tmpdir),
-        engine="pyarrow",
         row_group_size=row_group_size,
         write_metadata_file=metadata,
     )
@@ -3169,12 +3072,12 @@ def test_split_adaptive_blocksize(tmpdir, blocksize, engine, metadata):
 
     ddf2 = dd.read_parquet(
         path,
-        engine=engine,
         blocksize=blocksize,
         split_row_groups="adaptive",
         calculate_divisions=True,
         index="index",
         aggregate_files=True,
+        **engine,
     )
 
     assert_eq(ddf1, ddf2, check_divisions=False)
@@ -3211,7 +3114,6 @@ def test_blocksize(tmpdir, blocksize, engine, metadata):
     ddf1 = dd.from_pandas(df, npartitions=nparts)
     ddf1.to_parquet(
         str(tmpdir),
-        engine="pyarrow",
         row_group_size=row_group_size,
         write_metadata_file=metadata,
     )
@@ -3228,9 +3130,9 @@ def test_blocksize(tmpdir, blocksize, engine, metadata):
     # without file aggregation
     ddf2 = dd.read_parquet(
         path,
-        engine=engine,
         blocksize=blocksize,
         index="index",
+        **engine,
     )
     assert_eq(df, ddf2)
 
@@ -3238,10 +3140,10 @@ def test_blocksize(tmpdir, blocksize, engine, metadata):
         # Should get adaptive partitioning
         assert ddf2.npartitions > ddf1.npartitions
         outpath = os.path.join(str(tmpdir), "out")
-        ddf2.to_parquet(outpath, engine=engine)
+        ddf2.to_parquet(outpath, **engine)
         for i in range(ddf2.npartitions):
             fn = os.path.join(outpath, f"part.{i}.parquet")
-            if engine == "fastparquet":
+            if engine == {"engine": "fastparquet"}:
                 pf = fastparquet.ParquetFile(fn)
                 sizep0 = sum([rg.total_byte_size for rg in pf.row_groups])
             else:
@@ -3258,35 +3160,33 @@ def test_blocksize(tmpdir, blocksize, engine, metadata):
         assert ddf2.npartitions == ddf1.npartitions
 
 
-@write_read_engines()
 def test_roundtrip_pandas_blocksize(tmpdir, write_engine, read_engine):
     path = str(tmpdir.join("test.parquet"))
     pdf = df.copy()
     pdf.index.name = "index"
-    pdf.to_parquet(
-        path, engine="pyarrow" if write_engine.startswith("pyarrow") else "fastparquet"
-    )
+    pdf.to_parquet(path, **write_engine)
 
     ddf_read = dd.read_parquet(
         path,
-        engine=read_engine,
         blocksize="10 kiB",
         calculate_divisions=True,
         split_row_groups=True,
         index="index",
+        **read_engine,
     )
 
     assert_eq(pdf, ddf_read)
 
 
 @FASTPARQUET_MARK
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 def test_read_pandas_fastparquet_partitioned(tmpdir, engine):
     pdf = pd.DataFrame(
         [{"str": str(i), "int": i, "group": "ABC"[i % 3]} for i in range(6)]
     )
     path = str(tmpdir)
     pdf.to_parquet(path, partition_cols=["group"], engine="fastparquet")
-    ddf_read = dd.read_parquet(path, engine=engine)
+    ddf_read = dd.read_parquet(path, **engine)
 
     assert len(ddf_read["group"].compute()) == 6
     assert len(ddf_read.compute().group) == 6
@@ -3296,10 +3196,9 @@ def test_read_parquet_getitem_skip_when_getting_read_parquet(tmpdir, engine):
     # https://github.com/dask/dask/issues/5893
     pdf = pd.DataFrame({"A": [1, 2, 3, 4, 5, 6], "B": ["a", "b", "c", "d", "e", "f"]})
     path = os.path.join(str(tmpdir), "data.parquet")
-    pd_engine = "pyarrow" if engine.startswith("pyarrow") else "fastparquet"
-    pdf.to_parquet(path, engine=pd_engine)
+    pdf.to_parquet(path, engine=engine.get("engine", "pyarrow"))
 
-    ddf = dd.read_parquet(path, engine=engine)
+    ddf = dd.read_parquet(path, **engine)
     a, b = dask.optimize(ddf["A"], ddf)
 
     # Make sure we are still allowing the getitem optimization
@@ -3313,7 +3212,6 @@ def test_read_parquet_getitem_skip_when_getting_read_parquet(tmpdir, engine):
 
 
 @pytest.mark.parametrize("calculate_divisions", [None, True])
-@write_read_engines()
 def test_filter_nonpartition_columns(
     tmpdir, write_engine, read_engine, calculate_divisions
 ):
@@ -3326,15 +3224,13 @@ def test_filter_nonpartition_columns(
         }
     )
     ddf_write = dd.from_pandas(df_write, npartitions=4)
-    ddf_write.to_parquet(
-        tmpdir, write_index=False, partition_on=["id"], engine=write_engine
-    )
+    ddf_write.to_parquet(tmpdir, write_index=False, partition_on=["id"], **write_engine)
     ddf_read = dd.read_parquet(
         tmpdir,
         index=False,
-        engine=read_engine,
         calculate_divisions=calculate_divisions,
         filters=[(("time", "<", 5))],
+        **read_engine,
     )
     df_read = ddf_read.compute()
     assert len(df_read) == len(df_read[df_read["time"] < 5])
@@ -3354,14 +3250,14 @@ def test_pandas_metadata_nullable_pyarrow(tmpdir):
         ),
         npartitions=1,
     )
-    ddf1.to_parquet(tmpdir, engine="pyarrow")
-    ddf2 = dd.read_parquet(tmpdir, engine="pyarrow", calculate_divisions=True)
+    ddf1.to_parquet(tmpdir)
+    ddf2 = dd.read_parquet(tmpdir, calculate_divisions=True)
 
     assert_eq(ddf1, ddf2, check_index=False)
 
 
 @PYARROW_MARK
-def test_pandas_timestamp_overflow_pyarrow(tmpdir):
+def test_pandas_timestamp_overflow_pyarrow(tmpdir, monkeypatch):
     info = np.iinfo(np.dtype("int64"))
     # In `numpy=1.24.0` NumPy warns when an overflow is encountered when casting from float to int
     # https://numpy.org/doc/stable/release/1.24.0-notes.html#numpy-now-gives-floating-point-errors-in-casts
@@ -3383,14 +3279,14 @@ def test_pandas_timestamp_overflow_pyarrow(tmpdir):
     if pyarrow_version < parse_version("13.0.0.dev"):
         # This will raise by default due to overflow
         with pytest.raises(pa.lib.ArrowInvalid) as e:
-            dd.read_parquet(str(tmpdir), engine="pyarrow").compute()
+            dd.read_parquet(str(tmpdir)).compute()
             assert "out of bounds" in str(e.value)
     else:
-        dd.read_parquet(str(tmpdir), engine="pyarrow").compute()
+        dd.read_parquet(str(tmpdir)).compute()
 
-    from dask.dataframe.io.parquet.arrow import ArrowDatasetEngine as ArrowEngine
+    from dask.dataframe.io.parquet.arrow import ArrowDatasetEngine
 
-    class ArrowEngineWithTimestampClamp(ArrowEngine):
+    class ArrowEngineWithTimestampClamp(ArrowDatasetEngine):
         @classmethod
         def clamp_arrow_datetimes(cls, arrow_table: pa.Table) -> pa.Table:
             """Constrain datetimes to be valid for pandas
@@ -3443,8 +3339,13 @@ def test_pandas_timestamp_overflow_pyarrow(tmpdir):
                 **kwargs,
             )
 
+    from dask.dataframe.io.parquet.core import _ENGINES
+
+    assert _ENGINES["pyarrow"] is ArrowDatasetEngine
+    monkeypatch.setitem(_ENGINES, "pyarrow", ArrowEngineWithTimestampClamp)
+
     # this should not fail, but instead produce timestamps that are in the valid range
-    dd.read_parquet(str(tmpdir), engine=ArrowEngineWithTimestampClamp).compute()
+    dd.read_parquet(str(tmpdir)).compute()
 
 
 @PYARROW_MARK
@@ -3454,11 +3355,11 @@ def test_arrow_to_pandas(tmpdir, engine):
 
     df = pd.DataFrame({"A": [pd.Timestamp("2000-01-01")]})
     path = str(tmpdir.join("test.parquet"))
-    df.to_parquet(path, engine=engine)
+    df.to_parquet(path, **engine)
 
     arrow_to_pandas = {"timestamp_as_object": True}
     expect = pq.ParquetFile(path).read().to_pandas(**arrow_to_pandas)
-    got = dd.read_parquet(path, engine="pyarrow", arrow_to_pandas=arrow_to_pandas)
+    got = dd.read_parquet(path, arrow_to_pandas=arrow_to_pandas)
 
     assert_eq(expect, got)
     assert got.A.dtype == got.compute().A.dtype
@@ -3483,24 +3384,26 @@ def test_partitioned_column_overlap(tmpdir, engine, write_cols):
     df1.to_parquet(path0, index=False)
     df2.to_parquet(path1, index=False)
 
-    if engine == "fastparquet":
+    if engine == {"engine": "fastparquet"}:
         path = [path0, path1]
     else:
         path = str(tmpdir)
 
     expect = pd.concat([_df1, _df2], ignore_index=True)
-    if engine == "fastparquet" and fastparquet_version > parse_version("0.8.3"):
+    if engine == {"engine": "fastparquet"} and fastparquet_version > parse_version(
+        "0.8.3"
+    ):
         # columns will change order and partitions will be categorical
-        result = dd.read_parquet(path, engine=engine)
+        result = dd.read_parquet(path, **engine)
         assert result.compute().reset_index(drop=True).to_dict() == expect.to_dict()
     elif write_cols == ["part", "kind", "col"]:
-        result = dd.read_parquet(path, engine=engine)
+        result = dd.read_parquet(path, **engine)
         assert_eq(result, expect, check_index=False)
     else:
         # For now, partial overlap between partition columns and
         # real columns is not allowed for pyarrow or older fastparquet
         with pytest.raises(ValueError):
-            dd.read_parquet(path, engine=engine)
+            dd.read_parquet(path, **engine)
 
 
 @PYARROW_MARK
@@ -3535,7 +3438,7 @@ def test_partitioned_no_pandas_metadata(tmpdir, engine, write_cols):
 
     # Check results
     expect = pd.concat([_df1, _df2], ignore_index=True)
-    result = dd.read_parquet(str(tmpdir), engine=engine)
+    result = dd.read_parquet(str(tmpdir), **engine)
     result["part"] = result["part"].astype("object")
     assert_eq(result[list(expect.columns)], expect, check_index=False)
 
@@ -3549,21 +3452,19 @@ def test_pyarrow_directory_partitioning(tmpdir):
     path2 = os.path.join(path2, "data.parquet")
     _df1 = pd.DataFrame({"part": "a", "col": range(5)})
     _df2 = pd.DataFrame({"part": "b", "col": range(5)})
-    _df1.to_parquet(path1, engine="pyarrow")
-    _df2.to_parquet(path2, engine="pyarrow")
+    _df1.to_parquet(path1)
+    _df2.to_parquet(path2)
 
     # Check results
     expect = pd.concat([_df1, _df2], ignore_index=True)
     result = dd.read_parquet(
         str(tmpdir),
-        engine="pyarrow",
         dataset={"partitioning": ["part"], "partition_base_dir": str(tmpdir)},
     )
     result["part"] = result["part"].astype("object")
     assert_eq(result[list(expect.columns)], expect, check_index=False)
 
 
-@fp_pandas_xfail
 def test_partitioned_preserve_index(tmpdir, write_engine, read_engine):
     tmp = str(tmpdir)
     size = 1_000
@@ -3578,66 +3479,47 @@ def test_partitioned_preserve_index(tmpdir, write_engine, read_engine):
     ).set_index("myindex")
     data.index.name = None
     df1 = dd.from_pandas(data, npartitions=npartitions)
-    df1.to_parquet(tmp, partition_on="B", engine=write_engine)
+    df1.to_parquet(tmp, partition_on="B", **write_engine)
 
     expect = data[data["B"] == 1]
-    if PANDAS_GE_200 and read_engine == "fastparquet":
+    if PANDAS_GE_200 and read_engine == {"engine": "fastparquet"}:
         # fastparquet does not preserve dtype of cats
         expect = expect.copy()  # SettingWithCopyWarning
         expect["B"] = expect["B"].astype(
             pd.CategoricalDtype(expect["B"].dtype.categories.astype("int64"))
         )
-    got = dd.read_parquet(tmp, engine=read_engine, filters=[("B", "==", 1)])
+    got = dd.read_parquet(tmp, filters=[("B", "==", 1)], **read_engine)
     assert_eq(expect, got)
 
 
 def test_from_pandas_preserve_none_index(tmpdir, engine):
-    if engine.startswith("pyarrow"):
-        pytest.importorskip("pyarrow", minversion="0.15.0")
-
     fn = str(tmpdir.join("test.parquet"))
     df = pd.DataFrame({"a": [1, 2], "b": [4, 5], "c": [6, 7]}).set_index("c")
     df.index.name = None
-    df.to_parquet(
-        fn,
-        engine="pyarrow" if engine.startswith("pyarrow") else "fastparquet",
-        index=True,
-    )
-
+    df.to_parquet(fn, index=True, **engine)
     expect = pd.read_parquet(fn)
-    got = dd.read_parquet(fn, engine=engine)
+    got = dd.read_parquet(fn, **engine)
     assert_eq(expect, got)
 
 
 def test_multi_partition_none_index_false(tmpdir, engine):
-    if engine.startswith("pyarrow"):
-        pytest.importorskip("pyarrow", minversion="0.15.0")
-        write_engine = "pyarrow"
-    else:
-        assert engine == "fastparquet"
-        write_engine = "fastparquet"
-
     # Write dataset without dask.to_parquet
     ddf1 = ddf.reset_index(drop=True)
     for i, part in enumerate(ddf1.partitions):
         path = tmpdir.join(f"test.{i}.parquet")
-        part.compute().to_parquet(str(path), engine=write_engine)
+        part.compute().to_parquet(str(path), **engine)
 
     # Read back with index=False
-    ddf2 = dd.read_parquet(str(tmpdir), index=False, engine=engine)
+    ddf2 = dd.read_parquet(str(tmpdir), index=False, **engine)
     assert_eq(ddf1, ddf2)
 
 
-@write_read_engines()
 def test_from_pandas_preserve_none_rangeindex(tmpdir, write_engine, read_engine):
     # See GitHub Issue#6348
     fn = str(tmpdir.join("test.parquet"))
     df0 = pd.DataFrame({"t": [1, 2, 3]}, index=pd.RangeIndex(start=1, stop=4))
-    df0.to_parquet(
-        fn, engine="pyarrow" if write_engine.startswith("pyarrow") else "fastparquet"
-    )
-
-    df1 = dd.read_parquet(fn, engine=read_engine)
+    df0.to_parquet(fn, **write_engine)
+    df1 = dd.read_parquet(fn, **read_engine)
     assert_eq(df0, df1.compute())
 
 
@@ -3653,21 +3535,21 @@ def test_illegal_column_name(tmpdir, engine):
     # If we don't want to preserve the None index name, the
     # write should work, but the user should be warned
     with pytest.warns(UserWarning, match=null_name):
-        ddf.to_parquet(fn, engine=engine, write_index=False)
+        ddf.to_parquet(fn, write_index=False, **engine)
 
     # If we do want to preserve the None index name, should
     # get a ValueError for having an illegal column name
     with pytest.raises(ValueError) as e:
-        ddf.to_parquet(fn, engine=engine)
+        ddf.to_parquet(fn, **engine)
     assert null_name in str(e.value)
 
 
 def test_divisions_with_null_partition(tmpdir, engine):
     df = pd.DataFrame({"a": [1, 2, None, None], "b": [1, 2, 3, 4]})
     ddf = dd.from_pandas(df, npartitions=2)
-    ddf.to_parquet(str(tmpdir), engine=engine, write_index=False)
+    ddf.to_parquet(str(tmpdir), write_index=False, **engine)
 
-    ddf_read = dd.read_parquet(str(tmpdir), engine=engine, index="a")
+    ddf_read = dd.read_parquet(str(tmpdir), index="a", **engine)
     assert ddf_read.divisions == (None, None, None)
 
 
@@ -3677,8 +3559,8 @@ def test_pyarrow_dataset_simple(tmpdir, engine):
     df = pd.DataFrame({"a": [4, 5, 6], "b": ["a", "b", "b"]})
     df = df.set_index("a", drop=True)
     ddf = dd.from_pandas(df, npartitions=2)
-    ddf.to_parquet(fn, engine=engine)
-    read_df = dd.read_parquet(fn, engine="pyarrow", calculate_divisions=True)
+    ddf.to_parquet(fn, **engine)
+    read_df = dd.read_parquet(fn, calculate_divisions=True)
     read_df.compute()
     assert_eq(ddf, read_df)
 
@@ -3690,10 +3572,9 @@ def test_pyarrow_dataset_partitioned(tmpdir, engine, test_filter):
     df = pd.DataFrame({"a": [4, 5, 6], "b": ["a", "b", "b"]})
     df["b"] = df["b"].astype("category")
     ddf = dd.from_pandas(df, npartitions=2)
-    ddf.to_parquet(fn, engine=engine, partition_on="b", write_metadata_file=True)
+    ddf.to_parquet(fn, partition_on="b", write_metadata_file=True, **engine)
     read_df = dd.read_parquet(
         fn,
-        engine="pyarrow",
         filters=[("b", "==", "a")] if test_filter else None,
         calculate_divisions=True,
     )
@@ -3707,7 +3588,6 @@ def test_pyarrow_dataset_partitioned(tmpdir, engine, test_filter):
 @PYARROW_MARK
 @pytest.mark.parametrize("scheduler", [None, "processes"])
 def test_null_partition_pyarrow(tmpdir, scheduler):
-    engine = "pyarrow"
     df = pd.DataFrame(
         {
             "id": pd.Series([0, 1, None], dtype="Int64"),
@@ -3715,14 +3595,13 @@ def test_null_partition_pyarrow(tmpdir, scheduler):
         }
     )
     ddf = dd.from_pandas(df, npartitions=1)
-    ddf.to_parquet(str(tmpdir), engine=engine, partition_on="id")
+    ddf.to_parquet(str(tmpdir), partition_on="id")
     fns = glob.glob(os.path.join(tmpdir, "id=*/*.parquet"))
     assert len(fns) == 3
 
     # Check proper partitioning usage
     ddf_read = dd.read_parquet(
         str(tmpdir),
-        engine=engine,
         dtype_backend="numpy_nullable",
         dataset={
             "partitioning": {
@@ -3751,21 +3630,14 @@ def test_pyarrow_dataset_read_from_paths(tmpdir):
     df = pd.DataFrame({"a": [4, 5, 6], "b": ["a", "b", "b"]})
     df["b"] = df["b"].astype("category")
     ddf = dd.from_pandas(df, npartitions=2)
-    ddf.to_parquet(fn, engine="pyarrow", partition_on="b")
+    ddf.to_parquet(fn, partition_on="b")
 
     with pytest.warns(FutureWarning):
         read_df_1 = dd.read_parquet(
-            fn,
-            engine="pyarrow",
-            filters=[("b", "==", "a")],
-            read_from_paths=False,
+            fn, filters=[("b", "==", "a")], read_from_paths=False
         )
 
-    read_df_2 = dd.read_parquet(
-        fn,
-        engine="pyarrow",
-        filters=[("b", "==", "a")],
-    )
+    read_df_2 = dd.read_parquet(fn, filters=[("b", "==", "a")])
 
     assert_eq(read_df_1, read_df_2)
     assert_eq(ddf[ddf["b"] == "a"].compute(), read_df_2.compute())
@@ -3784,12 +3656,11 @@ def test_pyarrow_dataset_filter_partitioned(tmpdir, split_row_groups):
     )
     df["b"] = df["b"].astype("category")
     ddf = dd.from_pandas(df, npartitions=2)
-    ddf.to_parquet(fn, engine="pyarrow", partition_on=["b", "c"])
+    ddf.to_parquet(fn, partition_on=["b", "c"])
 
     # Filter on a a non-partition column
     read_df = dd.read_parquet(
         fn,
-        engine="pyarrow",
         split_row_groups=split_row_groups,
         filters=[("a", "==", 5)],
     )
@@ -3807,25 +3678,17 @@ def test_pyarrow_dataset_filter_on_partitioned(tmpdir, engine):
         lambda i: df.iloc[i : i + 1],
         range(7),
     )
-    ddf.to_parquet(tmpdir, engine=engine, partition_on=["part"])
+    ddf.to_parquet(tmpdir, partition_on=["part"], **engine)
 
     # Check that List[Tuple] filters are applied
-    read_ddf = dd.read_parquet(
-        tmpdir,
-        engine=engine,
-        filters=[("part", "==", "c")],
-    )
+    read_ddf = dd.read_parquet(tmpdir, filters=[("part", "==", "c")], **engine)
     read_ddf["part"] = read_ddf["part"].astype("object")
     assert_eq(df.iloc[2:3], read_ddf)
 
-    # Check that List[List[Tuple]] filters are aplied.
+    # Check that List[List[Tuple]] filters are applied.
     # (fastparquet doesn't support this format)
-    if engine == "pyarrow":
-        read_ddf = dd.read_parquet(
-            tmpdir,
-            engine=engine,
-            filters=[[("part", "==", "c")]],
-        )
+    if engine == {}:  # payrrow
+        read_ddf = dd.read_parquet(tmpdir, filters=[[("part", "==", "c")]])
         read_ddf["part"] = read_ddf["part"].astype("object")
         assert_eq(df.iloc[2:3], read_ddf)
 
@@ -3848,7 +3711,6 @@ def test_parquet_pyarrow_write_empty_metadata(tmpdir):
     df = dd.from_delayed([df_a, df_b, df_c])
     df.to_parquet(
         tmpdir,
-        engine="pyarrow",
         partition_on=["x"],
         append=False,
         write_metadata_file=True,
@@ -3883,7 +3745,6 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
     df1 = dd.from_delayed([df_a, df_b])
     df1.to_parquet(
         tmpdir,
-        engine="pyarrow",
         partition_on=["x"],
         append=False,
         write_metadata_file=True,
@@ -3899,7 +3760,6 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
     df2 = dd.from_delayed([df_c, df_d])
     df2.to_parquet(
         tmpdir,
-        engine="pyarrow",
         partition_on=["x"],
         append=True,
         ignore_divisions=True,
@@ -3909,7 +3769,6 @@ def test_parquet_pyarrow_write_empty_metadata_append(tmpdir):
 
 @PYARROW_MARK
 @pytest.mark.parametrize("partition_on", [None, "a"])
-@write_read_engines()
 def test_create_metadata_file(tmpdir, write_engine, read_engine, partition_on):
     tmpdir = str(tmpdir)
 
@@ -3921,7 +3780,7 @@ def test_create_metadata_file(tmpdir, write_engine, read_engine, partition_on):
         tmpdir,
         write_metadata_file=False,
         partition_on=partition_on,
-        engine=write_engine,
+        **write_engine,
     )
 
     # Add global _metadata file
@@ -3931,7 +3790,6 @@ def test_create_metadata_file(tmpdir, write_engine, read_engine, partition_on):
         fns = glob.glob(os.path.join(tmpdir, "*.parquet"))
     dd.io.parquet.create_metadata_file(
         fns,
-        engine="pyarrow",
         split_every=3,  # Force tree reduction
     )
 
@@ -3941,7 +3799,7 @@ def test_create_metadata_file(tmpdir, write_engine, read_engine, partition_on):
         tmpdir,
         calculate_divisions=True,
         split_row_groups=False,
-        engine=read_engine,
+        **read_engine,
         index="myindex",  # python-3.6 CI
     )
     if partition_on:
@@ -3953,7 +3811,6 @@ def test_create_metadata_file(tmpdir, write_engine, read_engine, partition_on):
     # Check if we can avoid writing an actual file
     fmd = dd.io.parquet.create_metadata_file(
         fns,
-        engine="pyarrow",
         split_every=3,  # Force tree reduction
         out_dir=False,  # Avoid writing file
     )
@@ -3978,14 +3835,14 @@ def test_read_write_overwrite_is_true(tmpdir, engine):
         npartitions=5,
     )
     ddf = ddf.reset_index(drop=True)
-    dd.to_parquet(ddf, tmpdir, engine=engine, overwrite=True)
+    dd.to_parquet(ddf, tmpdir, overwrite=True, **engine)
 
     # Keep the contents of the DataFrame constant but change the # of partitions
     ddf2 = ddf.repartition(npartitions=3)
 
     # Overwrite the existing Dataset with the new dataframe and evaluate
     # the number of files against the number of dask partitions
-    dd.to_parquet(ddf2, tmpdir, engine=engine, overwrite=True)
+    dd.to_parquet(ddf2, tmpdir, overwrite=True, **engine)
 
     # Assert the # of files written are identical to the number of
     # Dask DataFrame partitions (we exclude _metadata and _common_metadata)
@@ -4010,7 +3867,7 @@ def test_read_write_partition_on_overwrite_is_true(tmpdir, engine):
     )
     df.columns = ["A", "B", "C"]
     ddf = dd.from_pandas(df, npartitions=5)
-    dd.to_parquet(ddf, tmpdir, engine=engine, partition_on=["A", "B"], overwrite=True)
+    dd.to_parquet(ddf, tmpdir, partition_on=["A", "B"], overwrite=True, **engine)
 
     # Get the total number of files and directories from the original write
     files_ = Path(tmpdir).rglob("*")
@@ -4021,7 +3878,7 @@ def test_read_write_partition_on_overwrite_is_true(tmpdir, engine):
     # Overwrite the existing Dataset with the new dataframe and evaluate
     # the number of files against the number of dask partitions
     # Get the total number of files and directories from the original write
-    dd.to_parquet(ddf2, tmpdir, engine=engine, partition_on=["A", "B"], overwrite=True)
+    dd.to_parquet(ddf2, tmpdir, partition_on=["A", "B"], overwrite=True, **engine)
     files2_ = Path(tmpdir).rglob("*")
     files2 = [f.as_posix() for f in files2_]
     # After reducing the # of partitions and overwriting, we expect
@@ -4033,22 +3890,16 @@ def test_to_parquet_overwrite_adaptive_round_trip(tmpdir, engine):
     df = pd.DataFrame({"a": range(128)})
     ddf = dd.from_pandas(df, npartitions=8)
     path = os.path.join(str(tmpdir), "path")
-    ddf.to_parquet(path, engine=engine)
-    ddf2 = dd.read_parquet(
-        path,
-        engine=engine,
-        split_row_groups="adaptive",
-    ).repartition(partition_size="1GB")
+    ddf.to_parquet(path, **engine)
+    ddf2 = dd.read_parquet(path, split_row_groups="adaptive", **engine).repartition(
+        partition_size="1GB"
+    )
     path_new = os.path.join(str(tmpdir), "path_new")
-    ddf2.to_parquet(path_new, engine=engine, overwrite=True)
-    ddf2.to_parquet(path_new, engine=engine, overwrite=True)
+    ddf2.to_parquet(path_new, overwrite=True, **engine)
+    ddf2.to_parquet(path_new, overwrite=True, **engine)
     assert_eq(
         ddf2,
-        dd.read_parquet(
-            path_new,
-            engine=engine,
-            split_row_groups=False,
-        ),
+        dd.read_parquet(path_new, split_row_groups=False, **engine),
     )
 
 
@@ -4059,9 +3910,9 @@ def test_to_parquet_overwrite_raises(tmpdir, engine):
     df = pd.DataFrame({"a": range(12)})
     ddf = dd.from_pandas(df, npartitions=3)
     with pytest.raises(ValueError):
-        dd.to_parquet(ddf, "./", engine=engine, overwrite=True)
+        dd.to_parquet(ddf, "./", overwrite=True, **engine)
     with pytest.raises(ValueError):
-        dd.to_parquet(ddf, tmpdir, engine=engine, append=True, overwrite=True)
+        dd.to_parquet(ddf, tmpdir, append=True, overwrite=True, **engine)
 
 
 def test_to_parquet_overwrite_files_from_read_parquet_in_same_call_raises(
@@ -4070,7 +3921,7 @@ def test_to_parquet_overwrite_files_from_read_parquet_in_same_call_raises(
     subdir = tmpdir.mkdir("subdir")
 
     dd.from_pandas(pd.DataFrame({"x": range(20)}), npartitions=2).to_parquet(
-        subdir, engine=engine
+        subdir, **engine
     )
 
     ddf = dd.read_parquet(subdir)
@@ -4090,7 +3941,7 @@ def test_to_parquet_errors_non_string_column_names(tmpdir, engine):
     df = pd.DataFrame({"x": range(10), 1: range(10)})
     ddf = dd.from_pandas(df, npartitions=2)
     with pytest.raises(ValueError, match="non-string column names"):
-        ddf.to_parquet(str(tmpdir.join("temp")), engine=engine)
+        ddf.to_parquet(str(tmpdir.join("temp")), **engine)
 
 
 def test_dir_filter(tmpdir, engine):
@@ -4119,8 +3970,8 @@ def test_dir_filter(tmpdir, engine):
         }
     )
     ddf = dask.dataframe.from_pandas(df, npartitions=1)
-    ddf.to_parquet(tmpdir, partition_on="year", engine=engine)
-    ddf2 = dd.read_parquet(tmpdir, filters=[("year", "==", 2020)], engine=engine)
+    ddf.to_parquet(tmpdir, partition_on="year", **engine)
+    ddf2 = dd.read_parquet(tmpdir, filters=[("year", "==", 2020)], **engine)
     ddf2["year"] = ddf2.year.astype("int64")
     assert_eq(ddf2, df[df.year == 2020])
 
@@ -4139,8 +3990,8 @@ def test_roundtrip_decimal_dtype(tmpdir):
     ]
     ddf1 = dd.from_pandas(pd.DataFrame(data), npartitions=1)
 
-    ddf1.to_parquet(path=tmpdir, engine="pyarrow", schema={"col1": pa.decimal128(5, 2)})
-    ddf2 = dd.read_parquet(tmpdir, engine="pyarrow")
+    ddf1.to_parquet(path=tmpdir, schema={"col1": pa.decimal128(5, 2)})
+    ddf2 = dd.read_parquet(tmpdir)
 
     if pyarrow_strings_enabled():
         assert pa.types.is_decimal(ddf2["col1"].dtype.pyarrow_dtype)
@@ -4164,8 +4015,8 @@ def test_roundtrip_date_dtype(tmpdir):
     ]
     ddf1 = dd.from_pandas(pd.DataFrame(data), npartitions=1)
 
-    ddf1.to_parquet(path=tmpdir, engine="pyarrow", schema={"col1": pa.date32()})
-    ddf2 = dd.read_parquet(tmpdir, engine="pyarrow")
+    ddf1.to_parquet(path=tmpdir, schema={"col1": pa.date32()})
+    ddf2 = dd.read_parquet(tmpdir)
 
     if pyarrow_strings_enabled():
         assert pa.types.is_date32(ddf2["col1"].dtype.pyarrow_dtype)
@@ -4183,7 +4034,7 @@ def test_roundtrip_rename_columns(tmpdir, engine):
     df1.to_parquet(path)
 
     # read it with dask and rename columns
-    ddf2 = dd.read_parquet(path, engine=engine)
+    ddf2 = dd.read_parquet(path, **engine)
     ddf2.columns = ["d", "e", "f"]
     df1.columns = ["d", "e", "f"]
 
@@ -4201,13 +4052,13 @@ def test_custom_metadata(tmpdir, engine):
     df = pd.DataFrame({"a": range(10), "b": range(10)})
     dd.from_pandas(df, npartitions=2).to_parquet(
         path,
-        engine=engine,
         custom_metadata=custom_metadata,
         write_metadata_file=True,
+        **engine,
     )
 
     # Check that data is correct
-    assert_eq(df, dd.read_parquet(path, engine=engine))
+    assert_eq(df, dd.read_parquet(path, **engine))
 
     # Require pyarrow.parquet to check key/value metadata
     if pq:
@@ -4225,9 +4076,7 @@ def test_custom_metadata(tmpdir, engine):
     custom_metadata = {b"pandas": b"my_new_pandas_md"}
     with pytest.raises(ValueError) as e:
         dd.from_pandas(df, npartitions=2).to_parquet(
-            path,
-            engine=engine,
-            custom_metadata=custom_metadata,
+            path, custom_metadata=custom_metadata, **engine
         )
     assert "User-defined key/value" in str(e.value)
 
@@ -4241,12 +4090,8 @@ def test_ignore_metadata_file(tmpdir, engine, calculate_divisions):
     # Write two identical datasets without any _metadata file
     df1 = pd.DataFrame({"a": range(100), "b": ["dog", "cat"] * 50})
     ddf1 = dd.from_pandas(df1, npartitions=2)
-    ddf1.to_parquet(
-        path=dataset_with_bad_metadata, engine=engine, write_metadata_file=False
-    )
-    ddf1.to_parquet(
-        path=dataset_without_metadata, engine=engine, write_metadata_file=False
-    )
+    ddf1.to_parquet(path=dataset_with_bad_metadata, write_metadata_file=False, **engine)
+    ddf1.to_parquet(path=dataset_without_metadata, write_metadata_file=False, **engine)
 
     # Copy "bad" metadata into `dataset_with_bad_metadata`
     assert "_metadata" not in os.listdir(dataset_with_bad_metadata)
@@ -4259,15 +4104,15 @@ def test_ignore_metadata_file(tmpdir, engine, calculate_divisions):
     # test that the results are the same
     ddf2a = dd.read_parquet(
         dataset_with_bad_metadata,
-        engine=engine,
         ignore_metadata_file=True,
         calculate_divisions=calculate_divisions,
+        **engine,
     )
     ddf2b = dd.read_parquet(
         dataset_without_metadata,
-        engine=engine,
         ignore_metadata_file=True,
         calculate_divisions=calculate_divisions,
+        **engine,
     )
     assert_eq(ddf2a, ddf2b)
 
@@ -4279,32 +4124,22 @@ def test_metadata_task_size(tmpdir, engine, write_metadata_file, metadata_task_s
     tmpdir = str(tmpdir)
     df1 = pd.DataFrame({"a": range(100), "b": ["dog", "cat"] * 50})
     ddf1 = dd.from_pandas(df1, npartitions=10)
-    ddf1.to_parquet(
-        path=str(tmpdir), engine=engine, write_metadata_file=write_metadata_file
-    )
+    ddf1.to_parquet(path=str(tmpdir), write_metadata_file=write_metadata_file, **engine)
 
     # Read back
-    ddf2a = dd.read_parquet(
-        str(tmpdir),
-        engine=engine,
-        calculate_divisions=True,
-    )
+    ddf2a = dd.read_parquet(str(tmpdir), calculate_divisions=True, **engine)
     ddf2b = dd.read_parquet(
         str(tmpdir),
-        engine=engine,
         calculate_divisions=True,
         metadata_task_size=metadata_task_size,
+        **engine,
     )
     assert_eq(ddf2a, ddf2b)
 
     with dask.config.set(
         {"dataframe.parquet.metadata-task-size-local": metadata_task_size}
     ):
-        ddf2c = dd.read_parquet(
-            str(tmpdir),
-            engine=engine,
-            calculate_divisions=True,
-        )
+        ddf2c = dd.read_parquet(str(tmpdir), calculate_divisions=True, **engine)
     assert_eq(ddf2b, ddf2c)
 
 
@@ -4318,15 +4153,12 @@ def test_extra_file(tmpdir, engine, partition_on):
     df = df.assign(b=df.b.astype("category"))
     ddf = dd.from_pandas(df, npartitions=2)
     ddf.to_parquet(
-        tmpdir,
-        engine=engine,
-        write_metadata_file=True,
-        partition_on=partition_on,
+        tmpdir, write_metadata_file=True, partition_on=partition_on, **engine
     )
     open(os.path.join(tmpdir, "_SUCCESS"), "w").close()
     open(os.path.join(tmpdir, "part.0.parquet.crc"), "w").close()
     os.remove(os.path.join(tmpdir, "_metadata"))
-    out = dd.read_parquet(tmpdir, engine=engine, calculate_divisions=True)
+    out = dd.read_parquet(tmpdir, calculate_divisions=True, **engine)
     # Weird two-step since that we don't care if category ordering changes
     assert_eq(out, df, check_categorical=False)
     assert_eq(out.b, df.b, check_category_order=False)
@@ -4347,9 +4179,9 @@ def test_extra_file(tmpdir, engine, partition_on):
     # Should Work
     out = dd.read_parquet(
         tmpdir,
-        engine=engine,
         **_parquet_file_extension(".parquet"),
         calculate_divisions=True,
+        **engine,
     )
     # Weird two-step since that we don't care if category ordering changes
     assert_eq(out, df, check_categorical=False)
@@ -4359,23 +4191,19 @@ def test_extra_file(tmpdir, engine, partition_on):
     with pytest.warns(FutureWarning, match="require_extension is deprecated"):
         out = dd.read_parquet(
             tmpdir,
-            engine=engine,
             **_parquet_file_extension(".parquet", legacy=True),
             calculate_divisions=True,
+            **engine,
         )
 
     # Should Fail (for not capturing the _SUCCESS and crc files)
     with pytest.raises((OSError, pa.lib.ArrowInvalid)):
-        dd.read_parquet(
-            tmpdir, engine=engine, **_parquet_file_extension(None)
-        ).compute()
+        dd.read_parquet(tmpdir, **engine, **_parquet_file_extension(None)).compute()
 
     # Should Fail (for filtering out all files)
     # (Related to: https://github.com/dask/dask/issues/8349)
     with pytest.raises(ValueError):
-        dd.read_parquet(
-            tmpdir, engine=engine, **_parquet_file_extension(".foo")
-        ).compute()
+        dd.read_parquet(tmpdir, **engine, **_parquet_file_extension(".foo")).compute()
 
 
 def test_unsupported_extension_file(tmpdir, engine):
@@ -4384,10 +4212,8 @@ def test_unsupported_extension_file(tmpdir, engine):
     # (See: https://github.com/dask/dask/issues/8349)
     fn = os.path.join(str(tmpdir), "multi.foo")
     df0 = pd.DataFrame({"a": range(10)})
-    df0.to_parquet(fn, engine=engine)
-    assert_eq(
-        df0, dd.read_parquet(fn, engine=engine, index=False, calculate_divisions=True)
-    )
+    df0.to_parquet(fn, **engine)
+    assert_eq(df0, dd.read_parquet(fn, index=False, calculate_divisions=True, **engine))
 
 
 def test_unsupported_extension_dir(tmpdir, engine):
@@ -4398,11 +4224,11 @@ def test_unsupported_extension_dir(tmpdir, engine):
     ddf0 = dd.from_pandas(pd.DataFrame({"a": range(10)}), 1)
     ddf0.to_parquet(
         path,
-        engine=engine,
         name_function=lambda i: f"part.{i}.foo",
         write_metadata_file=True,
+        **engine,
     )
-    assert_eq(ddf0, dd.read_parquet(path, engine=engine, calculate_divisions=True))
+    assert_eq(ddf0, dd.read_parquet(path, calculate_divisions=True, **engine))
 
 
 def test_custom_filename(tmpdir, engine):
@@ -4415,7 +4241,7 @@ def test_custom_filename(tmpdir, engine):
         fn,
         write_metadata_file=True,
         name_function=lambda x: f"hi-{x}.parquet",
-        engine=engine,
+        **engine,
     )
 
     files = os.listdir(fn)
@@ -4423,10 +4249,11 @@ def test_custom_filename(tmpdir, engine):
     assert "_metadata" in files
     assert "hi-0.parquet" in files
     assert "hi-1.parquet" in files
-    assert_eq(df, dd.read_parquet(fn, engine=engine, calculate_divisions=True))
+    assert_eq(df, dd.read_parquet(fn, calculate_divisions=True, **engine))
 
 
-def test_custom_filename_works_with_pyarrow_when_append_is_true(tmpdir, engine):
+@PYARROW_MARK
+def test_custom_filename_works_with_pyarrow_when_append_is_true(tmpdir):
     fn = str(tmpdir)
     pdf = pd.DataFrame(
         {"num1": [1, 2, 3, 4], "num2": [7, 8, 9, 10]},
@@ -4436,23 +4263,16 @@ def test_custom_filename_works_with_pyarrow_when_append_is_true(tmpdir, engine):
         fn,
         write_metadata_file=True,
         name_function=lambda x: f"hi-{x * 2}.parquet",
-        engine=engine,
     )
 
     pdf = pd.DataFrame(
         {"num1": [33], "num2": [44]},
     )
     df = dd.from_pandas(pdf, npartitions=1)
-    if engine == "fastparquet":
-        pytest.xfail(
-            "fastparquet errors our with IndexError when ``name_function`` is customized "
-            "and append is set to True.  We didn't do a detailed investigation for expediency. "
-            "See this comment for the conversation: https://github.com/dask/dask/pull/7682#issuecomment-845243623"
-        )
+
     df.to_parquet(
         fn,
         name_function=lambda x: f"hi-{x * 2}.parquet",
-        engine=engine,
         append=True,
         ignore_divisions=True,
     )
@@ -4465,7 +4285,7 @@ def test_custom_filename_works_with_pyarrow_when_append_is_true(tmpdir, engine):
     expected_pdf = pd.DataFrame(
         {"num1": [1, 2, 3, 4, 33], "num2": [7, 8, 9, 10, 44]},
     )
-    actual = dd.read_parquet(fn, engine=engine, index=False)
+    actual = dd.read_parquet(fn, index=False)
     assert_eq(actual, expected_pdf, check_index=False)
 
 
@@ -4478,12 +4298,12 @@ def test_throws_error_if_custom_filename_is_invalid(tmpdir, engine):
     with pytest.raises(
         ValueError, match="``name_function`` must be a callable with one argument."
     ):
-        df.to_parquet(fn, name_function="whatever.parquet", engine=engine)
+        df.to_parquet(fn, name_function="whatever.parquet", **engine)
 
     with pytest.raises(
         ValueError, match="``name_function`` must produce unique filenames."
     ):
-        df.to_parquet(fn, name_function=lambda x: "whatever.parquet", engine=engine)
+        df.to_parquet(fn, name_function=lambda x: "whatever.parquet", **engine)
 
 
 def test_custom_filename_with_partition(tmpdir, engine):
@@ -4497,10 +4317,10 @@ def test_custom_filename_with_partition(tmpdir, engine):
     df = dd.from_pandas(pdf, npartitions=4)
     df.to_parquet(
         fn,
-        engine=engine,
         partition_on=["country"],
         name_function=lambda x: f"{x}-cool.parquet",
         write_index=False,
+        **engine,
     )
 
     for _, dirs, files in os.walk(fn):
@@ -4516,7 +4336,7 @@ def test_custom_filename_with_partition(tmpdir, engine):
                 "_common_metadata",
                 "_metadata",
             )
-    actual = dd.read_parquet(fn, engine=engine, index=False)
+    actual = dd.read_parquet(fn, index=False, **engine)
     assert_eq(
         pdf, actual, check_index=False, check_dtype=False, check_categorical=False
     )
@@ -4526,7 +4346,7 @@ def test_custom_filename_with_partition(tmpdir, engine):
 def test_roundtrip_partitioned_pyarrow_dataset(tmpdir, engine):
     # See: https://github.com/dask/dask/issues/8650
 
-    if engine == "fastparquet" and PANDAS_GE_200:
+    if engine == {"engine": "fastparquet"} and PANDAS_GE_200:
         # https://github.com/dask/dask/issues/9966
         pytest.xfail("fastparquet reads as int64 while pyarrow does as int32")
 
@@ -4539,7 +4359,7 @@ def test_roundtrip_partitioned_pyarrow_dataset(tmpdir, engine):
     # Write partitioned dataset with dask
     dask_path = tmpdir.mkdir("foo-dask")
     ddf = dd.from_pandas(df, npartitions=2)
-    ddf.to_parquet(dask_path, engine=engine, partition_on=["col1"], write_index=False)
+    ddf.to_parquet(dask_path, partition_on=["col1"], write_index=False, **engine)
 
     # Write partitioned dataset with pyarrow
     pa_path = tmpdir.mkdir("foo-pyarrow")
@@ -4558,12 +4378,12 @@ def test_roundtrip_partitioned_pyarrow_dataset(tmpdir, engine):
         return x.sort_values("col2")[["col1", "col2"]]
 
     # Check that reading dask-written data is the same for pyarrow and dask
-    df_read_dask = dd.read_parquet(dask_path, engine=engine)
+    df_read_dask = dd.read_parquet(dask_path, **engine)
     df_read_pa = pq.read_table(dask_path).to_pandas()
     assert_eq(_prep(df_read_dask), _prep(df_read_pa), check_index=False)
 
     # Check that reading pyarrow-written data is the same for pyarrow and dask
-    df_read_dask = dd.read_parquet(pa_path, engine=engine)
+    df_read_dask = dd.read_parquet(pa_path, **engine)
     df_read_pa = pq.read_table(pa_path).to_pandas()
     assert_eq(_prep(df_read_dask), _prep(df_read_pa), check_index=False)
 
@@ -4575,19 +4395,19 @@ def test_in_predicate_can_use_iterables(tmp_path, engine, filter_value):
     df = pd.DataFrame(
         {"A": [1, 2, 3, 4], "B": [1, 1, 2, 2]},
     )
-    df.to_parquet(path, engine=engine)
+    df.to_parquet(path, **engine)
     filters = [("B", "in", filter_value)]
-    result = dd.read_parquet(path, engine=engine, filters=filters)
-    expected = pd.read_parquet(path, engine=engine, filters=filters)
+    result = dd.read_parquet(path, filters=filters, **engine)
+    expected = pd.read_parquet(path, filters=filters, **engine)
     assert_eq(result, expected)
 
     # pandas to_parquet outputs a single file, dask outputs a folder with global
     # metadata that changes the filtering code path
     ddf = dd.from_pandas(df, npartitions=2)
     path = tmp_path / "in_predicate_iterable_dask.parquet"
-    ddf.to_parquet(path, engine=engine)
-    result = dd.read_parquet(path, engine=engine, filters=filters)
-    expected = pd.read_parquet(path, engine=engine, filters=filters)
+    ddf.to_parquet(path, **engine)
+    result = dd.read_parquet(path, filters=filters, **engine)
+    expected = pd.read_parquet(path, filters=filters, **engine)
     assert_eq(result, expected, check_index=False)
 
 
@@ -4596,15 +4416,15 @@ def test_not_in_predicate(tmp_path, engine):
         {"A": range(8), "B": [1, 1, 2, 2, 3, 3, 4, 4]},
         npartitions=4,
     )
-    ddf.to_parquet(tmp_path, engine=engine)
+    ddf.to_parquet(tmp_path, **engine)
     filters = [[("B", "not in", (1, 2))]]
-    result = dd.read_parquet(tmp_path, engine=engine, filters=filters)
-    expected = pd.read_parquet(tmp_path, engine=engine, filters=filters)
+    result = dd.read_parquet(tmp_path, filters=filters, **engine)
+    expected = pd.read_parquet(tmp_path, filters=filters, **engine)
     assert_eq(result, expected, check_index=False)
 
     with pytest.raises(ValueError, match="not a valid operator in predicates"):
         unsupported_op = [[("B", "not eq", 1)]]
-        dd.read_parquet(tmp_path, engine=engine, filters=unsupported_op)
+        dd.read_parquet(tmp_path, filters=unsupported_op, **engine)
 
 
 # Non-iterable filter value with `in` predicate
@@ -4631,17 +4451,17 @@ def test_in_predicate_requires_an_iterable(tmp_path, engine, filter_value):
     df = pd.DataFrame(
         {"A": [1, 2, 3, 4], "B": [1, 1, 2, 2]},
     )
-    df.to_parquet(path, engine=engine)
+    df.to_parquet(path, **engine)
     with pytest.raises(TypeError, match="Value of 'in' filter"):
-        dd.read_parquet(path, engine=engine, filters=filter_value)
+        dd.read_parquet(path, filters=filter_value, **engine)
 
     # pandas to_parquet outputs a single file, dask outputs a folder with global
     # metadata that changes the filtering code path
     ddf = dd.from_pandas(df, npartitions=2)
     path = tmp_path / "gh_8720_dask.parquet"
-    ddf.to_parquet(path, engine=engine)
+    ddf.to_parquet(path, **engine)
     with pytest.raises(TypeError, match="Value of 'in' filter"):
-        dd.read_parquet(path, engine=engine, filters=filter_value)
+        dd.read_parquet(path, filters=filter_value, **engine)
 
 
 def test_deprecate_gather_statistics(tmp_path, engine):
@@ -4651,13 +4471,9 @@ def test_deprecate_gather_statistics(tmp_path, engine):
     # See: https://github.com/dask/dask/pull/8992
     df = pd.DataFrame({"a": range(10)})
     path = tmp_path / "test_deprecate_gather_statistics.parquet"
-    df.to_parquet(path, engine=engine)
+    df.to_parquet(path, **engine)
     with pytest.warns(FutureWarning, match="deprecated"):
-        out = dd.read_parquet(
-            path,
-            engine=engine,
-            gather_statistics=True,
-        )
+        out = dd.read_parquet(path, gather_statistics=True, **engine)
     assert_eq(out, df)
 
 
@@ -4735,13 +4551,9 @@ def test_filesystem_option(tmp_path, engine, fs):
     from fsspec.implementations.local import LocalFileSystem
 
     df = pd.DataFrame({"a": range(10)})
-    dd.from_pandas(df, npartitions=2).to_parquet(tmp_path, engine=engine)
+    dd.from_pandas(df, npartitions=2).to_parquet(tmp_path, **engine)
     filesystem = fs or LocalFileSystem()
-    ddf = dd.read_parquet(
-        tmp_path,
-        engine=engine,
-        filesystem=filesystem,
-    )
+    ddf = dd.read_parquet(tmp_path, filesystem=filesystem, **engine)
     if fs is None:
         layer_fs = next(iter(ddf.dask.layers.values())).io_func.fs
         assert layer_fs is filesystem
@@ -4757,11 +4569,7 @@ def test_pyarrow_filesystem_option(tmp_path, fs):
     df = pd.DataFrame({"a": range(10)})
     fs = fs or LocalFileSystem()
     dd.from_pandas(df, npartitions=2).to_parquet(tmp_path, filesystem=fs)
-    ddf = dd.read_parquet(
-        tmp_path,
-        engine="pyarrow",
-        filesystem=fs,
-    )
+    ddf = dd.read_parquet(tmp_path, filesystem=fs)
     layer_fs = next(iter(ddf.dask.layers.values())).io_func.fs
     assert isinstance(layer_fs, ArrowFSWrapper)
     assert isinstance(layer_fs.fs, LocalFileSystem)
@@ -4790,16 +4598,12 @@ def test_fsspec_to_parquet_filesystem_option(tmp_path):
 
     df = pd.DataFrame({"a": range(10)})
     fs = get_filesystem_class("memory")(use_instance_cache=False)
-    df.to_parquet(key1, engine="pyarrow", filesystem=fs)
+    df.to_parquet(key1, filesystem=fs)
 
     # read in prepared data
-    ddf = dd.read_parquet(
-        key1,
-        engine="pyarrow",
-        filesystem=fs,
-    )
+    ddf = dd.read_parquet(key1, filesystem=fs)
     assert_eq(ddf, df)
-    ddf.to_parquet(key2, engine="pyarrow", filesystem=fs)
+    ddf.to_parquet(key2, filesystem=fs)
 
     # make sure we didn't write to local fs
     assert len(list(tmp_path.iterdir())) == 0, "wrote to local fs"
@@ -4808,41 +4612,48 @@ def test_fsspec_to_parquet_filesystem_option(tmp_path):
     assert len(fs.ls(key2, detail=False)) == 1
 
     # ensure append functionality works
-    ddf.to_parquet(key2, engine="pyarrow", append=True, filesystem=fs)
+    ddf.to_parquet(key2, append=True, filesystem=fs)
     assert len(fs.ls(key2, detail=False)) == 2, "should have two parts"
 
-    rddf = dd.read_parquet(key2, engine="pyarrow", filesystem=fs)
+    rddf = dd.read_parquet(key2, filesystem=fs)
     assert_eq(rddf, dd.concat([ddf, ddf]))
 
 
 def test_select_filtered_column(tmp_path, engine):
     df = pd.DataFrame({"a": range(10), "b": ["cat"] * 10})
     path = tmp_path / "test_select_filtered_column.parquet"
-    stats = {"write_statistics" if engine == "pyarrow" else "stats": True}
-    df.to_parquet(path, engine=engine, index=False, **stats)
+
+    if engine == {}:  # pyarrow
+        df.to_parquet(path, index=False, write_statistics=True)
+    else:  # fastparquet
+        df.to_parquet(path, index=False, stats=True, **engine)
 
     with pytest.warns(UserWarning, match="Sorted columns detected"):
-        ddf = dd.read_parquet(path, engine=engine, filters=[("b", "==", "cat")])
+        ddf = dd.read_parquet(path, filters=[("b", "==", "cat")], **engine)
         assert_eq(df, ddf)
 
     with pytest.warns(UserWarning, match="Sorted columns detected"):
-        ddf = dd.read_parquet(path, engine=engine, filters=[("b", "is not", None)])
+        ddf = dd.read_parquet(path, filters=[("b", "is not", None)], **engine)
         assert_eq(df, ddf)
 
 
 def test_select_filtered_column_no_stats(tmp_path, engine):
     df = pd.DataFrame({"a": range(10), "b": ["cat"] * 10})
     path = tmp_path / "test_select_filtered_column_no_stats.parquet"
-    stats = {"write_statistics" if engine == "pyarrow" else "stats": False}
-    df.to_parquet(path, engine=engine, **stats)
 
-    ddf = dd.read_parquet(path, engine=engine, filters=[("b", "==", "cat")])
+    if engine == {}:  # pyarrow
+        df.to_parquet(path, write_statistics=False)
+    else:  # fastparquet
+        df.to_parquet(path, stats=False, **engine)
+
+    ddf = dd.read_parquet(path, filters=[("b", "==", "cat")], **engine)
     assert_eq(df, ddf)
 
-    ddf = dd.read_parquet(path, engine=engine, filters=[("b", "is not", None)])
+    ddf = dd.read_parquet(path, filters=[("b", "is not", None)], **engine)
     assert_eq(df, ddf)
 
 
+@PYARROW_MARK
 @pytest.mark.parametrize("convert_string", [True, False])
 @pytest.mark.skipif(
     not PANDAS_GE_200, reason="dataframe.convert-string requires pandas>=2.0"
@@ -4853,12 +4664,12 @@ def test_read_parquet_convert_string(tmp_path, convert_string, engine):
     ).set_index("C")
 
     outfile = tmp_path / "out.parquet"
-    df.to_parquet(outfile, engine=engine)
+    df.to_parquet(outfile, **engine)
 
     with dask.config.set({"dataframe.convert-string": convert_string}):
-        ddf = dd.read_parquet(outfile, engine=engine)
+        ddf = dd.read_parquet(outfile, **engine)
 
-    if convert_string and engine == "pyarrow":
+    if convert_string and engine == {}:  # pyarrow
         expected = df.astype({"A": "string[pyarrow]"})
         expected.index = expected.index.astype("string[pyarrow]")
     else:
@@ -4868,9 +4679,9 @@ def test_read_parquet_convert_string(tmp_path, convert_string, engine):
 
     # Test collection name takes into account `dataframe.convert-string`
     with dask.config.set({"dataframe.convert-string": convert_string}):
-        ddf1 = dd.read_parquet(outfile, engine="pyarrow")
+        ddf1 = dd.read_parquet(outfile)
     with dask.config.set({"dataframe.convert-string": not convert_string}):
-        ddf2 = dd.read_parquet(outfile, engine="pyarrow")
+        ddf2 = dd.read_parquet(outfile)
 
     assert ddf1._name != ddf2._name
 
@@ -4892,7 +4703,7 @@ def test_read_parquet_convert_string_nullable_mapper(tmp_path, engine):
     ).set_index("I")
 
     outfile = tmp_path / "out.parquet"
-    df.to_parquet(outfile, engine=engine)
+    df.to_parquet(outfile, **engine)
 
     types_mapper = {
         pa.float32(): pd.Float64Dtype(),
@@ -4901,7 +4712,6 @@ def test_read_parquet_convert_string_nullable_mapper(tmp_path, engine):
     with dask.config.set({"dataframe.convert-string": True}):
         ddf = dd.read_parquet(
             tmp_path,
-            engine="pyarrow",
             dtype_backend="numpy_nullable",
             arrow_to_pandas={"types_mapper": types_mapper.get},
         )
@@ -4951,13 +4761,13 @@ def test_dtype_backend(tmp_path, dtype_backend, engine):
     dask.compute([write_partition(p, i) for i, p in enumerate(partitions)])
 
     # Not supported by fastparquet
-    if engine == "fastparquet":
+    if engine == {"engine": "fastparquet"}:
         with pytest.raises(ValueError, match="`dtype_backend` is not supported"):
-            dd.read_parquet(tmp_path, engine=engine, dtype_backend=dtype_backend)
+            dd.read_parquet(tmp_path, dtype_backend=dtype_backend, **engine)
 
     # Works in pyarrow
     else:
-        ddf2 = dd.read_parquet(tmp_path, engine=engine, dtype_backend=dtype_backend)
+        ddf2 = dd.read_parquet(tmp_path, dtype_backend=dtype_backend, **engine)
         assert_eq(df, ddf2, check_index=False)
 
 
@@ -4969,8 +4779,8 @@ def test_read_parquet_preserve_categorical_column_dtype(tmp_path):
     df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
 
     outdir = tmp_path / "out.parquet"
-    df.to_parquet(outdir, engine="pyarrow", partition_cols=["a"])
-    ddf = dd.read_parquet(outdir, engine="pyarrow")
+    df.to_parquet(outdir, partition_cols=["a"])
+    ddf = dd.read_parquet(outdir)
 
     expected = pd.DataFrame(
         {"b": ["x", "y"], "a": pd.Categorical(pd.Index([1, 2], dtype="int32"))},
@@ -4984,9 +4794,9 @@ def test_read_parquet_preserve_categorical_column_dtype(tmp_path):
 def test_dtype_backend_categoricals(tmp_path):
     df = pd.DataFrame({"a": pd.Series(["x", "y"], dtype="category"), "b": [1, 2]})
     outdir = tmp_path / "out.parquet"
-    df.to_parquet(outdir, engine="pyarrow")
-    ddf = dd.read_parquet(outdir, engine="pyarrow", dtype_backend="pyarrow")
-    pdf = pd.read_parquet(outdir, engine="pyarrow", dtype_backend="pyarrow")
+    df.to_parquet(outdir)
+    ddf = dd.read_parquet(outdir, dtype_backend="pyarrow")
+    pdf = pd.read_parquet(outdir, dtype_backend="pyarrow")
     # Set sort_results=False because of pandas bug up to 2.0.1
     assert_eq(ddf, pdf, sort_results=PANDAS_GE_202)
 
@@ -4998,23 +4808,15 @@ def test_non_categorical_partitioning_pyarrow(tmpdir, filters):
 
     df1 = pd.DataFrame({"a": range(100), "b": ["cat", "dog"] * 50})
     ddf1 = dd.from_pandas(df1, npartitions=2)
-    ddf1.to_parquet(
-        path=tmpdir, partition_on=["b"], write_index=False, engine="pyarrow"
-    )
+    ddf1.to_parquet(path=tmpdir, partition_on=["b"], write_index=False)
 
     schema = pa.schema([("b", pa.string())])
     partitioning = dict(flavor="hive", schema=schema)
     ddf = dd.read_parquet(
-        tmpdir,
-        dataset={"partitioning": partitioning},
-        filters=filters,
-        engine="pyarrow",
+        tmpdir, dataset={"partitioning": partitioning}, filters=filters
     )
     pdf = pd.read_parquet(
-        tmpdir,
-        partitioning=pd_partitioning(**partitioning),
-        filters=filters,
-        engine="pyarrow",
+        tmpdir, partitioning=pd_partitioning(**partitioning), filters=filters
     )
     assert_eq(ddf, pdf, check_index=False)
     assert ddf["b"].dtype != "category"

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -458,8 +458,10 @@ def test_blockwise_array_creation(c, io, fuse):
 @pytest.mark.parametrize(
     "io",
     [
-        "pyarrow",
-        pytest.param("fastparquet", marks=pytest.mark.skip_with_pyarrow_strings),
+        "parquet-pyarrow",
+        pytest.param(
+            "parquet-fastparquet", marks=pytest.mark.skip_with_pyarrow_strings
+        ),
         "csv",
         # See https://github.com/dask/dask/issues/9793
         pytest.param("hdf", marks=pytest.mark.flaky(reruns=5)),
@@ -480,11 +482,11 @@ def test_blockwise_dataframe_io(c, tmpdir, io, fuse, from_futures):
     else:
         ddf0 = dd.from_pandas(df, npartitions=3)
 
-    if io == "pyarrow":
-        pytest.importorskip("pyarrow.parquet")
+    if io == "parquet-pyarrow":
+        pytest.importorskip("pyarrow")
         ddf0.to_parquet(str(tmpdir))
         ddf = dd.read_parquet(str(tmpdir))
-    elif io == "fastparquet":
+    elif io == "parquet-fastparquet":
         pytest.importorskip("fastparquet")
         with pytest.warns(FutureWarning):
             ddf0.to_parquet(str(tmpdir), engine="fastparquet")

--- a/dask/tests/test_layers.py
+++ b/dask/tests/test_layers.py
@@ -134,8 +134,7 @@ def test_fractional_slice():
 
 
 def _pq_pyarrow(tmpdir):
-    pytest.importorskip("pyarrow.parquet")
-    pytest.importorskip("pyarrow.dataset")
+    pytest.importorskip("pyarrow")
     pd = pytest.importorskip("pandas")
     dd = pytest.importorskip("dask.dataframe")
 

--- a/dask/tests/test_layers.py
+++ b/dask/tests/test_layers.py
@@ -135,33 +135,17 @@ def test_fractional_slice():
 
 def _pq_pyarrow(tmpdir):
     pytest.importorskip("pyarrow.parquet")
+    pytest.importorskip("pyarrow.dataset")
     pd = pytest.importorskip("pandas")
     dd = pytest.importorskip("dask.dataframe")
 
-    try:
-        import pyarrow.dataset as pa_ds
-    except ImportError:
-        # PyArrow version too old for Dataset API
-        pa_ds = None
-
     dd.from_pandas(pd.DataFrame({"a": range(10)}), npartitions=2).to_parquet(
-        str(tmpdir),
-        engine="pyarrow",
+        str(tmpdir)
     )
     filters = [(("a", "<=", 2))]
 
-    ddf1 = dd.read_parquet(str(tmpdir), engine="pyarrow", filters=filters)
-    if pa_ds:
-        # Need to test that layer serialization succeeds
-        # with "pyarrow-dataset" filtering
-        ddf2 = dd.read_parquet(
-            str(tmpdir),
-            engine="pyarrow-dataset",
-            filters=filters,
-        )
-        return (ddf1, ddf2)
-    else:
-        return ddf1
+    ddf1 = dd.read_parquet(str(tmpdir), filters=filters)
+    return ddf1
 
 
 def _pq_fastparquet(tmpdir):
@@ -169,11 +153,10 @@ def _pq_fastparquet(tmpdir):
     pd = pytest.importorskip("pandas")
     dd = pytest.importorskip("dask.dataframe")
 
-    dd.from_pandas(pd.DataFrame({"a": range(10)}), npartitions=2).to_parquet(
-        str(tmpdir),
-        engine="fastparquet",
-    )
-    return dd.read_parquet(str(tmpdir), engine="fastparquet")
+    df = dd.from_pandas(pd.DataFrame({"a": range(10)}), npartitions=2)
+    with pytest.warns(FutureWarning):
+        df.to_parquet(str(tmpdir), engine="fastparquet")
+        return dd.read_parquet(str(tmpdir), engine="fastparquet")
 
 
 def _read_csv(tmpdir):

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -2061,7 +2061,6 @@ def show_versions() -> None:
         "cloudpickle",
         "fsspec",
         "bokeh",
-        "fastparquet",
         "pyarrow",
         "zarr",
     ]

--- a/docs/source/dataframe-hive.rst
+++ b/docs/source/dataframe-hive.rst
@@ -118,9 +118,8 @@ be interpreted as categorical columns.
 Defining a Custom Partitioning Schema
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When utilizing ``engine='pyarrow'``, it is possible to specify a custom
-schema for the hive-partitioned columns. The columns will then be read
-using the specified types and not as `category`.
+It is possible to specify a custom schema for the hive-partitioned columns. The columns
+will then be read using the specified types and not as `category`.
 
 .. code-block:: python
 

--- a/docs/source/dataframe-parquet.rst
+++ b/docs/source/dataframe-parquet.rst
@@ -11,6 +11,9 @@ and retrieval. Dask dataframe includes :func:`read_parquet` and
 respectively. Here we document these methods, and provide some tips and best
 practices.
 
+Parquet I/O requires ``pyarrow`` to be installed.
+
+
 Reading Parquet Files
 ---------------------
 
@@ -60,21 +63,6 @@ For more information on connecting to remote data, see
 
 :func:`read_parquet` has many configuration options affecting both behavior and
 performance. Here we highlight a few common options.
-
-Engine
-~~~~~~
-
-:func:`read_parquet` supports two backend engines - ``pyarrow`` and
-``fastparquet``. The ``pyarrow`` engine is used by default, falling back to
-``fastparquet`` if ``pyarrow`` isn't installed. If desired, you may explicitly
-specify the engine using the ``engine`` keyword argument:
-
-.. code-block:: python
-
-   >>> df = dd.read_parquet(
-   ...      "s3://bucket-name/my/parquet/",
-   ...      engine="fastparquet"  # explicitly specify the fastparquet engine
-   ... )
 
 Metadata
 ~~~~~~~~
@@ -223,21 +211,6 @@ your data is partitioned optimally.
 
 :func:`to_parquet` has many configuration options affecting both behavior and
 performance. Here we highlight a few common options.
-
-Engine
-~~~~~~
-
-:func:`to_parquet` supports two backend engines - ``pyarrow`` and
-``fastparquet``. The ``pyarrow`` engine is used by default, falling back to
-``fastparquet`` if ``pyarrow`` isn't installed. If desired, you may explicitly
-specify the engine using the ``engine`` keyword argument:
-
-.. code-block:: python
-
-   >>> df.to_parquet(
-   ...      "s3://bucket-name/my/parquet/",
-   ...      engine="fastparquet"  # explicitly specify the fastparquet engine
-   ... )
 
 Metadata
 ~~~~~~~~

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -118,8 +118,6 @@ These optional dependencies and their minimum supported versions are listed belo
 +------------------+-----------------+---------------------------------------------------------------------------------------------------------+
 | `fastavro`_      | ``>=1.1.0``     | Storing and reading data from Apache Avro files                                                         |
 +------------------+-----------------+---------------------------------------------------------------------------------------------------------+
-| `fastparquet`_   | ``>=0.8.2``     | Storing and reading data from Apache Parquet files                                                      |
-+------------------+-----------------+---------------------------------------------------------------------------------------------------------+
 | `gcsfs`_         | ``>=2021.9.0``  | Storing and reading data located in Google Cloud Storage                                                |
 +------------------+-----------------+---------------------------------------------------------------------------------------------------------+
 | `graphviz`_      | ``>=0.8.4``     | Graph visualization using the graphviz engine                                                           |
@@ -199,7 +197,6 @@ See the :ref:`section on testing <develop-test>` in the Development Guidelines f
 .. _cytoolz: https://github.com/pytoolz/cytoolz
 .. _dask-ml: https://ml.dask.org/
 .. _fastavro: https://fastavro.readthedocs.io/en/latest/
-.. _fastparquet: https://github.com/dask/fastparquet
 .. _graphviz: https://graphviz.readthedocs.io/en/stable/
 .. _gcsfs: https://gcsfs.readthedocs.io/en/latest/
 .. _h5py: https://www.h5py.org/


### PR DESCRIPTION
Changes to `to_parquet` and `read_parquet`:

- Closes #10725
- XREF #10602
- Deprecate `engine="fastparquet"`
- Deprecate `engine="arrow"` and `engine="pyarrow-dataset"` as aliases for `engine="pyarrow"`
- Add documentation and unit tests around `engine=<engine class>`, which is required by dask_cudf.