### PR TITLE
Set upper bound version for numba when pandas<2.1

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -26,6 +26,7 @@ dependencies:
   - mimesis<13.1.0  # https://github.com/dask/dask/issues/10858
   - numpy=1.23
   - pandas=1.5
+  - numba<0.59.0  # Removed numba.generated_jit which pandas<2.1 uses
   - flask
   - fastparquet
   - h5py
@@ -58,7 +59,6 @@ dependencies:
   - ipywidgets<8.0.5
   - ipykernel<6.22.0
   - lz4
-  - numba
   - psutil
   - requests
   - scikit-image

--- a/continuous_integration/environment-3.9.yaml
+++ b/continuous_integration/environment-3.9.yaml
@@ -26,6 +26,7 @@ dependencies:
   - mimesis<12
   - numpy=1.22
   - pandas=1.4
+  - numba<0.59.0  # Removed numba.generated_jit which pandas<2.1 uses
   - flask
   - fastparquet
   - h5py
@@ -58,7 +59,6 @@ dependencies:
   - ipywidgets<8.0.5
   - ipykernel<6.22.0
   - lz4
-  - numba
   - psutil
   - requests
   - scikit-image<0.20


### PR DESCRIPTION
Other failures from https://github.com/dask/dask/actions/runs/7782898192/job/21220260676?pr=10889#step:8:33175

numba 0.59.0, released 4 days ago, [removed `numba.generated_jit`](https://github.com/numba/numba/blob/main/docs/source/release/0.59.0-notes.rst#removal-of-deprecated-api-numbagenerated_jit) which [pandas<2.1](https://github.com/pandas-dev/pandas/pull/53455) had been using.
