### PR TITLE
Adjust test for support of median in Groupby.aggregate in dask-expr (2/2)

### DIFF
--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2897,7 +2897,11 @@ def test_groupby_aggregate_partial_function_unexpected_args(agg):
     # SeriesGroupBy
     with pytest.raises(
         TypeError,
-        match="doesn't support positional arguments|'Series' object cannot be interpreted as an integer",
+        match=(
+            "doesn't support positional arguments"
+            "|'Series' object cannot be interpreted as an integer"
+            "|cannot convert the series to <class 'int'>"
+        ),
     ):
         agg(ddf.groupby("a")["b"])
 


### PR DESCRIPTION
Follow-up to #10862. Missed the second `pytest.raises`.