### PR TITLE
Fix inplace modification on read-only arrays for string conversion

### DIFF
--- a/dask/dataframe/_pyarrow.py
+++ b/dask/dataframe/_pyarrow.py
@@ -75,8 +75,7 @@ def _to_string_dtype(df, dtype_check, index_check, string_dtype):
             col: string_dtype for col, dtype in df.dtypes.items() if dtype_check(dtype)
         }
         if dtypes:
-            keys = list(dtypes.keys())
-            df[keys] = df[keys].copy().astype(dtypes)
+            df = df.astype(dtypes)
     elif dtype_check(df.dtype):
         dtypes = string_dtype
         df = df.copy().astype(dtypes)

--- a/dask/dataframe/_pyarrow.py
+++ b/dask/dataframe/_pyarrow.py
@@ -70,16 +70,16 @@ def _to_string_dtype(df, dtype_check, index_check, string_dtype):
         string_dtype = pd.StringDtype("pyarrow")
 
     # Possibly convert DataFrame/Series/Index to `string[pyarrow]`
-    dtypes = None
     if is_dataframe_like(df):
         dtypes = {
             col: string_dtype for col, dtype in df.dtypes.items() if dtype_check(dtype)
         }
+        if dtypes:
+            keys = list(dtypes.keys())
+            df[keys] = df[keys].copy().astype(dtypes)
     elif dtype_check(df.dtype):
         dtypes = string_dtype
-
-    if dtypes:
-        df = df.astype(dtypes, copy=False)
+        df = df.copy().astype(dtypes)
 
     # Convert DataFrame/Series index too
     if (is_dataframe_like(df) or is_series_like(df)) and index_check(df.index):

--- a/dask/dataframe/tests/test_pyarrow_compat.py
+++ b/dask/dataframe/tests/test_pyarrow_compat.py
@@ -145,7 +145,8 @@ def test_inplace_modification_read_only():
     base = pd.Series(arr, copy=False, dtype=object, name="a")
     base_copy = pickle.loads(pickle.dumps(base))
     base_copy.values.flags.writeable = False
+    dtype = object if dd._dask_expr_enabled() else get_string_dtype()
     tm.assert_series_equal(
         dd.from_array(base_copy.values, columns="a").compute(),
-        base.astype(get_string_dtype()),
+        base.astype(dtype),
     )

--- a/dask/dataframe/tests/test_pyarrow_compat.py
+++ b/dask/dataframe/tests/test_pyarrow_compat.py
@@ -9,6 +9,8 @@ import pandas as pd
 import pandas._testing as tm
 import pytest
 
+from dask.dataframe.utils import get_string_dtype
+
 pa = pytest.importorskip("pyarrow")
 import dask.dataframe as dd
 from dask.dataframe._compat import PANDAS_GE_150
@@ -145,5 +147,5 @@ def test_inplace_modification_read_only():
     base_copy.values.flags.writeable = False
     tm.assert_series_equal(
         dd.from_array(base_copy.values, columns="a").compute(),
-        base.astype("string[pyarrow]"),
+        base.astype(get_string_dtype()),
     )


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

It took me a bit to come up with a case that runs into the pandas edge case that is fixed on 2.2