### PR TITLE
Set lower bound version for s3fs

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -48,7 +48,7 @@ dependencies:
   - bokeh
   - httpretty
   - aiohttp
-  - s3fs
+  - s3fs>=2021.9.0
   - crick
   - cytoolz
   - distributed

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -47,7 +47,7 @@ dependencies:
   - bokeh
   - httpretty
   - aiohttp
-  - s3fs
+  - s3fs>=2021.9.0
   # Need a new `crick` release with support for `numpy=1.24+`
   # https://github.com/dask/crick/issues/25
   # - crick

--- a/continuous_integration/environment-3.12.yaml
+++ b/continuous_integration/environment-3.12.yaml
@@ -47,7 +47,7 @@ dependencies:
   - bokeh
   - httpretty
   - aiohttp
-  - s3fs
+  - s3fs>=2021.9.0
   # Need a new `crick` release with support for `numpy=1.24+`
   # https://github.com/dask/crick/issues/25
   # - crick

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -48,7 +48,7 @@ dependencies:
   - bokeh
   - httpretty
   - aiohttp
-  - s3fs
+  - s3fs>=2021.9.0
   - crick
   - cytoolz
   - distributed


### PR DESCRIPTION
Fix s3fs from encountering errors found in https://github.com/dask/dask/actions/runs/7781526271/job/21216130971?pr=10888.

> AttributeError: module 'aiobotocore' has no attribute 'AioSession'

Which was fixed way back in https://github.com/fsspec/s3fs/pull/510, but `s3fs==0.6.0` was getting installed in the #10888 workflow runs. So setting a lower bound for s3fs seemed like a reasonable action.


