### PR TITLE
Add ``distributed.print`` and ``distributed.warn`` to API docs

### DIFF
--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -919,6 +919,8 @@ API
    secede
    rejoin
    wait
+   print
+   warn
 
 .. autofunction:: as_completed
 .. autofunction:: fire_and_forget
@@ -926,6 +928,8 @@ API
 .. autofunction:: secede
 .. autofunction:: rejoin
 .. autofunction:: wait
+.. autofunction:: print
+.. autofunction:: warn
 
 .. autoclass:: Client
    :members:


### PR DESCRIPTION
I was looking for these in the docs, but then realized that they are only documented over in the `distributed` docs. This PR adds them to the main docs too.  