### PR TITLE
Import distributed only once in `get_scheduler`

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -49,17 +49,17 @@ _DISTRIBUTED_AVAILABLE = None
 
 def _distributed_available() -> bool:
     # Lazy import in get_scheduler can be expensive
-    global DistributedClient, get_distributed_client, DISTRIBUTED_AVAILABLE
-    if DISTRIBUTED_AVAILABLE is not None:
-        return DISTRIBUTED_AVAILABLE  # type: ignore[unreachable]
+    global _DistributedClient, _get_distributed_client, _DISTRIBUTED_AVAILABLE
+    if _DISTRIBUTED_AVAILABLE is not None:
+        return _DISTRIBUTED_AVAILABLE  # type: ignore[unreachable]
     try:
-        from distributed import Client as DistributedClient
-        from distributed.worker import get_client as get_distributed_client
+        from distributed import Client as _DistributedClient
+        from distributed.worker import get_client as _get_distributed_client
 
-        DISTRIBUTED_AVAILABLE = True
+        _DISTRIBUTED_AVAILABLE = True
     except ImportError:
-        DISTRIBUTED_AVAILABLE = False
-    return DISTRIBUTED_AVAILABLE
+        _DISTRIBUTED_AVAILABLE = False
+    return _DISTRIBUTED_AVAILABLE
 
 
 __all__ = (
@@ -1472,9 +1472,9 @@ def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
 
             client_available = False
             if _distributed_available():
-                assert DistributedClient is not None
+                assert _DistributedClient is not None
                 with suppress(ValueError):
-                    DistributedClient.current(allow_global=True)
+                    _DistributedClient.current(allow_global=True)
                     client_available = True
             if scheduler in named_schedulers:
                 if client_available:
@@ -1488,8 +1488,8 @@ def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
                     raise RuntimeError(
                         f"Requested {scheduler} scheduler but no Client active."
                     )
-                assert get_distributed_client is not None
-                return get_distributed_client().get
+                assert _get_distributed_client is not None
+                return _get_distributed_client().get
             else:
                 raise ValueError(
                     "Expected one of [distributed, %s]"

--- a/dask/base.py
+++ b/dask/base.py
@@ -42,9 +42,9 @@ from dask.utils import (
     shorten_traceback,
 )
 
-DistributedClient = None
-get_distributed_client = None
-DISTRIBUTED_AVAILABLE = None
+_DistributedClient = None
+_get_distributed_client = None
+_DISTRIBUTED_AVAILABLE = None
 
 
 def _distributed_available() -> bool:


### PR DESCRIPTION
I had a look at our slowest tests (on CI we have a hand full of over paramterized tests, e.g. `test_arithmetics_different_index` that run for 1-2min) and profiled it.

Turns out that this lazy import eats up a lot of CPU cycles

![image](https://github.com/dask/dask/assets/8629629/aeeacb87-41c4-4a91-9cc3-3d522f921965)


locally this reduces this tests runtime by 30% for me.

I chose this rather complex indirection because I don't want to blindly import distributed since it is quite heavy. Having a fast import time is something nice