### PR TITLE
Avoid ``pytest.warns`` in ``test_to_datetime`` for GPU CI

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -5142,7 +5142,7 @@ def test_to_datetime(gpu):
 
     # infer_datetime_format is not supported anymore in dask-expr
     if not DASK_EXPR_ENABLED:
-        if PANDAS_GE_200:
+        if PANDAS_GE_200 and not gpu:
             ctx = pytest.warns(
                 UserWarning, match="'infer_datetime_format' is deprecated"
             )

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -5142,14 +5142,15 @@ def test_to_datetime(gpu):
 
     # infer_datetime_format is not supported anymore in dask-expr
     if not DASK_EXPR_ENABLED:
-        if PANDAS_GE_200 and not gpu:
+        if PANDAS_GE_200:
             ctx = pytest.warns(
                 UserWarning, match="'infer_datetime_format' is deprecated"
             )
         else:
             ctx = contextlib.nullcontext()
+        ctx_expected = contextlib.nullcontext() if gpu else ctx
 
-        with ctx:
+        with ctx_expected:
             expected = xd.to_datetime(s, infer_datetime_format=True)
         with ctx:
             result = dd.to_datetime(ds, infer_datetime_format=True)
@@ -5158,7 +5159,7 @@ def test_to_datetime(gpu):
             result = dd.to_datetime(s, infer_datetime_format=True)
         assert_eq(expected, result, check_dtype=check_dtype)
 
-        with ctx:
+        with ctx_expected:
             expected = xd.to_datetime(s.index, infer_datetime_format=True)
         with ctx:
             result = dd.to_datetime(ds.index, infer_datetime_format=True)


### PR DESCRIPTION
The `infer_datetime_format` argument is not yet deprecated in cudf. Adjusts `test_to_datetime` to unblock GPU CI.
