### PR TITLE
freq="w" and "d" are deprecated in pandas 2.2

### DIFF
--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -24,7 +24,7 @@ ME = "ME" if PANDAS_GE_220 else "M"
             ["series", "frame"],
             ["count", "mean", "ohlc"],
             [2, 5],
-            ["30min", "h", "d", "w", ME],
+            ["30min", "h", "D", "W", ME],
             ["right", "left"],
             ["right", "left"],
         )


### PR DESCRIPTION
- See https://pandas.pydata.org/docs/dev/user_guide/timeseries.html#offset-aliases
- Part of #10593