### PR TITLE
A couple of dask-expr fixes for new parquet cache

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -11,6 +11,7 @@ from functools import reduce
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+import pyarrow.fs as pa_fs
 import pyarrow.parquet as pq
 
 # Check PyArrow version for feature support
@@ -20,7 +21,7 @@ from pyarrow import dataset as pa_ds
 from pyarrow import fs as pa_fs
 
 import dask
-from dask.base import tokenize
+from dask.base import normalize_token, tokenize
 from dask.core import flatten
 from dask.dataframe.backends import pyarrow_schema_dispatch
 from dask.dataframe.io.parquet.utils import (
@@ -53,6 +54,11 @@ PYARROW_NULLABLE_DTYPE_MAPPING = {
     pa.float32(): pd.Float32Dtype(),
     pa.float64(): pd.Float64Dtype(),
 }
+
+
+@normalize_token.register(pa_fs.FileSystem)
+def tokenize_arrowfs(obj):
+    return obj.__reduce__()
 
 
 #

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -182,6 +182,9 @@ class PartitionObj:
         self.name = name
         self.keys = pd.Index(keys.sort_values(), copy=False)
 
+    def __dask_tokenize__(self):
+        return tokenize(self.name, self.keys)
+
 
 def _frag_subset(old_frag, row_groups):
     """Create new fragment with row-group subset."""

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2759,11 +2759,7 @@ def test_split_row_groups(tmpdir, engine):
     ddf3 = dd.read_parquet(
         tmp, engine=engine, calculate_divisions=True, split_row_groups=False
     )
-    if DASK_EXPR_ENABLED:
-        assert ddf3.npartitions == 2
-
-    else:
-        assert ddf3.npartitions == 4
+    assert ddf3.npartitions == 4
 
 
 @PYARROW_MARK

--- a/dask/dataframe/tests/test_indexing.py
+++ b/dask/dataframe/tests/test_indexing.py
@@ -106,12 +106,16 @@ def test_loc_with_series():
 def test_loc_with_array():
     assert_eq(d.loc[(d.a % 2 == 0).values], full.loc[(full.a % 2 == 0).values])
 
-    assert sorted(d.loc[(d.a % 2 == 0).values].dask) == sorted(
-        d.loc[(d.a % 2 == 0).values].dask
-    )
-    assert sorted(d.loc[(d.a % 2 == 0).values].dask) != sorted(
-        d.loc[(d.a % 3 == 0).values].dask
-    )
+    # FIXME: Left and right will have different keys due to
+    # https://github.com/dask/dask/issues/10799
+    # (But asserting on this here is odd)
+    if not dd._dask_expr_enabled():
+        assert sorted(d.loc[(d.a % 2 == 0).values].dask) == sorted(
+            d.loc[(d.a % 2 == 0).values].dask
+        )
+        assert sorted(d.loc[(d.a % 2 == 0).values].dask) != sorted(
+            d.loc[(d.a % 3 == 0).values].dask
+        )
 
 
 def test_loc_with_function():


### PR DESCRIPTION
This is required for https://github.com/dask-contrib/dask-expr/pull/798

I haven't really tried to understand why the one test now no longer deviates. I guess the previous deviation was a caching bug and the cache in https://github.com/dask-contrib/dask-expr/pull/798 is a little more specific.

Note: This one test will now fail on the dask-expr test branch until https://github.com/dask-contrib/dask-expr/pull/798 is merged as well