### PR TITLE
Cosmetic: Use skipif(DASK_EXPR_ENABLED)

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2459,10 +2459,9 @@ def test_repartition_freq_day():
     )
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="testing this over in expr")
 @pytest.mark.parametrize("type_ctor", [lambda o: o, tuple, list])
 def test_repartition_noop(type_ctor):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("testing this over in expr")
     df = pd.DataFrame({"x": [1, 2, 4, 5], "y": [6, 7, 8, 9]}, index=[-1, 0, 2, 7])
     ddf = dd.from_pandas(df, npartitions=2)
     ds = ddf.x
@@ -3180,9 +3179,8 @@ def test_drop_meta_mismatch():
     assert_eq(df.drop(columns=["x"]), ddf.drop(columns=["x"]))
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="FIXME hanging - don't know why")
 def test_gh580():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("don't know")
     df = pd.DataFrame({"x": np.arange(10, dtype=float)})
     ddf = dd.from_pandas(df, 2)
     assert_eq(np.cos(df["x"]), np.cos(ddf["x"]))
@@ -4321,9 +4319,10 @@ def test_columns_assignment():
     assert_eq(df, ddf)
 
 
+@pytest.mark.skipif(
+    DASK_EXPR_ENABLED, reason="Can't make this work with dynamic access"
+)
 def test_attribute_assignment():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("Can't make this work with dynamic access")
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [1.0, 2.0, 3.0, 4.0, 5.0]})
     ddf = dd.from_pandas(df, npartitions=2)
 
@@ -4684,10 +4683,9 @@ def test_shift_with_freq_errors():
     pytest.raises(NotImplementedError, lambda: ddf.index.shift(2))
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="deprecated in pandas")
 @pytest.mark.parametrize("method", ["first", "last"])
 def test_first_and_last(method):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("deprecated in pandas")
     f = lambda x, offset: getattr(x, method)(offset)
     freqs = ["12h", "D"]
     offsets = ["0d", "100h", "20d", "20B", "3W", "3M", "400d", "13M"]
@@ -4963,9 +4961,8 @@ def test_dataframe_reductions_arithmetic(reduction):
     )
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="duplicated columns not supported")
 def test_dataframe_mode():
-    if DASK_EXPR_ENABLED:
-        pytest.xfail("duplicated columns not supported")
     data = [["Tom", 10, 7], ["Farahn", 14, 7], ["Julie", 14, 5], ["Nick", 10, 10]]
 
     df = pd.DataFrame(data, columns=["Name", "Num", "Num"])
@@ -5250,10 +5247,8 @@ def test_bool():
             bool(cond)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="FIXME hanging - this is a bug")
 def test_cumulative_multiple_columns():
-    if DASK_EXPR_ENABLED:
-        # TODO(dask-expr) - this is a bug in dask-expr
-        pytest.skip("hanging")
     # GH 3037
     df = pd.DataFrame(np.random.randn(100, 5), columns=list("abcde"))
     ddf = dd.from_pandas(df, 5)
@@ -5720,9 +5715,8 @@ def test_dataframe_groupby_cumprod_agg_empty_partitions():
     assert_eq(ddf[ddf.x > 5].x.cumprod(), df[df.x > 5].x.cumprod())
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="doesn't make sense")
 def test_fuse_roots():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("doesn't nmake sense")
     pdf1 = pd.DataFrame(
         {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]}
     )
@@ -5735,9 +5729,8 @@ def test_fuse_roots():
     hlg.validate()
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not important now")
 def test_attrs_dataframe():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("not important now")
     df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": [5, 6]})
     df.attrs = {"date": "2020-10-16"}
     ddf = dd.from_pandas(df, 2)
@@ -5746,9 +5739,8 @@ def test_attrs_dataframe():
     assert df.abs().attrs == ddf.abs().attrs
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not important now")
 def test_attrs_series():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("not important now")
     s = pd.Series([1, 2], name="A")
     s.attrs["unit"] = "kg"
     ds = dd.from_pandas(s, 2)
@@ -5765,9 +5757,8 @@ def test_join_series():
     assert_eq(actual_df, expected_df)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="doesn't make sense")
 def test_dask_layers():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("doesn't make sense")
     df = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6, 7, 8]})
     ddf = dd.from_pandas(df, npartitions=2)
     assert ddf.dask.layers.keys() == {ddf._name}
@@ -6180,6 +6171,7 @@ def test_mask_where_array_like(df, cond):
     assert_eq(expected, result)
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="duplicated columns not supported")
 @pytest.mark.parametrize(
     "func, kwargs",
     [
@@ -6190,8 +6182,6 @@ def test_mask_where_array_like(df, cond):
     ],
 )
 def test_duplicate_columns(func, kwargs):
-    if DASK_EXPR_ENABLED:
-        pytest.xfail("duplicated columns not supported")
     df = pd.DataFrame(
         {
             "int": [1, 2, 3],

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -132,9 +132,8 @@ def test_groupby_internal_repr_xfail():
     assert isinstance(dp.obj, dd.Series)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="architecture different")
 def test_groupby_internal_repr():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("architecture different")
     pdf = pd.DataFrame({"x": [0, 1, 2, 3, 4, 6, 7, 8, 9, 10], "y": list("abcbabbcda")})
     ddf = dd.from_pandas(pdf, 3)
 
@@ -341,10 +340,9 @@ def test_groupby_dir():
     assert "b c d e" not in dir(g)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="FIXME hangs")
 @pytest.mark.parametrize("scheduler", ["sync", "threads"])
 def test_groupby_on_index(scheduler):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("hangs")
     pdf = pd.DataFrame(
         {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [4, 5, 6, 3, 2, 1, 0, 0, 0]},
         index=[0, 1, 3, 5, 6, 8, 9, 9, 9],
@@ -1301,11 +1299,10 @@ def test_shuffle_aggregate_defaults(shuffle_method):
         assert any("shuffle" in l for l in dsk.layers)
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="median not yet supported")
 @pytest.mark.parametrize("spec", [{"c": "median"}, {"b": "median", "c": "max"}])
 @pytest.mark.parametrize("keys", ["a", ["a", "d"]])
 def test_aggregate_median(spec, keys, shuffle_method):
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="median not yet supported")
     pdf = pd.DataFrame(
         {
             "a": [1, 2, 3, 1, 1, 2, 4, 3, 7] * 10,
@@ -1326,12 +1323,11 @@ def test_aggregate_median(spec, keys, shuffle_method):
         ddf.groupby(keys).median(shuffle=False)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="deprecated in pandas")
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize("group_keys", [True, False, None])
 @pytest.mark.parametrize("limit", [None, 1, 4])
 def test_fillna(axis, group_keys, limit):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("deprecated in pandas")
     df = pd.DataFrame(
         {
             "A": [1, 1, 2, 2],
@@ -1561,6 +1557,7 @@ def test_series_aggregations_multilevel(grouper, split_out, agg_func):
     )
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="don't store nonempty meta in dask-expr")
 @pytest.mark.parametrize(
     "grouper",
     [
@@ -1586,8 +1583,6 @@ def test_series_aggregations_multilevel(grouper, split_out, agg_func):
     ],
 )
 def test_groupby_meta_content(group_and_slice, grouper):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("don't store nonempty meta in dask-expr")
     pdf = pd.DataFrame(
         {
             "a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 10,
@@ -1904,13 +1899,12 @@ def test_groupby_dataframe_cum_caching(op):
     assert res1_a.equals(res1_b)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="MIDX columns not supported")
 def test_groupby_series_cum_caching():
     """Test caching behavior of cumulative operations on grouped Series
 
     Relates to #3755
     """
-    if DASK_EXPR_ENABLED:
-        pytest.skip("MIDX columns not supported")
     df = pd.DataFrame(
         dict(a=list("aabbcc")), index=pd.date_range(start="20100101", periods=6)
     )
@@ -2109,6 +2103,7 @@ else:
     custom_sum = dd.Aggregation("sum", lambda s: s.sum(), lambda s0: s0.sum())
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="Aggregation not supported")
 @pytest.mark.parametrize(
     "pandas_spec, dask_spec, check_dtype",
     [
@@ -2119,8 +2114,6 @@ else:
     ],
 )
 def test_dataframe_groupby_agg_custom_sum(pandas_spec, dask_spec, check_dtype):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("Aggregation not supported")
     df = pd.DataFrame({"g": [0, 0, 1] * 3, "b": [1, 2, 3] * 3})
     ddf = dd.from_pandas(df, npartitions=2)
 
@@ -2130,6 +2123,7 @@ def test_dataframe_groupby_agg_custom_sum(pandas_spec, dask_spec, check_dtype):
     assert_eq(result, expected, check_dtype=check_dtype)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="Aggregation not supported")
 @pytest.mark.parametrize(
     "pandas_spec, dask_spec",
     [
@@ -2139,8 +2133,6 @@ def test_dataframe_groupby_agg_custom_sum(pandas_spec, dask_spec, check_dtype):
     ],
 )
 def test_series_groupby_agg_custom_mean(pandas_spec, dask_spec):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("Aggregation not supported")
     d = pd.DataFrame({"g": [0, 0, 1] * 3, "b": [1, 2, 3] * 3})
     a = dd.from_pandas(d, npartitions=2)
 
@@ -2150,10 +2142,9 @@ def test_series_groupby_agg_custom_mean(pandas_spec, dask_spec):
     assert_eq(result, expected, check_dtype=False)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="Aggregation not supported")
 def test_groupby_agg_custom__name_clash_with_internal_same_column():
     """for a single input column only unique names are allowed"""
-    if DASK_EXPR_ENABLED:
-        pytest.skip("Aggregation not supported")
     d = pd.DataFrame({"g": [0, 0, 1] * 3, "b": [1, 2, 3] * 3})
     a = dd.from_pandas(d, npartitions=2)
 
@@ -2163,10 +2154,9 @@ def test_groupby_agg_custom__name_clash_with_internal_same_column():
         a.groupby("g").aggregate({"b": [agg_func, "sum"]})
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="Aggregation not supported")
 def test_groupby_agg_custom__name_clash_with_internal_different_column():
     """custom aggregation functions can share the name of a builtin function"""
-    if DASK_EXPR_ENABLED:
-        pytest.skip("Aggregation not supported")
     d = pd.DataFrame({"g": [0, 0, 1] * 3, "b": [1, 2, 3] * 3, "c": [4, 5, 6] * 3})
     a = dd.from_pandas(d, npartitions=2)
 
@@ -2186,11 +2176,10 @@ def test_groupby_agg_custom__name_clash_with_internal_different_column():
     assert_eq(result, expected, check_dtype=False)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="Aggregation not supported")
 def test_groupby_agg_custom__mode():
     # mode function passing intermediates as pure python objects around. to protect
     # results from pandas in apply use return results as single-item lists
-    if DASK_EXPR_ENABLED:
-        pytest.skip("Aggregation not supported")
 
     def agg_mode(s):
         def impl(s):
@@ -2314,9 +2303,8 @@ def test_std_object_dtype(func):
     assert_eq(expected, result)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="Uses legacy frame")
 def test_std_columns_int():
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="uses legacy frame")
     # Make sure std() works when index_by is a df with integer column names
     # Non regression test for issue #3560
 
@@ -3408,14 +3396,10 @@ def test_groupby_numeric_only_None_column_name():
         ddf.groupby(lambda x: x).mean(numeric_only=False)
 
 
-@pytest.mark.skipif(
-    not PANDAS_GE_140,
-    reason="requires pandas >= 1.4.0; not supported yet",
-)
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="Aggregation not supported")
+@pytest.mark.skipif(not PANDAS_GE_140, reason="requires pandas >= 1.4.0")
 @pytest.mark.parametrize("shuffle", [True, False])
 def test_dataframe_named_agg(shuffle):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("Aggregation not supported")
     df = pd.DataFrame(
         {
             "a": [1, 1, 2, 2],
@@ -3437,15 +3421,11 @@ def test_dataframe_named_agg(shuffle):
     assert_eq(expected, actual)
 
 
-@pytest.mark.skipif(
-    not PANDAS_GE_140,
-    reason="requires pandas >= 1.4.0; not supported yet",
-)
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="Aggregation not supported")
+@pytest.mark.skipif(not PANDAS_GE_140, reason="requires pandas >= 1.4.0")
 @pytest.mark.parametrize("shuffle", [True, False])
 @pytest.mark.parametrize("agg", ["count", "mean", partial(np.var, ddof=1)])
 def test_series_named_agg(shuffle, agg):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("Aggregation not supported")
     df = pd.DataFrame(
         {
             "a": [5, 4, 3, 5, 4, 2, 3, 2],
@@ -3571,9 +3551,8 @@ def test_groupby_multi_index_with_row_operations(operation):
     assert_eq(expected, actual)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="FIXME hangs")
 def test_groupby_iter_fails():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("hangs")
     df = pd.DataFrame(
         data=[
             ["a0", "b1"],
@@ -3588,9 +3567,8 @@ def test_groupby_iter_fails():
         list(ddf.groupby("A"))
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="will raise")
 def test_groupby_None_split_out_warns():
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="will raise")
     df = pd.DataFrame({"a": [1, 1, 2], "b": [2, 3, 4]})
     ddf = dd.from_pandas(df, npartitions=1)
     with pytest.warns(FutureWarning, match="split_out=None"):

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -47,9 +47,8 @@ except ImportError:
 DASK_EXPR_ENABLED = dd._dask_expr_enabled()
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not available")
 def test_align_partitions():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("not available in dask-expr")
     A = pd.DataFrame(
         {"x": [1, 2, 3, 4, 5, 6], "y": list("abdabd")}, index=[10, 20, 30, 40, 50, 60]
     )
@@ -125,9 +124,8 @@ def test_align_partitions():
         assert_eq(rresult, rdf)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not available")
 def test_align_partitions_unknown_divisions():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("not available in dask-expr")
     df = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7], "b": [7, 6, 5, 4, 3, 2, 1]})
     # One known, one unknown
     ddf = dd.from_pandas(df, npartitions=2)
@@ -147,9 +145,8 @@ def test_align_partitions_unknown_divisions():
         align_partitions(ddf, ddf2)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not available")
 def test__maybe_align_partitions():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("not available in dask-expr")
     df = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6, 7], "b": [7, 6, 5, 4, 3, 2, 1]})
     # Both known, same divisions
     ddf = dd.from_pandas(df + 1, npartitions=2)
@@ -263,10 +260,9 @@ def list_eq(aa, bb):
     dd._compat.assert_numpy_array_equal(av, bv)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not available")
 @pytest.mark.parametrize("how", ["inner", "left", "right", "outer"])
 def test_hash_join(how, shuffle_method):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("not available in dask-expr")
     A = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6], "y": [1, 1, 2, 2, 3, 4]})
     a = dd.repartition(A, [0, 4, 5])
 
@@ -321,9 +317,8 @@ def test_sequential_joins():
     assert_eq(multi_join_pd, multi_join_dd)
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="merge_asof not available yet")
 def test_merge_asof_indexed():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("merge_asof not available yet in dask-expr")
     A = pd.DataFrame(
         {"left_val": list("abcd" * 3)},
         index=[1, 3, 7, 9, 10, 13, 14, 17, 20, 24, 25, 28],
@@ -341,9 +336,8 @@ def test_merge_asof_indexed():
     assert_eq(c, C)
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="merge_asof not available yet")
 def test_merge_asof_on_basic():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("merge_asof not available yet in dask-expr")
     A = pd.DataFrame({"a": [1, 5, 10], "left_val": ["a", "b", "c"]})
     a = dd.from_pandas(A, npartitions=2)
     B = pd.DataFrame({"a": [1, 2, 3, 6, 7], "right_val": [1, 2, 3, 6, 7]})
@@ -355,9 +349,8 @@ def test_merge_asof_on_basic():
     assert_eq(c, C, check_index=False)
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="merge_asof not available yet")
 def test_merge_asof_on_lefton_righton_error():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("merge_asof not available yet in dask-expr")
     A = pd.DataFrame({"a": [1, 5, 10], "left_val": ["a", "b", "c"]})
     a = dd.from_pandas(A, npartitions=2)
     B = pd.DataFrame({"a": [1, 2, 3, 6, 7], "right_val": [1, 2, 3, 6, 7]})
@@ -371,9 +364,8 @@ def test_merge_asof_on_lefton_righton_error():
         dd.merge_asof(a, b, on="a", left_on="left_val", right_on="right_val")
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="merge_asof not available yet")
 def test_merge_asof_by_leftby_rightby_error():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("merge_asof not available yet in dask-expr")
     A = pd.DataFrame({"a": [1, 5, 10], "b": [3, 6, 9], "left_val": ["a", "b", "c"]})
     a = dd.from_pandas(A, npartitions=2)
     B = pd.DataFrame(
@@ -389,11 +381,10 @@ def test_merge_asof_by_leftby_rightby_error():
         dd.merge_asof(a, b, on="a", by="b", left_by="left_val", right_by="right_val")
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="merge_asof not available yet")
 @pytest.mark.parametrize("allow_exact_matches", [True, False])
 @pytest.mark.parametrize("direction", ["backward", "forward", "nearest"])
 def test_merge_asof_on(allow_exact_matches, direction):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("merge_asof not available yet in dask-expr")
     A = pd.DataFrame({"a": [1, 5, 10], "left_val": ["a", "b", "c"]})
     a = dd.from_pandas(A, npartitions=2)
     B = pd.DataFrame({"a": [1, 2, 3, 6, 7], "right_val": [1, 2, 3, 6, 7]})
@@ -409,14 +400,13 @@ def test_merge_asof_on(allow_exact_matches, direction):
     assert_eq(c, C, check_index=False)
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="merge_asof not available yet")
 @pytest.mark.parametrize("allow_exact_matches", [True, False])
 @pytest.mark.parametrize("direction", ["backward", "forward", "nearest"])
 @pytest.mark.parametrize("unknown_divisions", [False, True])
 def test_merge_asof_left_on_right_index(
     allow_exact_matches, direction, unknown_divisions
 ):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("merge_asof not available yet in dask-expr")
     A = pd.DataFrame({"a": [1, 5, 10], "left_val": ["a", "b", "c"]}, index=[10, 20, 30])
     a = dd.from_pandas(A, npartitions=2)
     B = pd.DataFrame({"right_val": [2, 3, 6, 7]}, index=[2, 3, 6, 7])
@@ -477,9 +467,8 @@ def test_merge_asof_left_on_right_index(
             assert_eq(c, C)
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="merge_asof not available yet")
 def test_merge_asof_indexed_two_partitions():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("merge_asof not available yet in dask-expr")
     A = pd.DataFrame({"left_val": ["a", "b", "c"]}, index=[1, 5, 10])
     a = dd.from_pandas(A, npartitions=2)
     B = pd.DataFrame({"right_val": [1, 2, 3, 6, 7]}, index=[1, 2, 3, 6, 7])
@@ -490,9 +479,8 @@ def test_merge_asof_indexed_two_partitions():
     assert_eq(c, C)
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="merge_asof not available yet")
 def test_merge_asof_on_by():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("merge_asof not available yet in dask-expr")
     times_A = [
         pd.to_datetime(d)
         for d in [
@@ -550,9 +538,8 @@ def test_merge_asof_on_by():
     assert_eq(c, C, check_index=False)
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="merge_asof not available yet")
 def test_merge_asof_on_by_tolerance():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("merge_asof not available yet in dask-expr")
     times_A = [
         pd.to_datetime(d)
         for d in [
@@ -610,9 +597,8 @@ def test_merge_asof_on_by_tolerance():
     assert_eq(c, C, check_index=False)
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="merge_asof not available yet")
 def test_merge_asof_on_by_tolerance_no_exact_matches():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("merge_asof not available yet in dask-expr")
     times_A = [
         pd.to_datetime(d)
         for d in [
@@ -684,9 +670,8 @@ def test_merge_asof_on_by_tolerance_no_exact_matches():
     assert_eq(c, C, check_index=False)
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="merge_asof not available yet")
 def test_merge_asof_unsorted_raises():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("merge_asof not available yet in dask-expr")
     A = pd.DataFrame({"a": [1, 5, 10], "left_val": ["a", "b", "c"]})
     a = dd.from_pandas(A, npartitions=2)
     B = pd.DataFrame({"a": [2, 1, 3, 6, 7], "right_val": [1, 2, 3, 6, 7]})
@@ -698,9 +683,8 @@ def test_merge_asof_unsorted_raises():
         result.compute()
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="merge_asof not available yet")
 def test_merge_asof_with_empty():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("merge_asof not available yet in dask-expr")
     good_df = pd.DataFrame({"index_col": list(range(10)), "good_val": list(range(10))})
     good_dd = dd.from_pandas(good_df, npartitions=2)
     empty_df = (
@@ -752,12 +736,11 @@ def test_merge_asof_with_empty():
     assert_eq(result_dd, result_df, check_index=False)
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="merge_asof not available yet")
 @pytest.mark.parametrize(
     "left_col, right_col", [("endofweek", "timestamp"), ("endofweek", "endofweek")]
 )
 def test_merge_asof_on_left_right(left_col, right_col):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("merge_asof not available yet in dask-expr")
     df1 = pd.DataFrame(
         {
             left_col: [1, 1, 2, 2, 3, 4],
@@ -780,9 +763,8 @@ def test_merge_asof_on_left_right(left_col, right_col):
     assert_eq(result_df, result_dd, check_index=False)
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="merge_asof not available yet")
 def test_merge_asof_with_various_npartitions():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("merge_asof not available yet in dask-expr")
     # https://github.com/dask/dask/issues/8999
     df = pd.DataFrame(dict(ts=[pd.to_datetime("1-1-2020")] * 3, foo=[1, 2, 3]))
     expected = pd.merge_asof(left=df, right=df, on="ts")
@@ -1101,9 +1083,8 @@ def test_merge(how, shuffle_method):
     #         pd.merge(A, B, left_index=True, right_on='y'))
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not deprecated in dask-expr")
 def test_merge_deprecated_shuffle_keyword(shuffle_method):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("not deprecated in dask-expr")
     A = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6], "y": [1, 1, 2, 2, 3, 4]})
     a = dd.repartition(A, [0, 4, 5])
 
@@ -1810,6 +1791,7 @@ def test_merge_by_multiple_columns(how, shuffle_method):
             )
 
 
+@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="melt not supported yet")
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -1823,8 +1805,6 @@ def test_merge_by_multiple_columns(how, shuffle_method):
     ],
 )
 def test_melt(kwargs):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("melt not supported yet")
     pdf = pd.DataFrame(
         {
             "obj": list("abcd") * 5,
@@ -2069,9 +2049,8 @@ def test_concat_unknown_divisions_errors():
             dd.concat([aa, bb], axis=1).compute()
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="constructor not supported")
 def test_concat2():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("constructor not supported")
     dsk = {
         ("x", 0): pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}),
         ("x", 1): pd.DataFrame({"a": [4, 5, 6], "b": [3, 2, 1]}),
@@ -2925,10 +2904,9 @@ def test_merge_tasks_large_to_small(how, npartitions, base):
     )
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not available in dask-expr")
 @pytest.mark.parametrize("shuffle", [None, "tasks"])
 def test_broadcast_true(shuffle):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("not available in dask-expr")
     # Check that broadcast=True is satisfied
     # See: https://github.com/dask/dask/issues/9851
     left = dd.from_dict({"a": [1, 2] * 80, "b_left": range(160)}, npartitions=16)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -83,9 +83,8 @@ def test_shuffle(shuffle_method):
     assert shuffle_func(d, d.b)._name == shuffle_func(d, d.b)._name
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="no deprecation necessary")
 def test_shuffle_deprecated_shuffle_keyword(shuffle_method):
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="no deprecation necessary")
     from dask.dataframe.tests.test_multi import list_eq
 
     with pytest.warns(FutureWarning, match="'shuffle' keyword is deprecated"):
@@ -315,9 +314,8 @@ def test_set_index_names(shuffle_method):
 ME = "ME" if PANDAS_GE_220 else "M"
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="no demo module")
 def test_set_index_2(shuffle_method):
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="no demo module")
     df = dd.demo.make_timeseries(
         "2000",
         "2004",
@@ -381,10 +379,9 @@ def test_shuffle_sort(shuffle_method):
     assert_eq(ddf2, df2, sort_results=False)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not available")
 @pytest.mark.parametrize("scheduler", ["threads", "processes"])
 def test_rearrange(shuffle_method, scheduler):
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="not available")
     df = pd.DataFrame({"x": np.random.random(10)})
     ddf = dd.from_pandas(df, npartitions=4)
     ddf2 = ddf.assign(_partitions=ddf.x % 4)
@@ -404,9 +401,8 @@ def test_rearrange(shuffle_method, scheduler):
         assert sum(i in set(part._partitions) for part in parts) == 1
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not available")
 def test_rearrange_cleanup():
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="not available")
     df = pd.DataFrame({"x": np.random.random(10)})
     ddf = dd.from_pandas(df, npartitions=4)
     ddf2 = ddf.assign(_partitions=ddf.x % 4)
@@ -426,9 +422,8 @@ def mock_shuffle_group_3(df, col, npartitions, p):
     raise ValueError("Mock exception!")
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not available")
 def test_rearrange_disk_cleanup_with_exception():
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="not available")
     # ensure temporary files are cleaned up when there's an internal exception.
 
     with mock.patch("dask.dataframe.shuffle.shuffle_group_3", new=mock_shuffle_group_3):
@@ -448,9 +443,8 @@ def test_rearrange_disk_cleanup_with_exception():
     assert len(os.listdir(tmpdir)) == 0
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not available")
 def test_rearrange_by_column_with_narrow_divisions():
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="not available")
     from dask.dataframe.tests.test_multi import list_eq
 
     A = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6], "y": [1, 1, 2, 2, 3, 4]})
@@ -523,9 +517,8 @@ def test_set_index_divisions_2():
     assert list(result.compute(scheduler="sync").index[-2:]) == ["d", "d"]
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not available")
 def test_set_index_divisions_compute():
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="not available")
     d2 = d.set_index("b", divisions=[0, 2, 9], compute=False)
     d3 = d.set_index("b", divisions=[0, 2, 9], compute=True)
 
@@ -544,9 +537,8 @@ def test_set_index_divisions_compute():
     assert len(d4.dask) > len(d5.dask)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="constructor doesn't work")
 def test_set_index_divisions_sorted():
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="constructor doesn't work")
     p1 = pd.DataFrame({"x": [10, 11, 12], "y": ["a", "a", "a"]})
     p2 = pd.DataFrame({"x": [13, 14, 15], "y": ["b", "b", "c"]})
     p3 = pd.DataFrame({"x": [16, 17, 18], "y": ["d", "e", "e"]})
@@ -601,9 +593,8 @@ def make_part(n):
     return pd.DataFrame({"x": np.random.random(n), "y": np.random.random(n)})
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="auto not supported")
 def test_npartitions_auto_raises_deprecation_warning():
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="auto not supported")
     df = pd.DataFrame({"x": range(100), "y": range(100)})
     ddf = dd.from_pandas(df, npartitions=10, name="x", sort=False)
     with pytest.raises(FutureWarning, match="npartitions='auto'"):
@@ -612,9 +603,8 @@ def test_npartitions_auto_raises_deprecation_warning():
         ddf.sort_values(by=["x"], npartitions="auto")
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="auto not supported")
 def test_set_index_doesnt_increase_partitions(shuffle_method):
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="auto not supported")
     nparts = 2
     nbytes = 1e6
     n = int(nbytes / (nparts * 8))
@@ -762,9 +752,8 @@ def test_set_index(engine):
     assert_eq(d5, full.set_index(["b"]))
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not deprecated")
 def test_set_index_deprecated_shuffle_keyword(shuffle_method):
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="not deprecated")
     df = pd.DataFrame({"x": [4, 1, 1, 3, 3], "y": [1.0, 1, 1, 1, 2]})
     ddf = dd.from_pandas(df, 2)
 
@@ -832,12 +821,13 @@ def test_set_index_interpolate_int(engine):
     assert all(np.issubdtype(type(x), np.integer) for x in d1.divisions)
 
 
+@pytest.mark.skipif(
+    DASK_EXPR_ENABLED, reason="we don't do division inference for 1 partition frames"
+)
 @pytest.mark.parametrize(
     "engine", ["pandas", pytest.param("cudf", marks=pytest.mark.gpu)]
 )
 def test_set_index_interpolate_large_uint(engine):
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="we don't do division inference for 1 partition frames")
     if engine == "cudf":
         # NOTE: engine == "cudf" requires cudf/dask_cudf,
         # will be skipped by non-GPU CI.
@@ -861,9 +851,10 @@ def test_set_index_interpolate_large_uint(engine):
     assert set(d1.divisions) == {612509347682975743, 616762138058293247}
 
 
+@pytest.mark.skipif(
+    DASK_EXPR_ENABLED, reason="we don't do division inference for 1 partition frames"
+)
 def test_set_index_timezone():
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="we don't do division inference for 1 partition frames")
     s_naive = pd.Series(pd.date_range("20130101", periods=3))
     s_aware = pd.Series(pd.date_range("20130101", periods=3, tz="US/Eastern"))
     df = pd.DataFrame({"tz": s_aware, "notz": s_naive})
@@ -1000,9 +991,10 @@ def test_set_index_sorted_single_partition():
     assert_eq(ddf.set_index("x", sorted=True), df.set_index("x"))
 
 
+@pytest.mark.skipif(
+    DASK_EXPR_ENABLED, reason="we don't do division inference for sorted=True"
+)
 def test_set_index_sorted_min_max_same():
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="we don't do division inference for sorted=True")
     a = pd.DataFrame({"x": [1, 2, 3], "y": [0, 0, 0]})
     b = pd.DataFrame({"x": [1, 2, 3], "y": [1, 1, 1]})
 
@@ -1147,9 +1139,8 @@ def test_gh_2730():
     tm.assert_frame_equal(result.sort_values("KEY").reset_index(drop=True), expected)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="we test this over in dask-expr")
 def test_set_index_does_not_repeat_work_due_to_optimizations():
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="we test this over in dask-expr")
     # Atomic counter
     count = itertools.count()
 
@@ -1172,9 +1163,8 @@ def test_set_index_does_not_repeat_work_due_to_optimizations():
     assert ntimes == nparts
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="we don't support inplace")
 def test_set_index_errors_with_inplace_kwarg():
-    if DASK_EXPR_ENABLED:
-        pytest.skip(reason="we don't support inplace there")
     df = pd.DataFrame({"a": [9, 8, 7], "b": [6, 5, 4], "c": [3, 2, 1]})
     ddf = dd.from_pandas(df, npartitions=1)
 
@@ -1371,9 +1361,8 @@ def test_compute_current_divisions_overlap_2():
         ddf2.compute_current_divisions()
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not valid for dask-expr")
 def test_shuffle_hlg_layer():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("not valid for dask-expr")
     # This test checks that the `ShuffleLayer` HLG Layer
     # is used (as expected) for a multi-stage shuffle.
     ddf = dd.from_pandas(
@@ -1431,6 +1420,7 @@ def test_shuffle_partitions_meta_dtype():
                 assert layer.meta_input["_partitions"].dtype == np.int64
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not valid for dask-expr")
 @pytest.mark.parametrize(
     "npartitions",
     [
@@ -1439,8 +1429,6 @@ def test_shuffle_partitions_meta_dtype():
     ],
 )
 def test_shuffle_hlg_layer_serialize(npartitions):
-    if DASK_EXPR_ENABLED:
-        pytest.skip("not valid for dask-expr")
     ddf = dd.from_pandas(
         pd.DataFrame({"a": np.random.randint(0, 10, 100)}), npartitions=npartitions
     )
@@ -1524,9 +1512,8 @@ def test_set_index_with_series_uses_fastpath():
     assert_eq(res, expected)
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not valid for dask-expr")
 def test_set_index_partitions_meta_dtype():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("not valid for dask-expr")
     ddf = dd.from_pandas(
         pd.DataFrame({"a": np.random.randint(0, 10, 100)}, index=np.random.random(100)),
         npartitions=10,
@@ -1541,9 +1528,8 @@ def test_set_index_partitions_meta_dtype():
             assert layer.meta_input["_partitions"].dtype == np.int64
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not valid for dask-expr")
 def test_sort_values_partitions_meta_dtype_with_divisions():
-    if DASK_EXPR_ENABLED:
-        pytest.skip("not valid for dask-expr")
     with dask.config.set({"dataframe.shuffle.method": "tasks"}):
         ddf = dd.from_pandas(
             pd.DataFrame(


### PR DESCRIPTION
Follow-up from https://github.com/dask/dask/pull/10766, which fixed a bug where the config variable was a literal string and was eval'ed by pytest.mark.skipif.