### PR TITLE
pandas 2.2: groupby(...).apply() to state include_groups=False

### DIFF
--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1829,12 +1829,15 @@ def test_shuffle_nulls_introduced():
     ddf1 = dd.from_pandas(df1, npartitions=10)
     ddf2 = dd.from_pandas(df2, npartitions=1)
     meta = pd.Series(dtype=int, index=pd.Index([], dtype=bool, name="A"), name="A")
+    include_groups = {"include_groups": False} if PANDAS_GE_220 else {}
     result = (
         dd.merge(ddf1, ddf2, how="outer", on="B")
         .groupby("A")
-        .apply(lambda df: len(df), meta=meta)
+        .apply(lambda df: len(df), meta=meta, **include_groups)
     )
     expected = (
-        pd.merge(df1, df2, how="outer", on="B").groupby("A").apply(lambda df: len(df))
+        pd.merge(df1, df2, how="outer", on="B")
+        .groupby("A")
+        .apply(lambda df: len(df), **include_groups)
     )
     assert_eq(result, expected, check_names=False)


### PR DESCRIPTION
This was deprecated overnight upon publication of pandas 2.2 final.
Read: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.core.groupby.DataFrameGroupBy.apply.html

Besides unit tests that explicitly call `groupby(...).apply`, this change also impacted
- `groupby(...).cov`
- `groupby(...).fillna`
- `groupby(...).ffill`
- `groupby(...).bfill`
