### PR TITLE
Improve exception for `validate_key`

### DIFF
--- a/dask/core.py
+++ b/dask/core.py
@@ -218,9 +218,26 @@ def iskey(key: object) -> bool:
 
 
 def validate_key(key: object) -> None:
-    """Validate the format of a dask key."""
-    if not iskey(key):
-        raise TypeError(f"Unexpected key type {type(key)} (value: {key!r})")
+    """Validate the format of a dask key.
+
+    See Also
+    --------
+    iskey
+    """
+    if iskey(key):
+        return
+    typ = type(key)
+
+    if typ is tuple:
+        _index = None
+        try:
+            for _index, part in enumerate(cast(tuple, key)):
+                validate_key(part)
+        except TypeError as e:
+            raise TypeError(
+                f"Composite key contains unexpected key type at {_index=} ({key=!r})"
+            ) from e
+    raise TypeError(f"Unexpected key type {typ} ({key=!r})")
 
 
 @overload

--- a/dask/core.py
+++ b/dask/core.py
@@ -229,13 +229,13 @@ def validate_key(key: object) -> None:
     typ = type(key)
 
     if typ is tuple:
-        _index = None
+        index = None
         try:
-            for _index, part in enumerate(cast(tuple, key)):
+            for index, part in enumerate(cast(tuple, key)):  # noqa: B007
                 validate_key(part)
         except TypeError as e:
             raise TypeError(
-                f"Composite key contains unexpected key type at {_index=} ({key=!r})"
+                f"Composite key contains unexpected key type at {index=} ({key=!r})"
             ) from e
     raise TypeError(f"Unexpected key type {typ} ({key=!r})")
 

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -73,8 +73,11 @@ def test_iskey_numpy_types():
 def test_validate_key():
     validate_key(1)
     validate_key(("x", 1))
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="Unexpected key type.*list"):
         validate_key(["x", 1])
+
+    with pytest.raises(TypeError, match="unexpected key type at index=1"):
+        validate_key((2, int))
 
 
 def test_istask():


### PR DESCRIPTION
- [x] Closes #10764
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

The exception now indicates the index of the invalid key type and the traceback reveals the actual problem. The latter is important for nested tuples.

```
Traceback (most recent call last):
  File "/Users/hendrikmakait/projects/dask/dask/dask/core.py", line 235, in validate_key
    validate_key(part)
  File "/Users/hendrikmakait/projects/dask/dask/dask/core.py", line 240, in validate_key
    raise TypeError(f"Unexpected key type {typ} ({key=!r})")
TypeError: Unexpected key type <class 'numpy.int64'> (key=2)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/hendrikmakait/projects/dask/dask/dask/core.py", line 237, in validate_key
    raise TypeError(
TypeError: Composite key contains unexpected key type at _index=1 (key=(1, 2, 3))
```