### PR TITLE
Generalize ``CreationDispatch`` for dask-expr

### DIFF
--- a/dask/backends.py
+++ b/dask/backends.py
@@ -59,6 +59,7 @@ class CreationDispatch(Generic[BackendEntrypointType]):
     _config_field: str
     _default: str
     _entrypoint_class: type[BackendEntrypointType]
+    _entrypoint_root: str
 
     def __init__(
         self,
@@ -66,12 +67,14 @@ class CreationDispatch(Generic[BackendEntrypointType]):
         default: str,
         entrypoint_class: type[BackendEntrypointType],
         name: str | None = None,
+        entrypoint_root: str = "dask",
     ):
         self._lookup = {}
         self._module_name = module_name
         self._config_field = f"{module_name}.backend"
         self._default = default
         self._entrypoint_class = entrypoint_class
+        self._entrypoint_root = entrypoint_root
         if name:
             self.__name__ = name
 
@@ -94,7 +97,9 @@ class CreationDispatch(Generic[BackendEntrypointType]):
             impl = self._lookup[backend]
         except KeyError:
             # Check entrypoints for the specified backend
-            entrypoints = detect_entrypoints(f"dask.{self._module_name}.backends")
+            entrypoints = detect_entrypoints(
+                f"{self._entrypoint_root}.{self._module_name}.backends"
+            )
             if backend in entrypoints:
                 return self.register_backend(backend, entrypoints[backend].load()())
         else:


### PR DESCRIPTION
Minor change to simplify migration of creation dispatching to dask-expr (see https://github.com/dask-contrib/dask-expr/pull/728).
