### PR TITLE
Improve performance for groupby.nunique

### DIFF
--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -167,8 +167,6 @@ def test_unknown_categoricals(
         )
     else:
         ddf = dd.from_pandas(pd.concat(dsk.values()).astype(meta), npartitions=4)
-    if npartitions == 10 and not PANDAS_GE_150:
-        request.applymarker(pytest.mark.xfail(reason="group_keys not supported"))
     if npartitions is not None:
         ddf = ddf.repartition(npartitions=npartitions)
     # Compute


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

I found this while debugging query 21. The current implementation is just ridiculously slow. 

This change makes the following query 6x faster locally on scale 1 tpch (from 60 to 10 seconds, 4 workers)

```
        lineitem.groupby("l_orderkey")["l_suppkey"]
        .nunique()
        .rename("nunique_col")
        .reset_index()
```

The apply call just kills the GIL