### PR TITLE
Allow length of ascending to be larger than one in sort_values

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -189,7 +189,7 @@ def sort_values(
     divisions_ascending = ascending
     if divisions_ascending and not isinstance(divisions_ascending, bool):
         divisions_ascending = divisions_ascending[0]
-    assert isinstance(divisions_ascending, bool)
+    assert divisions_ascending is None or isinstance(divisions_ascending, bool)
     divisions, _, _, presorted = _calculate_divisions(
         df,
         sort_by_col,

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -152,6 +152,13 @@ def sort_values(
             "You passed %s" % str(by)
         )
 
+    if (
+        ascending is not None
+        and not isinstance(ascending, bool)
+        and not len(ascending) == len(by)
+    ):
+        raise ValueError(f"Length of {ascending=} != length of {by=}")
+
     sort_kwargs = {
         "by": by,
         "ascending": ascending,
@@ -179,22 +186,18 @@ def sort_values(
         repartition = False
 
     sort_by_col = df[by[0]]
-
-    if not isinstance(ascending, bool):
-        # support [True] as input
-        if (
-            isinstance(ascending, list)
-            and len(ascending) == 1
-            and isinstance(ascending[0], bool)
-        ):
-            ascending = ascending[0]
-        else:
-            raise NotImplementedError(
-                f"Dask currently only supports a single boolean for ascending. You passed {str(ascending)}"
-            )
-
+    divisions_ascending = ascending
+    if divisions_ascending and not isinstance(divisions_ascending, bool):
+        divisions_ascending = divisions_ascending[0]
+    assert isinstance(divisions_ascending, bool)
     divisions, _, _, presorted = _calculate_divisions(
-        df, sort_by_col, repartition, npartitions, upsample, partition_size, ascending
+        df,
+        sort_by_col,
+        repartition,
+        npartitions,
+        upsample,
+        partition_size,
+        divisions_ascending,
     )
 
     if len(divisions) == 2:
@@ -211,7 +214,7 @@ def sort_values(
         by[0],
         divisions,
         shuffle_method=shuffle_method,
-        ascending=ascending,
+        ascending=divisions_ascending,
         na_position=na_position,
         duplicates=False,
     )

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1722,6 +1722,8 @@ def test_sort_values_bool_ascending():
     # attempt to sort with list of ascending booleans
     with pytest.raises(ValueError, match="length"):
         ddf.sort_values(by="a", ascending=[True, False])
+    with pytest.raises(ValueError, match="length"):
+        ddf.sort_values(by=["a", "b"], ascending=[True])
     assert_eq(
         ddf.sort_values(by="a", ascending=[True]),
         df.sort_values(by="a", ascending=[True]),

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -1720,8 +1720,16 @@ def test_sort_values_bool_ascending():
     ddf = dd.from_pandas(df, npartitions=10)
 
     # attempt to sort with list of ascending booleans
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(ValueError, match="length"):
         ddf.sort_values(by="a", ascending=[True, False])
+    assert_eq(
+        ddf.sort_values(by="a", ascending=[True]),
+        df.sort_values(by="a", ascending=[True]),
+    )
+    assert_eq(
+        ddf.sort_values(by=["a", "b"], ascending=[True, False]),
+        df.sort_values(by=["a", "b"], ascending=[True, False]),
+    )
 
 
 @pytest.mark.parametrize("npartitions", [1, 3])


### PR DESCRIPTION
This was added in https://github.com/dask/dask/pull/8440 but there is and never was any reason to raise a `NotImplementedError`. This has nothing to do with `rearrange_by_divisions` since we will _shuffle_  (i.e. rearrange by divisions) only on one column but we can still sort by how many columns we want.