### PR TITLE
Deprecate `compute` parameter in shuffle::set_index

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -35,7 +35,6 @@ from dask.dataframe.utils import UNKNOWN_CATEGORIES
 from dask.highlevelgraph import HighLevelGraph
 from dask.layers import ShuffleLayer, SimpleShuffleLayer
 from dask.sizeof import sizeof
-from dask.typing import no_default
 from dask.utils import M, digit, get_default_shuffle_method
 
 logger = logging.getLogger(__name__)
@@ -220,6 +219,7 @@ def sort_values(
     return df
 
 
+@_deprecated_kwarg("compute", None)
 @_deprecated_kwarg("shuffle", "shuffle_method")
 def set_index(
     df: DataFrame,
@@ -239,13 +239,6 @@ def set_index(
         return df.map_partitions(
             M.set_index, index, align_dataframes=False, drop=drop, **kwargs
         ).clear_divisions()
-
-    if compute is not no_default:
-        warnings.warn(
-            "`compute` parameter is deprecated and will be removed in a future version.",
-            FutureWarning,
-            2,
-        )
 
     if npartitions == "auto":
         warnings.warn(

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -239,6 +239,13 @@ def set_index(
             M.set_index, index, align_dataframes=False, drop=drop, **kwargs
         ).clear_divisions()
 
+    if compute is not False:
+        warnings.warn(
+            "`compute` parameter is deprecated and will be removed in a future version.",
+            FutureWarning,
+            2,
+        )
+
     if npartitions == "auto":
         warnings.warn(
             "`npartitions='auto'` is deprecated, either set it as an integer or leave as `None`.",

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -35,6 +35,7 @@ from dask.dataframe.utils import UNKNOWN_CATEGORIES
 from dask.highlevelgraph import HighLevelGraph
 from dask.layers import ShuffleLayer, SimpleShuffleLayer
 from dask.sizeof import sizeof
+from dask.typing import no_default
 from dask.utils import M, digit, get_default_shuffle_method
 
 logger = logging.getLogger(__name__)
@@ -239,7 +240,7 @@ def set_index(
             M.set_index, index, align_dataframes=False, drop=drop, **kwargs
         ).clear_divisions()
 
-    if compute is not False:
+    if compute is not no_default:
         warnings.warn(
             "`compute` parameter is deprecated and will be removed in a future version.",
             FutureWarning,

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -519,9 +519,11 @@ def test_set_index_divisions_2():
 
 @pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not available")
 def test_set_index_divisions_compute():
-    d2 = d.set_index("b", divisions=[0, 2, 9], compute=False)
+    deprecated = pytest.warns(FutureWarning, match="`compute` parameter is deprecated")
 
-    with pytest.warns(FutureWarning, match="`compute` parameter is deprecated"):
+    with deprecated:
+        d2 = d.set_index("b", divisions=[0, 2, 9], compute=False)
+    with deprecated:
         d3 = d.set_index("b", divisions=[0, 2, 9], compute=True)
 
     assert_eq(d2, d3)
@@ -529,8 +531,9 @@ def test_set_index_divisions_compute():
     assert_eq(d3, full.set_index("b"))
     assert len(d2.dask) > len(d3.dask)
 
-    d4 = d.set_index(d.b, divisions=[0, 2, 9], compute=False)
-    with pytest.warns(FutureWarning, match="`compute` parameter is deprecated"):
+    with deprecated:
+        d4 = d.set_index(d.b, divisions=[0, 2, 9], compute=False)
+    with deprecated:
         d5 = d.set_index(d.b, divisions=[0, 2, 9], compute=True)
     exp = full.copy()
     exp.index = exp.b

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -520,7 +520,9 @@ def test_set_index_divisions_2():
 @pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not available")
 def test_set_index_divisions_compute():
     d2 = d.set_index("b", divisions=[0, 2, 9], compute=False)
-    d3 = d.set_index("b", divisions=[0, 2, 9], compute=True)
+
+    with pytest.warns(FutureWarning, match="`compute` parameter is deprecated"):
+        d3 = d.set_index("b", divisions=[0, 2, 9], compute=True)
 
     assert_eq(d2, d3)
     assert_eq(d2, full.set_index("b"))
@@ -528,7 +530,8 @@ def test_set_index_divisions_compute():
     assert len(d2.dask) > len(d3.dask)
 
     d4 = d.set_index(d.b, divisions=[0, 2, 9], compute=False)
-    d5 = d.set_index(d.b, divisions=[0, 2, 9], compute=True)
+    with pytest.warns(FutureWarning, match="`compute` parameter is deprecated"):
+        d5 = d.set_index(d.b, divisions=[0, 2, 9], compute=True)
     exp = full.copy()
     exp.index = exp.b
     assert_eq(d4, d5)

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -519,7 +519,9 @@ def test_set_index_divisions_2():
 
 @pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not available")
 def test_set_index_divisions_compute():
-    deprecated = pytest.warns(FutureWarning, match="`compute` parameter is deprecated")
+    deprecated = pytest.warns(
+        FutureWarning, match="the 'compute' keyword is deprecated"
+    )
 
     with deprecated:
         d2 = d.set_index("b", divisions=[0, 2, 9], compute=False)


### PR DESCRIPTION
- [x] Closes #10737 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
