### PR TITLE
Fix test-report cache key indent

### DIFF
--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -50,8 +50,8 @@ jobs:
           path: |
             test_report*
             !test_report.html
-                    # Note: these files are in the dask/distributed repository
-                    key: ${{ hashFiles('continuous_integration/scripts/test_report*') }}
+          # Note: these files are in the dask/distributed repository
+          key: ${{ hashFiles('continuous_integration/scripts/test_report*') }}
 
       - name: Generate report
         run: |


### PR DESCRIPTION
Follow up to #10783 
Think the `key` indent went bad during a commit of suggestion. 
