### PR TITLE
Pickle da.argwhere and da.count_nonzero

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -2049,31 +2049,22 @@ def choose(a, choices):
     return elemwise(variadic_choose, a, *choices)
 
 
-def _isnonzero_vec(v):
-    return bool(np.count_nonzero(v))
+_isnonzero_vec = np.vectorize(lambda v: bool(np.count_nonzero(v)), otypes=[bool])
 
 
-_isnonzero_vec = np.vectorize(_isnonzero_vec, otypes=[bool])
+def _isnonzero(a):
+    # Output of np.vectorize can't be pickled
+    return _isnonzero_vec(a)
 
 
 def isnonzero(a):
-    if a.dtype.kind in {"U", "S"}:
-        # NumPy treats all-whitespace strings as falsy (like in `np.nonzero`).
-        # but not in `.astype(bool)`. To match the behavior of numpy at least until
-        # 1.19, we use `_isnonzero_vec`. When NumPy changes behavior, we should just
-        # use the try block below.
-        # https://github.com/numpy/numpy/issues/9875
-        return a.map_blocks(_isnonzero_vec, dtype=bool)
+    """Handle special cases where conversion to bool does not work correctly.
+    xref: https://github.com/numpy/numpy/issues/9479
+    """
     try:
-        np.zeros(tuple(), dtype=a.dtype).astype(bool)
+        np.zeros([], dtype=a.dtype).astype(bool)
     except ValueError:
-        ######################################################
-        # Handle special cases where conversion to bool does #
-        # not work correctly.                                #
-        #                                                    #
-        # xref: https://github.com/numpy/numpy/issues/9479   #
-        ######################################################
-        return a.map_blocks(_isnonzero_vec, dtype=bool)
+        return a.map_blocks(_isnonzero, dtype=bool)
     else:
         return a.astype(bool)
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -2049,7 +2049,11 @@ def choose(a, choices):
     return elemwise(variadic_choose, a, *choices)
 
 
-_isnonzero_vec = np.vectorize(lambda v: bool(np.count_nonzero(v)), otypes=[bool])
+def _isnonzero_vec(v):
+    return bool(np.count_nonzero(v))
+
+
+_isnonzero_vec = np.vectorize(_isnonzero_vec, otypes=[bool])
 
 
 def _isnonzero(a):

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import itertools
+import pickle
 import sys
 import warnings
 from numbers import Number
@@ -2708,3 +2709,18 @@ def test_tril_triu_indices(n, k, m, chunks):
         )
     else:
         assert_eq(actual, expected)
+
+
+def test_pickle_vectorized_routines():
+    """Test that graphs that internally use np.vectorize can be pickled"""
+    a = da.from_array(["foo", "bar", ""])
+
+    b = da.count_nonzero(a)
+    assert_eq(b, 2, check_dtype=False)
+    b2 = pickle.loads(pickle.dumps(b))
+    assert_eq(b2, 2, check_dtype=False)
+
+    c = da.argwhere(a)
+    assert_eq(c, [[0], [1]], check_dtype=False)
+    c2 = pickle.loads(pickle.dumps(c))
+    assert_eq(c2, [[0], [1]], check_dtype=False)


### PR DESCRIPTION
Fix serialization of da.argwhere and da.count_nonzero:

```
_pickle.PicklingError: Can't pickle <ufunc '_isnonzero_vec (vectorized)'>: attribute lookup _isnonzero_vec (vectorized) on __main__ failed
```