### PR TITLE
Enforce getitem deprecation dispatching to loc for datetime slicing

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -5072,17 +5072,6 @@ class DataFrame(_Frame):
     def __getitem__(self, key):
         name = "getitem-%s" % tokenize(self, key)
         if np.isscalar(key) or isinstance(key, (tuple, str)):
-            if isinstance(self._meta.index, (pd.DatetimeIndex, pd.PeriodIndex)):
-                if key not in self._meta.columns:
-                    warnings.warn(
-                        "Indexing a DataFrame with a datetimelike index using a single "
-                        "string to slice the rows, like `frame[string]`, is deprecated "
-                        "and will be removed in a future version. Use `frame.loc[string]` "
-                        "instead.",
-                        FutureWarning,
-                    )
-                    return self.loc[key]
-
             # error is raised from pandas
             meta = self._meta[_extract_meta(key)]
             dsk = partitionwise_graph(operator.getitem, name, self, key)

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -460,8 +460,8 @@ def test_getitem_timestamp_str():
     )
     ddf = dd.from_pandas(df, 10)
 
-    with pytest.warns(FutureWarning, match="Indexing a DataFrame with a datetimelike"):
-        assert_eq(df.loc["2011-01-02"], ddf["2011-01-02"])
+    with pytest.raises(KeyError, match="2011-01-02"):
+        ddf["2011-01-02"]
     assert_eq(df["2011-01-02":"2011-01-10"], ddf["2011-01-02":"2011-01-10"])
 
     df = pd.DataFrame(
@@ -511,8 +511,8 @@ def test_getitem_period_str():
     ddf = dd.from_pandas(df, 10)
 
     # partial string slice
-    with pytest.warns(FutureWarning, match="Indexing a DataFrame with a datetimelike"):
-        assert_eq(df.loc["2011-01-02"], ddf["2011-01-02"])
+    with pytest.raises(KeyError, match="2011-01-02"):
+        ddf["2011-01-02"]
     assert_eq(df["2011-01-02":"2011-01-10"], ddf["2011-01-02":"2011-01-10"])
     # same reso, dask result is always DataFrame
 
@@ -522,11 +522,10 @@ def test_getitem_period_str():
     )
     ddf = dd.from_pandas(df, 50)
 
-    with pytest.warns(FutureWarning, match="Indexing a DataFrame with a datetimelike"):
-        assert_eq(df.loc["2011-01"], ddf["2011-01"])
-
-    with pytest.warns(FutureWarning, match="Indexing a DataFrame with a datetimelike"):
-        assert_eq(df.loc["2011"], ddf["2011"])
+    with pytest.raises(KeyError, match="2011-01"):
+        ddf["2011-01"]
+    with pytest.raises(KeyError, match="2011"):
+        ddf["2011"]
 
     assert_eq(df["2011-01":"2012-05"], ddf["2011-01":"2012-05"])
     assert_eq(df["2011":"2015"], ddf["2011":"2015"])


### PR DESCRIPTION
This was deprecated for almost 3 years now, let's rip it out