### PR TITLE
Deprecate `axis` in GroupBy cumulative transformers

### DIFF
--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -48,7 +48,14 @@ from dask.dataframe.utils import (
 )
 from dask.highlevelgraph import HighLevelGraph
 from dask.typing import no_default
-from dask.utils import M, _deprecated, derived_from, funcname, itemgetter
+from dask.utils import (
+    M,
+    _deprecated,
+    _deprecated_kwarg,
+    derived_from,
+    funcname,
+    itemgetter,
+)
 
 if PANDAS_GE_140:
     from pandas.core.apply import reconstruct_func, validate_func_kwargs
@@ -1763,6 +1770,7 @@ class _GroupBy:
 
         return df4, by2
 
+    @_deprecated_kwarg("axis", None)
     @derived_from(pd.core.groupby.GroupBy)
     def cumsum(self, axis=no_default, numeric_only=no_default):
         axis = self._normalize_axis(axis, "cumsum")
@@ -1779,6 +1787,7 @@ class _GroupBy:
                 numeric_only=numeric_only,
             )
 
+    @_deprecated_kwarg("axis", None)
     @derived_from(pd.core.groupby.GroupBy)
     def cumprod(self, axis=no_default, numeric_only=no_default):
         axis = self._normalize_axis(axis, "cumprod")
@@ -1795,14 +1804,9 @@ class _GroupBy:
                 numeric_only=numeric_only,
             )
 
+    @_deprecated_kwarg("axis", None)
     @derived_from(pd.core.groupby.GroupBy)
     def cumcount(self, axis=no_default):
-        if axis is not no_default:
-            warnings.warn(
-                "The `axis` keyword argument is deprecated and will removed in a future release. "
-                "Previously it was unused and had no effect.",
-                FutureWarning,
-            )
         return self._cum_agg(
             "cumcount", chunk=M.cumcount, aggregate=_cumcount_aggregate, initial=-1
         )


### PR DESCRIPTION
- [x] Closes #10786 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
