### PR TITLE
Deterministic tokenize for pyarrow datatypes

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -1289,6 +1289,15 @@ def register_pandas():
         return offset.freqstr
 
 
+@normalize_token.register_lazy("pyarrow")
+def register_pyarrow():
+    import pyarrow as pa
+
+    @normalize_token.register(pa.DataType)
+    def normalize_datatype(dt):
+        return pickle.dumps(dt, protocol=4)
+
+
 @normalize_token.register_lazy("numpy")
 def register_numpy():
     import numpy as np

--- a/dask/tests/test_tokenize.py
+++ b/dask/tests/test_tokenize.py
@@ -25,6 +25,7 @@ from dask.utils_test import import_or_none
 dd = import_or_none("dask.dataframe")
 np = import_or_none("numpy")
 sp = import_or_none("scipy.sparse")
+pa = import_or_none("pyarrow")
 pd = import_or_none("pandas")
 
 
@@ -781,3 +782,19 @@ def test_tokenize_random_functions_with_state_numpy():
     c = np.random.RandomState(456).random
     assert tokenize(a) == tokenize(b)
     assert tokenize(a) != tokenize(c)
+
+
+@pytest.mark.skipif("not pa")
+def test_tokenize_pyarrow_datatypes_simple():
+    a = pa.int64()
+    b = pa.float64()
+    assert tokenize(a) == tokenize(a)
+    assert tokenize(a) != tokenize(b)
+
+
+@pytest.mark.skipif("not pa")
+def test_tokenize_pyarrow_datatypes_complex():
+    a = pa.struct({"x": pa.int32(), "y": pa.string()})
+    b = pa.struct({"x": pa.float64(), "y": pa.int16()})
+    assert tokenize(a) == tokenize(a)
+    assert tokenize(a) != tokenize(b)


### PR DESCRIPTION
Fix regression introduced in #10865 (dask-expr specific)