### PR TITLE
Deprecate `npartitions='auto'` for set_index & sort_values

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -166,6 +166,7 @@ def sort_values(
         return df.map_partitions(sort_function, **sort_kwargs)
 
     if npartitions == "auto":
+        warnings.warn("`npartitions='auto'` is deprecated.", FutureWarning, 2)
         repartition = True
         npartitions = max(100, df.npartitions)
     else:
@@ -235,6 +236,7 @@ def set_index(
         ).clear_divisions()
 
     if npartitions == "auto":
+        warnings.warn("`npartitions='auto'` is deprecated.", FutureWarning, 2)
         repartition = True
         npartitions = max(100, df.npartitions)
     else:

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -166,7 +166,11 @@ def sort_values(
         return df.map_partitions(sort_function, **sort_kwargs)
 
     if npartitions == "auto":
-        warnings.warn("`npartitions='auto'` is deprecated.", FutureWarning, 2)
+        warnings.warn(
+            "`npartitions='auto'` is deprecated, either set it as an integer or leave as `None`.",
+            FutureWarning,
+            2,
+        )
         repartition = True
         npartitions = max(100, df.npartitions)
     else:
@@ -236,7 +240,11 @@ def set_index(
         ).clear_divisions()
 
     if npartitions == "auto":
-        warnings.warn("`npartitions='auto'` is deprecated.", FutureWarning, 2)
+        warnings.warn(
+            "`npartitions='auto'` is deprecated, either set it as an integer or leave as `None`.",
+            FutureWarning,
+            2,
+        )
         repartition = True
         npartitions = max(100, df.npartitions)
     else:

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -569,30 +569,8 @@ def _set_index(i, df, idx):
     return df.set_index(idx).divisions
 
 
-def test_set_index_not_reduce_partitions_small(shuffle_method):
-    df = pd.DataFrame({"x": np.random.random(100)})
-    ddf = dd.from_pandas(df, npartitions=50)
-
-    ddf2 = ddf.set_index("x", shuffle_method=shuffle_method)
-    assert ddf2.npartitions == ddf.npartitions
-
-
 def make_part(n):
     return pd.DataFrame({"x": np.random.random(n), "y": np.random.random(n)})
-
-
-def test_set_index_not_reduce_partitions_large(shuffle_method):
-    nbytes = 1e6
-    nparts = 50
-    n = int(nbytes / (nparts * 8))
-    ddf = dd.DataFrame(
-        {("x", i): (make_part, n) for i in range(nparts)},
-        "x",
-        make_part(1),
-        [None] * (nparts + 1),
-    )
-    ddf2 = ddf.set_index("x", shuffle_method=shuffle_method, partition_size=nbytes)
-    assert ddf2.npartitions == ddf.npartitions
 
 
 def test_set_index_doesnt_increase_partitions(shuffle_method):

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -573,6 +573,15 @@ def make_part(n):
     return pd.DataFrame({"x": np.random.random(n), "y": np.random.random(n)})
 
 
+def test_npartitions_auto_raises_deprecation_warning():
+    df = pd.DataFrame({"x": range(100), "y": range(100)})
+    ddf = dd.from_pandas(df, npartitions=10, name="x", sort=False)
+    with pytest.raises(FutureWarning, match="npartitions='auto'"):
+        ddf.set_index("x", npartitions="auto")
+    with pytest.raises(FutureWarning, match="npartitions='auto'"):
+        ddf.sort_values(by=["x"], npartitions="auto")
+
+
 def test_set_index_doesnt_increase_partitions(shuffle_method):
     nparts = 2
     nbytes = 1e6


### PR DESCRIPTION
- [x] Closes #10736 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
