### PR TITLE
Deprecate out= and dtype= parameter in most dataframe methods

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6712,7 +6712,7 @@ def elemwise(op, *args, meta=no_default, out=None, transform_divisions=True, **k
     ----------
     op: callable
         Function to apply across input dataframes
-    *args: DataFrames, Series, Scalars, Arrays,
+    *args: DataFrames, Series, Scalars, Arrays, etc.
         The arguments of the operation
     meta: pd.DataFrame, pd.Series (optional)
         Valid metadata for the operation.  Will evaluate on a small piece of
@@ -6722,8 +6722,8 @@ def elemwise(op, *args, meta=no_default, out=None, transform_divisions=True, **k
         the function onto the divisions and apply those transformed divisions
         to the output.  You can pass ``transform_divisions=False`` to override
         this behavior
-    out : dask.dataframe object or None
-        DEPRECATED - If out is a dask.DataFrame, dask.Series or dask.Scalar then
+    out : dask.DataFrame, dask.Series, dask.Scalar, or None
+        If out is a dask.DataFrame, dask.Series or dask.Scalar then
         this overwrites the contents of it with the result
     **kwargs: scalars
 
@@ -6809,7 +6809,7 @@ def elemwise(op, *args, meta=no_default, out=None, transform_divisions=True, **k
 
 
 def handle_out(out, result):
-    """DEPRECATED - Handle out parameters
+    """Handle out parameters
 
     If out is a dask.DataFrame, dask.Series or dask.Scalar then
     this overwrites the contents of it with the result

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2229,7 +2229,7 @@ Dask Name: {name}, {layers}"""
         axis=None,
         skipna=True,
         split_every=False,
-        out=no_default,  # Deprecated
+        out=None,  # Deprecated
         numeric_only=None,
         none_is_zero=True,
     ):
@@ -2292,43 +2292,33 @@ Dask Name: {name}, {layers}"""
         meta = self._meta_nonempty.abs()
         return self.map_partitions(M.abs, meta=meta, enforce_metadata=False)
 
+    @_deprecated_kwarg("out")
     @derived_from(pd.DataFrame)
-    def all(
-        self,
-        axis=None,
-        skipna=True,
-        split_every=False,
-        out=no_default,  # Deprecated
-    ):
+    def all(self, axis=None, skipna=True, split_every=False, out=None):
         return self._reduction_agg(
             "all", axis=axis, skipna=skipna, split_every=split_every, out=out
         )
 
+    @_deprecated_kwarg("out")
     @derived_from(pd.DataFrame)
-    def any(
-        self,
-        axis=None,
-        skipna=True,
-        split_every=False,
-        out=no_default,  # Deprecated
-    ):
+    def any(self, axis=None, skipna=True, split_every=False, out=None):
         return self._reduction_agg(
             "any", axis=axis, skipna=skipna, split_every=split_every, out=out
         )
 
+    @_deprecated_kwarg("dtype")
+    @_deprecated_kwarg("out")
     @derived_from(pd.DataFrame)
     def sum(
         self,
         axis=None,
         skipna=True,
         split_every=False,
-        dtype=no_default,  # Deprecated
-        out=no_default,  # Deprecated
+        dtype=None,
+        out=None,
         min_count=None,
         numeric_only=None,
     ):
-        _warn_deprecated("dtype", dtype)
-
         result = self._reduction_agg(
             "sum",
             axis=axis,
@@ -2348,19 +2338,19 @@ Dask Name: {name}, {layers}"""
         else:
             return result
 
+    @_deprecated_kwarg("dtype")
+    @_deprecated_kwarg("out")
     @derived_from(pd.DataFrame)
     def prod(
         self,
         axis=None,
         skipna=True,
         split_every=False,
-        dtype=no_default,  # Deprecated
-        out=no_default,  # Deprecated
+        dtype=None,
+        out=None,
         min_count=None,
         numeric_only=None,
     ):
-        _warn_deprecated("dtype", dtype)
-
         result = self._reduction_agg(
             "prod",
             axis=axis,
@@ -2382,15 +2372,9 @@ Dask Name: {name}, {layers}"""
 
     product = prod  # aliased dd.product
 
+    @_deprecated_kwarg("out")
     @derived_from(pd.DataFrame)
-    def max(
-        self,
-        axis=0,
-        skipna=True,
-        split_every=False,
-        out=no_default,  # Deprecated
-        numeric_only=None,
-    ):
+    def max(self, axis=0, skipna=True, split_every=False, out=None, numeric_only=None):
         if (
             PANDAS_GE_140
             and not PANDAS_GE_200
@@ -2415,15 +2399,9 @@ Dask Name: {name}, {layers}"""
             numeric_only=numeric_only,
         )
 
+    @_deprecated_kwarg("out")
     @derived_from(pd.DataFrame)
-    def min(
-        self,
-        axis=0,
-        skipna=True,
-        split_every=False,
-        out=no_default,  # Deprecated,
-        numeric_only=None,
-    ):
+    def min(self, axis=0, skipna=True, split_every=False, out=None, numeric_only=None):
         if (
             PANDAS_GE_140
             and not PANDAS_GE_200
@@ -2442,7 +2420,7 @@ Dask Name: {name}, {layers}"""
             axis=axis,
             skipna=skipna,
             split_every=split_every,
-            out=no_default,  # Deprecated
+            out=out,
             # Starting in pandas 2.0, `axis=None` does a full aggregation across both axes
             none_is_zero=not PANDAS_GE_200,
             numeric_only=numeric_only,
@@ -2576,6 +2554,8 @@ Dask Name: {name}, {layers}"""
         mode_series.name = self.name
         return mode_series
 
+    @_deprecated_kwarg("dtype")
+    @_deprecated_kwarg("out")
     @_numeric_only
     @derived_from(pd.DataFrame)
     def mean(
@@ -2583,12 +2563,10 @@ Dask Name: {name}, {layers}"""
         axis=0,
         skipna=True,
         split_every=False,
-        dtype=no_default,  # Deprecated
-        out=no_default,  # Deprecated
+        dtype=None,
+        out=None,
         numeric_only=None,
     ):
-        _warn_deprecated("dtype", dtype)
-
         if (
             PANDAS_GE_140
             and not PANDAS_GE_200
@@ -2669,6 +2647,8 @@ Dask Name: {name}, {layers}"""
             "See the `median_approximate` method instead, which uses an approximate algorithm."
         )
 
+    @_deprecated_kwarg("dtype")
+    @_deprecated_kwarg("out")
     @derived_from(pd.DataFrame)
     def var(
         self,
@@ -2676,12 +2656,10 @@ Dask Name: {name}, {layers}"""
         skipna=True,
         ddof=1,
         split_every=False,
-        dtype=no_default,  # Deprecated
-        out=no_default,  # Deprecated
+        dtype=None,
+        out=None,
         numeric_only=no_default,
     ):
-        _warn_deprecated("dtype", dtype)
-
         axis = self._validate_axis(axis)
         _raise_if_object_series(self, "var")
         numeric_only_kwargs = get_numeric_only_kwargs(numeric_only)
@@ -2773,6 +2751,8 @@ Dask Name: {name}, {layers}"""
             graph, name, column._meta_nonempty.var(), divisions=[None, None]
         )
 
+    @_deprecated_kwarg("dtype")
+    @_deprecated_kwarg("out")
     @_numeric_data
     @derived_from(pd.DataFrame)
     def std(
@@ -2781,12 +2761,10 @@ Dask Name: {name}, {layers}"""
         skipna=True,
         ddof=1,
         split_every=False,
-        dtype=no_default,  # Deprecated
-        out=no_default,  # Deprecated
+        dtype=None,
+        out=None,
         numeric_only=no_default,
     ):
-        _warn_deprecated("dtype", dtype)
-
         axis = self._validate_axis(axis)
         _raise_if_object_series(self, "std")
         _raise_if_not_series_or_dataframe(self, "std")
@@ -2891,13 +2869,14 @@ Dask Name: {name}, {layers}"""
 
         return numeric_dd, needs_time_conversion
 
+    @_deprecated_kwarg("out")
     @derived_from(pd.DataFrame)
     def skew(
         self,
         axis=0,
         bias=True,
         nan_policy="propagate",
-        out=no_default,  # Deprecated
+        out=None,
         numeric_only=no_default,
     ):
         """
@@ -3011,6 +2990,7 @@ Dask Name: {name}, {layers}"""
             graph, name, num._meta_nonempty.skew(), divisions=[None, None]
         )
 
+    @_deprecated_kwarg("out")
     @derived_from(pd.DataFrame)
     def kurtosis(
         self,
@@ -3018,7 +2998,7 @@ Dask Name: {name}, {layers}"""
         fisher=True,
         bias=True,
         nan_policy="propagate",
-        out=no_default,  # Deprecated
+        out=None,
         numeric_only=no_default,
     ):
         """
@@ -3485,15 +3465,9 @@ Dask Name: {name}, {layers}"""
         meta = data._meta_nonempty.describe(**datetime_is_numeric_kwarg)
         return new_dd_object(graph, name, meta, divisions=[None, None])
 
+    @_deprecated_kwarg("out")
     def _cum_agg(
-        self,
-        op_name,
-        chunk,
-        aggregate,
-        axis,
-        skipna=True,
-        chunk_kwargs=None,
-        out=no_default,  # Deprecated
+        self, op_name, chunk, aggregate, axis, skipna=True, chunk_kwargs=None, out=None
     ):
         """Wrapper for cumulative operation"""
 
@@ -3546,16 +3520,10 @@ Dask Name: {name}, {layers}"""
             result = new_dd_object(graph, name, chunk(self._meta), self.divisions)
             return handle_out(out, result)
 
+    @_deprecated_kwarg("dtype")
+    @_deprecated_kwarg("out")
     @derived_from(pd.DataFrame)
-    def cumsum(
-        self,
-        axis=None,
-        skipna=True,
-        dtype=no_default,  # Deprecated
-        out=no_default,  # Deprecated
-    ):
-        _warn_deprecated("dtype", dtype)
-
+    def cumsum(self, axis=None, skipna=True, dtype=None, out=None):
         return self._cum_agg(
             "cumsum",
             chunk=M.cumsum,
@@ -3566,16 +3534,10 @@ Dask Name: {name}, {layers}"""
             out=out,
         )
 
+    @_deprecated_kwarg("dtype")
+    @_deprecated_kwarg("out")
     @derived_from(pd.DataFrame)
-    def cumprod(
-        self,
-        axis=None,
-        skipna=True,
-        dtype=no_default,  # Deprecated
-        out=no_default,  # Deprecated
-    ):
-        _warn_deprecated("dtype", dtype)
-
+    def cumprod(self, axis=None, skipna=True, dtype=None, out=None):
         return self._cum_agg(
             "cumprod",
             chunk=M.cumprod,
@@ -3586,13 +3548,9 @@ Dask Name: {name}, {layers}"""
             out=out,
         )
 
+    @_deprecated_kwarg("out")
     @derived_from(pd.DataFrame)
-    def cummax(
-        self,
-        axis=None,
-        skipna=True,
-        out=no_default,  # Deprecated
-    ):
+    def cummax(self, axis=None, skipna=True, out=None):
         return self._cum_agg(
             "cummax",
             chunk=M.cummax,
@@ -3603,13 +3561,9 @@ Dask Name: {name}, {layers}"""
             out=out,
         )
 
+    @_deprecated_kwarg("out")
     @derived_from(pd.DataFrame)
-    def cummin(
-        self,
-        axis=None,
-        skipna=True,
-        out=no_default,  # Deprecated
-    ):
+    def cummin(self, axis=None, skipna=True, out=None):
         return self._cum_agg(
             "cummin",
             chunk=M.cummin,
@@ -4478,14 +4432,9 @@ Dask Name: {name}, {layers}""".format(
             M.between, left=left, right=right, inclusive=inclusive
         )
 
+    @_deprecated_kwarg("out")
     @derived_from(pd.Series)
-    def clip(
-        self,
-        lower=None,
-        upper=None,
-        out=no_default,  # Deprecated
-        axis=None,
-    ):
+    def clip(self, lower=None, upper=None, out=None, axis=None):
         if out is not None:
             raise ValueError("'out' must be None")
         if axis not in (None, 0):
@@ -5789,18 +5738,11 @@ class DataFrame(_Frame):
 
         return self.map_partitions(M.dropna, **kwargs, enforce_metadata=False)
 
+    @_deprecated_kwarg("out")
     @derived_from(pd.DataFrame)
-    def clip(
-        self,
-        lower=None,
-        upper=None,
-        out=no_default,  # Deprecated
-        axis=None,
-    ):
-        _warn_deprecated("out", out)
-        if out not in (no_default, None):
-            raise ValueError("'out' is not supported")
-
+    def clip(self, lower=None, upper=None, out=None, axis=None):
+        if out is not None:
+            raise ValueError("'out' must be None")
         return self.map_partitions(
             M.clip,
             lower=lower,
@@ -6763,14 +6705,7 @@ def is_broadcastable(dfs, s):
     )
 
 
-def elemwise(
-    op,
-    *args,
-    meta=no_default,
-    out=no_default,  # Deprecated
-    transform_divisions=True,
-    **kwargs,
-):
+def elemwise(op, *args, meta=no_default, out=None, transform_divisions=True, **kwargs):
     """Elementwise operation for Dask dataframes
 
     Parameters
@@ -6787,6 +6722,9 @@ def elemwise(
         the function onto the divisions and apply those transformed divisions
         to the output.  You can pass ``transform_divisions=False`` to override
         this behavior
+    out : dask.dataframe object or None
+        DEPRECATED - If out is a dask.DataFrame, dask.Series or dask.Scalar then
+        this overwrites the contents of it with the result
     **kwargs: scalars
 
     Examples
@@ -6870,25 +6808,12 @@ def elemwise(
     return handle_out(out, result)
 
 
-def _warn_deprecated(param_name: str, value: object) -> None:
-    if value is not no_default:
-        warnings.warn(
-            f"Parameter '{param_name}' has been deprecated "
-            "and will be removed in a future release",
-            FutureWarning,
-        )
-
-
 def handle_out(out, result):
     """DEPRECATED - Handle out parameters
 
     If out is a dask.DataFrame, dask.Series or dask.Scalar then
     this overwrites the contents of it with the result
     """
-    _warn_deprecated("out", out)
-    if out is no_default:
-        out = None
-
     if isinstance(out, tuple):
         if len(out) == 1:
             out = out[0]

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -3465,9 +3465,15 @@ Dask Name: {name}, {layers}"""
         meta = data._meta_nonempty.describe(**datetime_is_numeric_kwarg)
         return new_dd_object(graph, name, meta, divisions=[None, None])
 
-    @_deprecated_kwarg("out")
     def _cum_agg(
-        self, op_name, chunk, aggregate, axis, skipna=True, chunk_kwargs=None, out=None
+        self,
+        op_name,
+        chunk,
+        aggregate,
+        axis,
+        skipna=True,
+        chunk_kwargs=None,
+        out=None,  # Deprecated
     ):
         """Wrapper for cumulative operation"""
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2229,7 +2229,7 @@ Dask Name: {name}, {layers}"""
         axis=None,
         skipna=True,
         split_every=False,
-        out=None,
+        out=no_default,  # Deprecated
         numeric_only=None,
         none_is_zero=True,
     ):
@@ -2293,13 +2293,25 @@ Dask Name: {name}, {layers}"""
         return self.map_partitions(M.abs, meta=meta, enforce_metadata=False)
 
     @derived_from(pd.DataFrame)
-    def all(self, axis=None, skipna=True, split_every=False, out=None):
+    def all(
+        self,
+        axis=None,
+        skipna=True,
+        split_every=False,
+        out=no_default,  # Deprecated
+    ):
         return self._reduction_agg(
             "all", axis=axis, skipna=skipna, split_every=split_every, out=out
         )
 
     @derived_from(pd.DataFrame)
-    def any(self, axis=None, skipna=True, split_every=False, out=None):
+    def any(
+        self,
+        axis=None,
+        skipna=True,
+        split_every=False,
+        out=no_default,  # Deprecated
+    ):
         return self._reduction_agg(
             "any", axis=axis, skipna=skipna, split_every=split_every, out=out
         )
@@ -2310,11 +2322,13 @@ Dask Name: {name}, {layers}"""
         axis=None,
         skipna=True,
         split_every=False,
-        dtype=None,
-        out=None,
+        dtype=no_default,  # Deprecated
+        out=no_default,  # Deprecated
         min_count=None,
         numeric_only=None,
     ):
+        _warn_deprecated("dtype", dtype)
+
         result = self._reduction_agg(
             "sum",
             axis=axis,
@@ -2340,11 +2354,13 @@ Dask Name: {name}, {layers}"""
         axis=None,
         skipna=True,
         split_every=False,
-        dtype=None,
-        out=None,
+        dtype=no_default,  # Deprecated
+        out=no_default,  # Deprecated
         min_count=None,
         numeric_only=None,
     ):
+        _warn_deprecated("dtype", dtype)
+
         result = self._reduction_agg(
             "prod",
             axis=axis,
@@ -2367,7 +2383,14 @@ Dask Name: {name}, {layers}"""
     product = prod  # aliased dd.product
 
     @derived_from(pd.DataFrame)
-    def max(self, axis=0, skipna=True, split_every=False, out=None, numeric_only=None):
+    def max(
+        self,
+        axis=0,
+        skipna=True,
+        split_every=False,
+        out=no_default,  # Deprecated
+        numeric_only=None,
+    ):
         if (
             PANDAS_GE_140
             and not PANDAS_GE_200
@@ -2393,7 +2416,14 @@ Dask Name: {name}, {layers}"""
         )
 
     @derived_from(pd.DataFrame)
-    def min(self, axis=0, skipna=True, split_every=False, out=None, numeric_only=None):
+    def min(
+        self,
+        axis=0,
+        skipna=True,
+        split_every=False,
+        out=no_default,  # Deprecated,
+        numeric_only=None,
+    ):
         if (
             PANDAS_GE_140
             and not PANDAS_GE_200
@@ -2412,7 +2442,7 @@ Dask Name: {name}, {layers}"""
             axis=axis,
             skipna=skipna,
             split_every=split_every,
-            out=out,
+            out=no_default,  # Deprecated
             # Starting in pandas 2.0, `axis=None` does a full aggregation across both axes
             none_is_zero=not PANDAS_GE_200,
             numeric_only=numeric_only,
@@ -2553,10 +2583,12 @@ Dask Name: {name}, {layers}"""
         axis=0,
         skipna=True,
         split_every=False,
-        dtype=None,
-        out=None,
+        dtype=no_default,  # Deprecated
+        out=no_default,  # Deprecated
         numeric_only=None,
     ):
+        _warn_deprecated("dtype", dtype)
+
         if (
             PANDAS_GE_140
             and not PANDAS_GE_200
@@ -2644,10 +2676,12 @@ Dask Name: {name}, {layers}"""
         skipna=True,
         ddof=1,
         split_every=False,
-        dtype=None,
-        out=None,
+        dtype=no_default,  # Deprecated
+        out=no_default,  # Deprecated
         numeric_only=no_default,
     ):
+        _warn_deprecated("dtype", dtype)
+
         axis = self._validate_axis(axis)
         _raise_if_object_series(self, "var")
         numeric_only_kwargs = get_numeric_only_kwargs(numeric_only)
@@ -2747,10 +2781,12 @@ Dask Name: {name}, {layers}"""
         skipna=True,
         ddof=1,
         split_every=False,
-        dtype=None,
-        out=None,
+        dtype=no_default,  # Deprecated
+        out=no_default,  # Deprecated
         numeric_only=no_default,
     ):
+        _warn_deprecated("dtype", dtype)
+
         axis = self._validate_axis(axis)
         _raise_if_object_series(self, "std")
         _raise_if_not_series_or_dataframe(self, "std")
@@ -2861,7 +2897,7 @@ Dask Name: {name}, {layers}"""
         axis=0,
         bias=True,
         nan_policy="propagate",
-        out=None,
+        out=no_default,  # Deprecated
         numeric_only=no_default,
     ):
         """
@@ -2982,7 +3018,7 @@ Dask Name: {name}, {layers}"""
         fisher=True,
         bias=True,
         nan_policy="propagate",
-        out=None,
+        out=no_default,  # Deprecated
         numeric_only=no_default,
     ):
         """
@@ -3450,7 +3486,14 @@ Dask Name: {name}, {layers}"""
         return new_dd_object(graph, name, meta, divisions=[None, None])
 
     def _cum_agg(
-        self, op_name, chunk, aggregate, axis, skipna=True, chunk_kwargs=None, out=None
+        self,
+        op_name,
+        chunk,
+        aggregate,
+        axis,
+        skipna=True,
+        chunk_kwargs=None,
+        out=no_default,  # Deprecated
     ):
         """Wrapper for cumulative operation"""
 
@@ -3504,7 +3547,15 @@ Dask Name: {name}, {layers}"""
             return handle_out(out, result)
 
     @derived_from(pd.DataFrame)
-    def cumsum(self, axis=None, skipna=True, dtype=None, out=None):
+    def cumsum(
+        self,
+        axis=None,
+        skipna=True,
+        dtype=no_default,  # Deprecated
+        out=no_default,  # Deprecated
+    ):
+        _warn_deprecated("dtype", dtype)
+
         return self._cum_agg(
             "cumsum",
             chunk=M.cumsum,
@@ -3516,7 +3567,15 @@ Dask Name: {name}, {layers}"""
         )
 
     @derived_from(pd.DataFrame)
-    def cumprod(self, axis=None, skipna=True, dtype=None, out=None):
+    def cumprod(
+        self,
+        axis=None,
+        skipna=True,
+        dtype=no_default,  # Deprecated
+        out=no_default,  # Deprecated
+    ):
+        _warn_deprecated("dtype", dtype)
+
         return self._cum_agg(
             "cumprod",
             chunk=M.cumprod,
@@ -3528,7 +3587,12 @@ Dask Name: {name}, {layers}"""
         )
 
     @derived_from(pd.DataFrame)
-    def cummax(self, axis=None, skipna=True, out=None):
+    def cummax(
+        self,
+        axis=None,
+        skipna=True,
+        out=no_default,  # Deprecated
+    ):
         return self._cum_agg(
             "cummax",
             chunk=M.cummax,
@@ -3540,7 +3604,12 @@ Dask Name: {name}, {layers}"""
         )
 
     @derived_from(pd.DataFrame)
-    def cummin(self, axis=None, skipna=True, out=None):
+    def cummin(
+        self,
+        axis=None,
+        skipna=True,
+        out=no_default,  # Deprecated
+    ):
         return self._cum_agg(
             "cummin",
             chunk=M.cummin,
@@ -4410,7 +4479,13 @@ Dask Name: {name}, {layers}""".format(
         )
 
     @derived_from(pd.Series)
-    def clip(self, lower=None, upper=None, out=None, axis=None):
+    def clip(
+        self,
+        lower=None,
+        upper=None,
+        out=no_default,  # Deprecated
+        axis=None,
+    ):
         if out is not None:
             raise ValueError("'out' must be None")
         if axis not in (None, 0):
@@ -5715,9 +5790,17 @@ class DataFrame(_Frame):
         return self.map_partitions(M.dropna, **kwargs, enforce_metadata=False)
 
     @derived_from(pd.DataFrame)
-    def clip(self, lower=None, upper=None, out=None, axis=None):
-        if out is not None:
-            raise ValueError("'out' must be None")
+    def clip(
+        self,
+        lower=None,
+        upper=None,
+        out=no_default,  # Deprecated
+        axis=None,
+    ):
+        _warn_deprecated("out", out)
+        if out not in (no_default, None):
+            raise ValueError("'out' is not supported")
+
         return self.map_partitions(
             M.clip,
             lower=lower,
@@ -6680,7 +6763,14 @@ def is_broadcastable(dfs, s):
     )
 
 
-def elemwise(op, *args, meta=no_default, out=None, transform_divisions=True, **kwargs):
+def elemwise(
+    op,
+    *args,
+    meta=no_default,
+    out=no_default,  # Deprecated
+    transform_divisions=True,
+    **kwargs,
+):
     """Elementwise operation for Dask dataframes
 
     Parameters
@@ -6697,9 +6787,6 @@ def elemwise(op, *args, meta=no_default, out=None, transform_divisions=True, **k
         the function onto the divisions and apply those transformed divisions
         to the output.  You can pass ``transform_divisions=False`` to override
         this behavior
-    out : ``dask.array`` or ``None``
-        If out is a dask.DataFrame, dask.Series or dask.Scalar then
-        this overwrites the contents of it with the result
     **kwargs: scalars
 
     Examples
@@ -6783,12 +6870,25 @@ def elemwise(op, *args, meta=no_default, out=None, transform_divisions=True, **k
     return handle_out(out, result)
 
 
+def _warn_deprecated(param_name: str, value: object) -> None:
+    if value is not no_default:
+        warnings.warn(
+            f"Parameter '{param_name}' has been deprecated "
+            "and will be removed in a future release",
+            FutureWarning,
+        )
+
+
 def handle_out(out, result):
-    """Handle out parameters
+    """DEPRECATED - Handle out parameters
 
     If out is a dask.DataFrame, dask.Series or dask.Scalar then
     this overwrites the contents of it with the result
     """
+    _warn_deprecated("out", out)
+    if out is no_default:
+        out = None
+
     if isinstance(out, tuple):
         if len(out) == 1:
             out = out[0]
@@ -6819,6 +6919,7 @@ def handle_out(out, result):
 
         if not isinstance(out, Scalar):
             out._divisions = result.divisions
+        return None
     elif out is not None:
         msg = (
             "The out parameter is not fully supported."

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -7,7 +7,7 @@ from functools import partial, wraps
 from numbers import Integral, Number
 from operator import getitem
 from pprint import pformat
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, cast
 
 import numpy as np
 import pandas as pd
@@ -255,7 +255,7 @@ def _dummy_numpy_dispatcher(
 
             return func(*args, **kwargs)
 
-        return wrapper
+        return cast(F, wrapper)
 
     return decorator
 

--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -6844,7 +6844,7 @@ def handle_out(out, result):
 
         if not isinstance(out, Scalar):
             out._divisions = result.divisions
-        return None
+        return result
     elif out is not None:
         msg = (
             "The out parameter is not fully supported."

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1770,7 +1770,7 @@ class _GroupBy:
 
         return df4, by2
 
-    @_deprecated_kwarg("axis", None)
+    @_deprecated_kwarg("axis")
     @derived_from(pd.core.groupby.GroupBy)
     def cumsum(self, axis=no_default, numeric_only=no_default):
         axis = self._normalize_axis(axis, "cumsum")
@@ -1787,7 +1787,7 @@ class _GroupBy:
                 numeric_only=numeric_only,
             )
 
-    @_deprecated_kwarg("axis", None)
+    @_deprecated_kwarg("axis")
     @derived_from(pd.core.groupby.GroupBy)
     def cumprod(self, axis=no_default, numeric_only=no_default):
         axis = self._normalize_axis(axis, "cumprod")
@@ -1804,7 +1804,7 @@ class _GroupBy:
                 numeric_only=numeric_only,
             )
 
-    @_deprecated_kwarg("axis", None)
+    @_deprecated_kwarg("axis")
     @derived_from(pd.core.groupby.GroupBy)
     def cumcount(self, axis=no_default):
         return self._cum_agg(

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -219,7 +219,7 @@ def sort_values(
     return df
 
 
-@_deprecated_kwarg("compute", None)
+@_deprecated_kwarg("compute")
 @_deprecated_kwarg("shuffle", "shuffle_method")
 def set_index(
     df: DataFrame,

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -10,7 +10,6 @@ import pytest
 from pandas.api.types import is_scalar
 
 import dask.dataframe as dd
-from dask.array.numpy_compat import _numpy_125
 from dask.dataframe._compat import (
     PANDAS_GE_140,
     PANDAS_GE_150,
@@ -890,20 +889,20 @@ def test_reductions_out(frame, axis, out, redfunc):
         # numpy has default ddof value 0 while
         # dask and pandas have 1, so ddof should be passed
         # explicitly when calling np.var(dask)
-        np_redfunc(dsk_in, axis=axis, ddof=1, out=dsk_out)
+        with pytest.warns(FutureWarning, match="the 'out' keyword is deprecated"):
+            np_redfunc(dsk_in, axis=axis, ddof=1, out=dsk_out)
     else:
-        ctx = contextlib.nullcontext()
-        if _numpy_125 and redfunc == "product":
-            ctx = pytest.warns(DeprecationWarning, match="`product` is deprecated")
-        with ctx:
+        with pytest.warns(FutureWarning, match="the 'out' keyword is deprecated"):
             np_redfunc(dsk_in, axis=axis, out=dsk_out)
 
     assert_eq(dsk_out, pd_redfunc(frame, axis=axis))
 
-    dsk_redfunc(dsk_in, axis=axis, split_every=False, out=dsk_out)
+    with pytest.warns(FutureWarning, match="the 'out' keyword is deprecated"):
+        dsk_redfunc(dsk_in, axis=axis, split_every=False, out=dsk_out)
     assert_eq(dsk_out, pd_redfunc(frame, axis=axis))
 
-    dsk_redfunc(dsk_in, axis=axis, split_every=2, out=dsk_out)
+    with pytest.warns(FutureWarning, match="the 'out' keyword is deprecated"):
+        dsk_redfunc(dsk_in, axis=axis, split_every=2, out=dsk_out)
     assert_eq(dsk_out, pd_redfunc(frame, axis=axis))
 
 
@@ -936,24 +935,29 @@ def test_allany(split_every):
         pd.Series(np.random.choice([True, False], size=(100,))), 10
     )
 
-    # all
-    ddf.all(split_every=split_every, out=ddf_out_axis_default)
+    with pytest.warns(FutureWarning, match="the 'out' keyword is deprecated"):
+        ddf.all(split_every=split_every, out=ddf_out_axis_default)
     assert_eq(ddf_out_axis_default, df.all())
 
-    ddf.all(axis=1, split_every=split_every, out=ddf_out_axis1)
+    with pytest.warns(FutureWarning, match="the 'out' keyword is deprecated"):
+        ddf.all(axis=1, split_every=split_every, out=ddf_out_axis1)
     assert_eq(ddf_out_axis1, df.all(axis=1))
 
-    ddf.all(split_every=split_every, axis=0, out=ddf_out_axis_default)
+    with pytest.warns(FutureWarning, match="the 'out' keyword is deprecated"):
+        ddf.all(split_every=split_every, axis=0, out=ddf_out_axis_default)
     assert_eq(ddf_out_axis_default, df.all(axis=0))
 
     # any
-    ddf.any(split_every=split_every, out=ddf_out_axis_default)
+    with pytest.warns(FutureWarning, match="the 'out' keyword is deprecated"):
+        ddf.any(split_every=split_every, out=ddf_out_axis_default)
     assert_eq(ddf_out_axis_default, df.any())
 
-    ddf.any(axis=1, split_every=split_every, out=ddf_out_axis1)
+    with pytest.warns(FutureWarning, match="the 'out' keyword is deprecated"):
+        ddf.any(axis=1, split_every=split_every, out=ddf_out_axis1)
     assert_eq(ddf_out_axis1, df.any(axis=1))
 
-    ddf.any(split_every=split_every, axis=0, out=ddf_out_axis_default)
+    with pytest.warns(FutureWarning, match="the 'out' keyword is deprecated"):
+        ddf.any(split_every=split_every, axis=0, out=ddf_out_axis_default)
     assert_eq(ddf_out_axis_default, df.any(axis=0))
 
 

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -10,6 +10,7 @@ import pytest
 from pandas.api.types import is_scalar
 
 import dask.dataframe as dd
+from dask.array.numpy_compat import _numpy_125
 from dask.dataframe._compat import (
     PANDAS_GE_140,
     PANDAS_GE_150,
@@ -855,55 +856,72 @@ def test_reductions_timedelta(split_every):
     assert_eq(dds.count(split_every=split_every), ds.count())
 
 
+@pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize(
-    "frame,axis,out",
-    [
-        (
-            pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=[0, 1, 3]),
-            0,
-            pd.Series([], dtype="float64"),
-        ),
-        (
-            pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=[0, 1, 3]),
-            1,
-            pd.Series([], dtype="float64"),
-        ),
-        (pd.Series([1, 2.5, 6]), None, None),
-    ],
+    "redfunc",
+    ["sum", "prod", "product", "min", "max", "mean", "var", "std", "all", "any"],
 )
-@pytest.mark.parametrize(
-    "redfunc", ["sum", "prod", "product", "min", "max", "mean", "var", "std"]
-)
-def test_reductions_out(frame, axis, out, redfunc):
+def test_reductions_out(axis, redfunc):
+    frame = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=[0, 1, 3])
     dsk_in = dd.from_pandas(frame, 3)
-    dsk_out = dd.from_pandas(pd.Series([0]), 1).sum()
 
-    if out is not None:
-        dsk_out = dd.from_pandas(out, 3)
+    out = dd.from_pandas(pd.Series([], dtype="float64"), 3)
 
     np_redfunc = getattr(np, redfunc)
     pd_redfunc = getattr(frame.__class__, redfunc)
     dsk_redfunc = getattr(dsk_in.__class__, redfunc)
 
+    ctx = pytest.warns(FutureWarning, match=r"the '(out|dtype)' keyword is deprecated")
+
     if redfunc in ["var", "std"]:
         # numpy has default ddof value 0 while
         # dask and pandas have 1, so ddof should be passed
         # explicitly when calling np.var(dask)
-        with pytest.warns(FutureWarning, match="the 'out' keyword is deprecated"):
-            np_redfunc(dsk_in, axis=axis, ddof=1, out=dsk_out)
+        with ctx:
+            np_redfunc(dsk_in, axis=axis, ddof=1, out=out)
+    elif _numpy_125 and redfunc == "product" and out is None:
+        with pytest.warns(DeprecationWarning, match="`product` is deprecated"):
+            np_redfunc(dsk_in, axis=axis, out=out)
     else:
-        with pytest.warns(FutureWarning, match="the 'out' keyword is deprecated"):
-            np_redfunc(dsk_in, axis=axis, out=dsk_out)
+        with ctx:
+            np_redfunc(dsk_in, axis=axis, out=out)
 
-    assert_eq(dsk_out, pd_redfunc(frame, axis=axis))
+    assert_eq(out, pd_redfunc(frame, axis=axis))
+
+    with ctx:
+        dsk_redfunc(dsk_in, axis=axis, split_every=False, out=out)
+    assert_eq(out, pd_redfunc(frame, axis=axis))
 
     with pytest.warns(FutureWarning, match="the 'out' keyword is deprecated"):
-        dsk_redfunc(dsk_in, axis=axis, split_every=False, out=dsk_out)
-    assert_eq(dsk_out, pd_redfunc(frame, axis=axis))
+        dsk_redfunc(dsk_in, axis=axis, split_every=2, out=out)
+    assert_eq(out, pd_redfunc(frame, axis=axis))
 
-    with pytest.warns(FutureWarning, match="the 'out' keyword is deprecated"):
-        dsk_redfunc(dsk_in, axis=axis, split_every=2, out=dsk_out)
-    assert_eq(dsk_out, pd_redfunc(frame, axis=axis))
+
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize(
+    "redfunc",
+    ["sum", "prod", "product", "min", "max", "mean", "var", "std", "all", "any"],
+)
+def test_reductions_numpy_dispatch(axis, redfunc):
+    pdf = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}, index=[0, 1, 3])
+    df = dd.from_pandas(pdf, 3)
+    np_redfunc = getattr(np, redfunc)
+
+    if redfunc in ("var", "std"):
+        # numpy has default ddof value 0 while
+        # dask and pandas have 1, so ddof should be passed
+        # explicitly when calling np.var(dask)
+        expect = np_redfunc(pdf, axis=axis, ddof=1)
+        actual = np_redfunc(df, axis=axis, ddof=1)
+    elif _numpy_125 and redfunc == "product":
+        expect = np_redfunc(pdf, axis=axis)
+        with pytest.warns(DeprecationWarning, match="`product` is deprecated"):
+            actual = np_redfunc(df, axis=axis)
+    else:
+        expect = np_redfunc(pdf, axis=axis)
+        actual = np_redfunc(df, axis=axis)
+
+    assert_eq(expect, actual)
 
 
 @pytest.mark.parametrize("split_every", [False, 2])

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -871,7 +871,7 @@ def test_reductions_out(axis, redfunc):
     pd_redfunc = getattr(frame.__class__, redfunc)
     dsk_redfunc = getattr(dsk_in.__class__, redfunc)
 
-    ctx = pytest.warns(FutureWarning, match=r"the '(out|dtype)' keyword is deprecated")
+    ctx = pytest.warns(FutureWarning, match=r"the 'out' keyword is deprecated")
 
     if redfunc in ["var", "std"]:
         # numpy has default ddof value 0 while

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -27,6 +27,7 @@ import tlz as toolz
 
 from dask import config
 from dask.core import get_deps
+from dask.typing import no_default
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -144,7 +145,7 @@ def _deprecated(
 
 def _deprecated_kwarg(
     old_arg_name: str,
-    new_arg_name: str | None,
+    new_arg_name: str | None = None,
     mapping: Mapping[Any, Any] | Callable[[Any], Any] | None = None,
     stacklevel: int = 2,
 ) -> Callable[[F], F]:
@@ -155,10 +156,10 @@ def _deprecated_kwarg(
     ----------
     old_arg_name : str
         Name of argument in function to deprecate
-    new_arg_name : str or None
-        Name of preferred argument in function. Use None to raise warning that
+    new_arg_name : str, optional
+        Name of preferred argument in function. Omit to warn that
         ``old_arg_name`` keyword is deprecated.
-    mapping : dict or callable
+    mapping : dict or callable, optional
         If mapping is present, use it to translate old arguments to
         new arguments. A callable must do its own value checking;
         values not found in a dict will be forwarded unchanged.
@@ -217,9 +218,9 @@ def _deprecated_kwarg(
     def _deprecated_kwarg(func: F) -> F:
         @wraps(func)
         def wrapper(*args, **kwargs) -> Callable[..., Any]:
-            old_arg_value = kwargs.pop(old_arg_name, None)
+            old_arg_value = kwargs.pop(old_arg_name, no_default)
 
-            if old_arg_value is not None:
+            if old_arg_value is not no_default:
                 if new_arg_name is None:
                     msg = (
                         f"the {repr(old_arg_name)} keyword is deprecated and "


### PR DESCRIPTION
- Closes #10777

NOT deprecated out parameter:
- from_dict
- to_sql
- elementwise ufuncs (e.g. `np.log`)

