### PR TITLE
Avoid shortcut in tasks shuffle that let to data loss

### DIFF
--- a/dask/dataframe/multi.py
+++ b/dask/dataframe/multi.py
@@ -1423,7 +1423,16 @@ def _split_partition(df, on, nsplits):
         on = [on] if isinstance(on, str) else list(on)
         nset = set(on)
         if nset.intersection(set(df.columns)) == nset:
-            ind = hash_object_dispatch(df[on], index=False)
+            o = df[on]
+            dtypes = {}
+            for col, dtype in o.dtypes.items():
+                if pd.api.types.is_numeric_dtype(dtype):
+                    dtypes[col] = np.float64
+            if not dtypes:
+                ind = hash_object_dispatch(df[on], index=False)
+            else:
+                ind = hash_object_dispatch(df[on].astype(dtypes), index=False)
+
             ind = ind % nsplits
             return group_split_dispatch(df, ind, nsplits, ignore_index=False)
 

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -416,25 +416,6 @@ def shuffle(
     """
     list_like = pd.api.types.is_list_like(index) and not is_dask_collection(index)
     shuffle_method = shuffle_method or get_default_shuffle_method()
-    if shuffle_method == "tasks" and (isinstance(index, str) or list_like):
-        # Avoid creating the "_partitions" column if possible.
-        # We currently do this if the user is passing in
-        # specific column names (and shuffle == "tasks").
-        if isinstance(index, str):
-            index = [index]
-        else:
-            index = list(index)
-        nset = set(index)
-        if nset & set(df.columns) == nset:
-            return rearrange_by_column(
-                df,
-                index,
-                npartitions=npartitions,
-                max_branch=max_branch,
-                shuffle_method=shuffle_method,
-                ignore_index=ignore_index,
-                compute=compute,
-            )
 
     if not isinstance(index, _Frame):
         if list_like:

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -725,7 +725,8 @@ async def test_shuffle_priority(c, s, a, b, max_branch, expected_layer_type):
 
     shuffle_layers = set(ddf2.dask.layers) - set(ddf.dask.layers)
     for layer_name in shuffle_layers:
-        assert isinstance(ddf2.dask.layers[layer_name], expected_layer_type)
+        if "shuffle" in layer_name:
+            assert isinstance(ddf2.dask.layers[layer_name], expected_layer_type)
     await c.compute(ddf2)
     assert not EnsureSplitsRunImmediatelyPlugin.failure
 


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

The shortcut let to inconsistent casting logic, which is problematic...