### PR TITLE
Fix more tests to use `pytest.warns()`

### DIFF
--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -806,12 +806,12 @@ def test_solve_assume_a(shape, chunk):
     assert_eq(res, _scipy_linalg_solve(A, b, assume_a="pos"), check_graph=False)
     assert_eq(dA.dot(res), b.astype(float), check_graph=False)
 
-    with pytest.raises(FutureWarning, match="sym_pos keyword is deprecated"):
+    with pytest.warns(FutureWarning, match="sym_pos keyword is deprecated"):
         res = da.linalg.solve(dA, db, sym_pos=True)
         assert_eq(res, _scipy_linalg_solve(A, b, assume_a="pos"), check_graph=False)
         assert_eq(dA.dot(res), b.astype(float), check_graph=False)
 
-    with pytest.raises(FutureWarning, match="sym_pos keyword is deprecated"):
+    with pytest.warns(FutureWarning, match="sym_pos keyword is deprecated"):
         res = da.linalg.solve(dA, db, sym_pos=False)
         assert_eq(res, _scipy_linalg_solve(A, b, assume_a="gen"), check_graph=False)
         assert_eq(dA.dot(res), b.astype(float), check_graph=False)

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -199,7 +199,7 @@ def test_random_all(sz):
 
 def test_RandomState_only_funcs():
     da.random.randint(10, size=5, chunks=3).compute()
-    with pytest.raises(DeprecationWarning):
+    with pytest.warns(DeprecationWarning):
         da.random.random_integers(10, size=5, chunks=3).compute()
     da.random.random_sample(10, chunks=3).compute()
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1222,7 +1222,7 @@ def test_categories(tmpdir, engine):
             # attempt to load as category that which is not so encoded
             dd.read_parquet(fn, categories=["x"], engine=engine).compute()
 
-    with pytest.raises((ValueError, FutureWarning)):
+    with pytest.raises(ValueError) or pytest.warns(FutureWarning):
         # attempt to load as category unknown column
         dd.read_parquet(fn, categories=["foo"], engine=engine)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -5666,7 +5666,7 @@ def test_view():
     ddf = dd.from_pandas(df, npartitions=2)
 
     msg = "Will be removed in a future version. Use "
-    with pytest.raises(FutureWarning, match=msg):
+    with pytest.warns(FutureWarning, match=msg):
         assert_eq(ddf["x"].view("uint8"), df["x"].view("uint8"))
         assert_eq(ddf["y"].view("int64"), df["y"].view("int64"))
 

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -605,9 +605,9 @@ def make_part(n):
 def test_npartitions_auto_raises_deprecation_warning():
     df = pd.DataFrame({"x": range(100), "y": range(100)})
     ddf = dd.from_pandas(df, npartitions=10, name="x", sort=False)
-    with pytest.raises(FutureWarning, match="npartitions='auto'"):
+    with pytest.warns(FutureWarning, match="npartitions='auto'"):
         ddf.set_index("x", npartitions="auto")
-    with pytest.raises(FutureWarning, match="npartitions='auto'"):
+    with pytest.warns(FutureWarning, match="npartitions='auto'"):
         ddf.sort_values(by=["x"], npartitions="auto")
 
 


### PR DESCRIPTION
Fix more tests to use `pytest.warns()` to assert for warnings rather than incorrect `pytest.raises()`.  More specifically, the latter does not work when `-Werror` is not used.  In Gentoo, we avoid `-Werror` since it tends to cause irrelevant test suite failures when old versions are tested against newer dependencies.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
