### PR TITLE
Fix test for sizeof(pd.MultiIndex) in upstream CI

### DIFF
--- a/dask/sizeof.py
+++ b/dask/sizeof.py
@@ -213,10 +213,7 @@ def register_pandas():
 
     @sizeof.register(pd.MultiIndex)
     def sizeof_pandas_multiindex(i):
-        p = sum(sizeof(lev) for lev in i.levels)
-        for c in i.codes:
-            p += c.nbytes
-        return p
+        return sum(sizeof(l) for l in i.levels) + sum(c.nbytes for c in i.codes)
 
 
 @sizeof.register_lazy("scipy")

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -78,7 +78,7 @@ def test_pandas_contiguous_dtypes():
 
 @requires_pandas
 def test_pandas_multiindex():
-    index = pd.MultiIndex.from_product([range(5), ["a", "b", "c", "d", "e"]])
+    index = pd.MultiIndex.from_product([range(50), list("abcdefghilmnopqrstuvwxyz")])
     actual_size = sys.getsizeof(index)
 
     assert 0.5 * actual_size < sizeof(index) < 2 * actual_size


### PR DESCRIPTION
- Part of #10593 

Output is much smaller than vs. published releases, but still very accurate for non-trivial data sizes