### PR TITLE
Restrict mimesis to < 12 for 3.9 build

### DIFF
--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -23,7 +23,7 @@ dependencies:
   - pytest-xdist
   - moto
   # Optional dependencies
-  - mimesis
+  - mimesis<12+
   - numpy=1.22
   - pandas=1.4
   - flask

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -23,7 +23,7 @@ dependencies:
   - pytest-xdist
   - moto
   # Optional dependencies
-  - mimesis<12+
+  - mimesis<12
   - numpy=1.22
   - pandas=1.4
   - flask


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

they dropped 3.9 support in 12