### PR TITLE
Deprecate `inplace` in DataFrame::eval

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5681,6 +5681,13 @@ class DataFrame(_Frame):
     def eval(self, expr, inplace=None, **kwargs):
         if inplace is None:
             inplace = False
+        else:
+            warnings.warn(
+                "`inplace` is deprecated and will be removed in a futuere version.",
+                FutureWarning,
+                2,
+            )
+
         if "=" in expr and inplace in (True, None):
             raise NotImplementedError(
                 "Inplace eval not supported. Please use inplace=False"

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2831,8 +2831,15 @@ def test_eval():
     d = dd.from_pandas(p, npartitions=2)
 
     assert_eq(p.eval("x + y"), d.eval("x + y"))
-    assert_eq(p.eval("z = x + y", inplace=False), d.eval("z = x + y", inplace=False))
-    with pytest.raises(NotImplementedError):
+
+    deprecate_ctx = pytest.warns(FutureWarning, match="`inplace` is deprecated")
+
+    expected = p.eval("z = x + y", inplace=False)
+    with deprecate_ctx:
+        actual = d.eval("z = x + y", inplace=False)
+    assert_eq(expected, actual)
+
+    with pytest.raises(NotImplementedError), deprecate_ctx:
         d.eval("z = x + y", inplace=True)
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2824,6 +2824,7 @@ def test_query():
     )
 
 
+@pytest.mark.skipif(DASK_EXPR_ENABLED, reason="not available")
 def test_eval():
     pytest.importorskip("numexpr")
 


### PR DESCRIPTION
- [x] Closes #10744 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

`set_index` didn't seem to need it, as there is already a [`NotImplementedError` on its use in that method](https://github.com/dask/dask/blob/1f764e7a11c51601033fc23d91c5a5177b0f2f4e/dask/dataframe/core.py#L5404).
