### PR TITLE
Deprecate `axis` in DataFrame.rolling

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -2158,6 +2158,7 @@ Dask Name: {name}, {layers}"""
         else:
             return lambda self, other: elemwise(op, self, other)
 
+    @_deprecated_kwarg("axis", None)
     def rolling(
         self, window, min_periods=None, center=False, win_type=None, axis=no_default
     ):

--- a/dask/dataframe/tests/test_rolling.py
+++ b/dask/dataframe/tests/test_rolling.py
@@ -330,8 +330,12 @@ def test_rolling_raises():
     pytest.raises(ValueError, lambda: ddf.rolling(-1))
     pytest.raises(ValueError, lambda: ddf.rolling(3, min_periods=1.2))
     pytest.raises(ValueError, lambda: ddf.rolling(3, min_periods=-2))
-    pytest.raises(ValueError, lambda: ddf.rolling(3, axis=10))
-    pytest.raises(ValueError, lambda: ddf.rolling(3, axis="coulombs"))
+
+    axis_deprecated = pytest.warns(FutureWarning, match="'axis' keyword is deprecated")
+    with axis_deprecated:
+        pytest.raises(ValueError, lambda: ddf.rolling(3, axis=10))
+    with axis_deprecated:
+        pytest.raises(ValueError, lambda: ddf.rolling(3, axis="coulombs"))
     pytest.raises(NotImplementedError, lambda: ddf.rolling(100).mean().compute())
 
 
@@ -356,23 +360,31 @@ def test_rolling_axis(kwargs):
     df = pd.DataFrame(np.random.randn(20, 16))
     ddf = dd.from_pandas(df, npartitions=3)
 
-    ctx = contextlib.nullcontext()
+    axis_deprecated_pandas = contextlib.nullcontext()
     if PANDAS_GE_210:
-        ctx = pytest.warns(FutureWarning, match="The 'axis' keyword|Support for axis")
+        axis_deprecated_pandas = pytest.warns(
+            FutureWarning, match="'axis' keyword|Support for axis"
+        )
+
+    axis_deprecated_dask = pytest.warns(
+        FutureWarning, match="'axis' keyword is deprecated"
+    )
 
     if kwargs["axis"] == "series":
         # Series
-        with ctx:
+        with axis_deprecated_pandas:
             expected = df[3].rolling(5, axis=0).std()
-        with ctx:
+        with axis_deprecated_dask:
             result = ddf[3].rolling(5, axis=0).std()
         assert_eq(expected, result)
     else:
         # DataFrame
-        with ctx:
+        with axis_deprecated_pandas:
             expected = df.rolling(3, **kwargs).mean()
         if kwargs["axis"] in (1, "rows") and not PANDAS_GE_210:
             ctx = pytest.warns(FutureWarning, match="Using axis=1 in Rolling")
+        elif "axis" in kwargs:
+            ctx = axis_deprecated_dask
         with ctx:
             result = ddf.rolling(3, **kwargs).mean()
         assert_eq(expected, result)


### PR DESCRIPTION
- [x] Closes #10793 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
