### PR TITLE
Fix regression in test_graph_manipulation

### DIFF
--- a/dask/tests/test_graph_manipulation.py
+++ b/dask/tests/test_graph_manipulation.py
@@ -26,6 +26,9 @@ class NodeCounter:
     def __init__(self):
         self.n = 0
 
+    def __dask_tokenize__(self):
+        return type(self), self.n
+
     def f(self, x):
         time.sleep(random.random() / 100)
         self.n += 1


### PR DESCRIPTION
Fix regression introduced in #10865, appearing in dask_expr only.
The above PR changes tokenization of bound methods from

- pickle of the whole instance plus method name

to
- tokenization of the instance plus method name

and tokenization of generic objects does not attempt to pickle (by design).