### PR TITLE
Minor[CI]: publish-test-results not marked as failed

### DIFF
--- a/.github/workflows/publish-test-results.yaml
+++ b/.github/workflows/publish-test-results.yaml
@@ -47,3 +47,4 @@ jobs:
           event_file: artifacts/Event File/event.json
           event_name: ${{ github.event.workflow_run.event }}
           junit_files: artifacts/**/*.xml
+          fail_on: "errors"


### PR DESCRIPTION
Change the [publish unit test result action](https://github.com/EnricoMi/publish-unit-test-result-action) to not report itself as failed if other tests in CI have failed, only on errors. 

Rationale:
PRs like https://github.com/dask/dask/pull/10824 get the ugly :x: when any tests fail b/c the action itself reports itself as failed when any tests in the CI has failed.

However, "nothing" in the PR has failed, only tests for dask-expr which are expected and thus marked green on CI.
https://github.com/dask/dask/actions/runs/7567879416/job/20607928150?pr=10824#step:8:28559
