### PR TITLE
Override tokenize.ensure-deterministic config flag

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -1007,9 +1007,13 @@ def persist(*args, traverse=True, optimize_graph=True, scheduler=None, **kwargs)
 ############
 # Tokenize #
 ############
+class TokenizationError(RuntimeError):
+    pass
 
 
-def tokenize(*args, **kwargs):
+def tokenize(
+    *args: object, ensure_deterministic: bool | None = None, **kwargs: object
+) -> str:
     """Deterministic token
 
     >>> tokenize([1, 2, '3'])
@@ -1017,17 +1021,87 @@ def tokenize(*args, **kwargs):
 
     >>> tokenize('Hello') == tokenize('Hello')
     True
+
+    Parameters
+    ----------
+    args, kwargs:
+        objects to tokenize
+    ensure_deterministic: bool, optional
+        If True, raise TokenizationError if the objects cannot be deterministically
+        tokenized, e.g. two identical objects will return different tokens.
+        Defaults to the `tokenize.ensure-deterministic` configuration parameter.
     """
-    tok = _seen.set({})
-    try:
-        token = _normalize_seq_func(args)
+    with _seen_ctx(reset=True), _ensure_deterministic_ctx(ensure_deterministic):
+        token: object = _normalize_seq_func(args)
         if kwargs:
             token = token, _normalize_seq_func(sorted(kwargs.items()))
-    finally:
-        _seen.reset(tok)
 
     # Pass `usedforsecurity=False` to support FIPS builds of Python
     return hashlib.md5(str(token).encode(), usedforsecurity=False).hexdigest()
+
+
+# tokenize.ensure-deterministic flag, potentially overridden by tokenize()
+_ensure_deterministic: ContextVar[bool] = ContextVar("_ensure_deterministic")
+
+# Circular reference breaker used by _normalize_seq_func.
+# This variable is recreated anew every time you call tokenize(). Note that this means
+# that you could call tokenize() from inside tokenize() and they would be fully
+# independent.
+#
+# It is a map of {id(obj): (<first seen incremental int>, obj)} which causes an object
+# to be tokenized as ("__seen", <incremental>) the second time it's encountered while
+# traversing collections. A strong reference to the object is stored in the context to
+# prevent ids from being reused by different objects.
+_seen: ContextVar[dict[int, tuple[int, object]]] = ContextVar("_seen")
+
+
+@contextmanager
+def _ensure_deterministic_ctx(ensure_deterministic: bool | None) -> Iterator[bool]:
+    try:
+        ensure_deterministic = _ensure_deterministic.get()
+        # There's a call of tokenize() higher up in the stack
+        tok = None
+    except LookupError:
+        # Outermost tokenize(), or normalize_token() was called directly
+        if ensure_deterministic is None:
+            ensure_deterministic = config.get("tokenize.ensure-deterministic")
+        tok = _ensure_deterministic.set(ensure_deterministic)
+
+    try:
+        yield ensure_deterministic
+    finally:
+        if tok:
+            tok.var.reset(tok)
+
+
+def _maybe_raise_nondeterministic(msg: str) -> None:
+    with _ensure_deterministic_ctx(None) as ensure_deterministic:
+        if ensure_deterministic:
+            raise TokenizationError(msg)
+
+
+@contextmanager
+def _seen_ctx(reset: bool) -> Iterator[dict[int, tuple[int, object]]]:
+    if reset:
+        # It is important to reset the token on tokenize() to avoid artifacts when
+        # it is called recursively
+        seen: dict[int, tuple[int, object]] = {}
+        tok = _seen.set(seen)
+    else:
+        try:
+            seen = _seen.get()
+            tok = None
+        except LookupError:
+            # This is for debug only, for when normalize_token is called outside of
+            # tokenize()
+            seen = {}
+            tok = _seen.set(seen)
+
+    try:
+        yield seen
+    finally:
+        if tok:
+            tok.var.reset(tok)
 
 
 normalize_token = Dispatch()
@@ -1078,30 +1152,8 @@ def normalize_set(s):
     return "set", _normalize_seq_func(sorted(s, key=str))
 
 
-# Circular reference breaker used by _normalize_seq_func.
-# This variable is recreated anew every time you call tokenize(). Note that this means
-# that you could call tokenize() from inside tokenize() and they would be fully
-# independent.
-#
-# It is a map of {id(obj): (<first seen incremental int>, obj)} which causes an object
-# to be tokenized as ("__seen", <incremental>) the second time it's encountered while
-# traversing collections. A strong reference to the object is stored in the context to
-# prevent ids from being reused by different objects.
-_seen: ContextVar[dict[int, tuple[int, object]]] = ContextVar("_seen")
-
-
 def _normalize_seq_func(seq: Iterable[object]) -> list[object]:
-    try:
-        seen = _seen.get()
-        tok = None
-    except LookupError:
-        # This is for debug only, for when normalize_token is called outside of
-        # tokenize(). It is important to reset the token on tokenize to avoid artifacts
-        # when tokenize() is called recursively.
-        seen = {}
-        tok = _seen.set(seen)
-
-    try:
+    with _seen_ctx(reset=False) as seen:
         out = []
         for item in seq:
             if isinstance(item, (str, bytes, int, float, bool, type(None))):
@@ -1117,9 +1169,6 @@ def _normalize_seq_func(seq: Iterable[object]) -> list[object]:
                 item = normalize_token(item)
             out.append(item)
         return out
-    finally:
-        if tok is not None:
-            _seen.reset(tok)
 
 
 @normalize_token.register((tuple, list))
@@ -1172,9 +1221,6 @@ def normalize_builtin_function_or_method(func):
         return normalize_object(func)
 
 
-_seen_objects = set()
-
-
 @normalize_token.register(object)
 def normalize_object(o):
     method = getattr(o, "__dask_tokenize__", None)
@@ -1182,15 +1228,7 @@ def normalize_object(o):
         return method()
 
     if type(o) is object:
-        if config.get("tokenize.ensure-deterministic"):
-            raise RuntimeError(
-                "object() cannot be deterministically hashed. See "
-                "https://docs.dask.org/en/latest/custom-collections.html#implementing-deterministic-hashing "
-                "for more information."
-            )
-        # Idempotent, but not deterministic. Make sure that the id is not reused.
-        _seen_objects.add(o)
-        return "object", id(o)
+        return _normalize_pure_object(o)
 
     if dataclasses.is_dataclass(o) and not isinstance(o, type):
         return _normalize_dataclass(o)
@@ -1198,13 +1236,26 @@ def normalize_object(o):
     try:
         return _normalize_pickle(o)
     except Exception:
-        if config.get("tokenize.ensure-deterministic"):
-            raise RuntimeError(
-                f"Object {o!r} cannot be deterministically hashed. See "
-                "https://docs.dask.org/en/latest/custom-collections.html#implementing-deterministic-hashing "
-                "for more information."
-            )
+        _maybe_raise_nondeterministic(
+            f"Object {o!r} cannot be deterministically hashed. See "
+            "https://docs.dask.org/en/latest/custom-collections.html#implementing-deterministic-hashing "
+            "for more information."
+        )
         return uuid.uuid4().hex
+
+
+_seen_objects = set()
+
+
+def _normalize_pure_object(o: object) -> tuple[str, int]:
+    _maybe_raise_nondeterministic(
+        "object() cannot be deterministically hashed. See "
+        "https://docs.dask.org/en/latest/custom-collections.html#implementing-deterministic-hashing "
+        "for more information."
+    )
+    # Idempotent, but not deterministic. Make sure that the id is not reused.
+    _seen_objects.add(o)
+    return "object", id(o)
 
 
 def _normalize_pickle(o: object) -> tuple:
@@ -1370,12 +1421,11 @@ def register_numpy():
             try:
                 return _normalize_pickle(x)
             except Exception:
-                if config.get("tokenize.ensure-deterministic"):
-                    raise RuntimeError(
-                        f"Cannot tokenize numpy ufunc {x!r}. Please use functions "
-                        "of the dask.array.ufunc module instead. See also "
-                        "https://docs.dask.org/en/latest/array-numpy-compatibility.html"
-                    )
+                _maybe_raise_nondeterministic(
+                    f"Cannot tokenize numpy ufunc {x!r}. Please use functions "
+                    "of the dask.array.ufunc module instead. See also "
+                    "https://docs.dask.org/en/latest/array-numpy-compatibility.html"
+                )
                 return uuid.uuid4().hex
 
     @normalize_token.register(np.random.RandomState)

--- a/dask/tests/test_tokenize.py
+++ b/dask/tests/test_tokenize.py
@@ -18,7 +18,13 @@ import pytest
 from tlz import compose, curry, partial
 
 import dask
-from dask.base import normalize_token, tokenize
+from dask.base import (
+    TokenizationError,
+    _ensure_deterministic,
+    _seen,
+    normalize_token,
+    tokenize,
+)
 from dask.core import literal
 from dask.utils import tmpfile
 from dask.utils_test import import_or_none
@@ -264,12 +270,27 @@ def test_normalize_numpy_ufunc_unserializable():
     # Make a ufunc that isn't in the numpy namespace and can't be serialized
     inc = np.frompyfunc(lambda x: x + 1, 1, 1)
     with dask.config.set({"tokenize.ensure-deterministic": False}):
+        # Not idempotent
         assert tokenize(inc) != tokenize(inc)
+        # You can call normalize_token directly
+        assert normalize_token(inc) != normalize_token(inc)
+
     with dask.config.set({"tokenize.ensure-deterministic": True}):
         with pytest.raises(
-            RuntimeError, match=r"Cannot tokenize.*dask\.array\.ufunc.*instead"
+            TokenizationError, match=r"Cannot tokenize.*dask\.array\.ufunc.*instead"
         ):
             tokenize(inc)
+
+    # Test env override
+    assert tokenize(inc, ensure_deterministic=False) != tokenize(
+        inc, ensure_deterministic=False
+    )
+    with pytest.raises(TokenizationError, match="Cannot tokenize"):
+        tokenize(inc, ensure_deterministic=True)
+
+    # Test ctx variable cleanup
+    with pytest.raises(LookupError):
+        _ensure_deterministic.get()
 
 
 def test_normalize_object_unserializable():
@@ -280,10 +301,27 @@ def test_normalize_object_unserializable():
     c = C()
 
     with dask.config.set({"tokenize.ensure-deterministic": False}):
+        # Not idempotent
         assert tokenize(c) != tokenize(c)
+        # You can call normalize_token directly
+        assert normalize_token(c) != normalize_token(c)
+
     with dask.config.set({"tokenize.ensure-deterministic": True}):
-        with pytest.raises(RuntimeError, match="cannot be deterministically hashed"):
+        with pytest.raises(
+            TokenizationError, match="cannot be deterministically hashed"
+        ):
             tokenize(c)
+
+    # Test env override
+    assert tokenize(c, ensure_deterministic=False) != tokenize(
+        c, ensure_deterministic=False
+    )
+    with pytest.raises(TokenizationError, match="cannot be deterministically hashed"):
+        tokenize(c, ensure_deterministic=True)
+
+    # Test ctx variable cleanup
+    with pytest.raises(LookupError):
+        _ensure_deterministic.get()
 
 
 def test_tokenize_partial_func_args_kwargs_consistent():
@@ -308,18 +346,58 @@ def test_normalize_base():
 
 
 def test_tokenize_object():
-    # object() tokenization is idempotent
-    o = object()
-    assert tokenize(o) == tokenize(o)
+    with dask.config.set({"tokenize.ensure-deterministic": False}):
+        # object() tokenization is idempotent...
+        o = object()
+        assert tokenize(o) == tokenize(o)
+        # ...but not deterministic
+        assert tokenize(object()) != tokenize(object())
+
+        # Two objects don't tokenize to the same token even if their pickle output is
+        # identical. Stress id reuse by creating and dereferencing many objects in quick
+        # succession.
+        assert len({tokenize(object()) for _ in range(100)}) == 100
+
+        # You can call normalize_token even if the _ensure_deterministic context
+        # variable hasn't been set
+        assert normalize_token(o) == normalize_token(o)
 
     with dask.config.set({"tokenize.ensure-deterministic": True}):
-        with pytest.raises(RuntimeError, match="deterministic"):
+        with pytest.raises(TokenizationError, match="deterministic"):
             tokenize(o)
+        with pytest.raises(TokenizationError, match="deterministic"):
+            normalize_token(o)
 
-    # Two objects don't tokenize to the same token even if their pickle output is
-    # identical. Stress id reuse by creating and dereferencing many objects in quick
-    # succession.
-    assert len({tokenize(object()) for _ in range(100)}) == 100
+    # Test env override
+    assert tokenize(o, ensure_deterministic=False) == tokenize(
+        o, ensure_deterministic=False
+    )
+    with pytest.raises(TokenizationError, match="deterministic"):
+        tokenize(o, ensure_deterministic=True)
+
+    # Test ctx variable cleanup
+    with pytest.raises(LookupError):
+        _ensure_deterministic.get()
+
+
+def nested_tokenize_ensure_deterministic():
+    """Test that the ensure_deterministic override is not lost if tokenize() is
+    called recursively
+    """
+
+    class C:
+        def __dask_tokenize__(self):
+            return tokenize(object())
+
+    assert tokenize(C(), ensure_deterministic=False) != tokenize(
+        C(), ensure_deterministic=False
+    )
+    with pytest.raises(TokenizationError):
+        tokenize(C())
+
+    # Test ctx variable cleanup
+    with pytest.raises(LookupError):
+        _ensure_deterministic.get()
 
 
 _GLOBAL = 1
@@ -764,6 +842,35 @@ def test_tokenize_sequences():
             ("list", [("__seen", 0), ("tuple", [2, 3])]),
         ],
     )
+    # Test context variable cleanup
+    with pytest.raises(LookupError):
+        _seen.get()
+
+
+def test_nested_tokenize_seen():
+    """Test that calling tokenize() recursively doesn't alter the output due to
+    memoization of already-seen objects
+    """
+    o = [1, 2, 3]
+
+    class C:
+        def __init__(self, x):
+            self.x = x
+            self.tok = None
+
+        def __dask_tokenize__(self):
+            if not self.tok:
+                self.tok = tokenize(self.x)
+            return self.tok
+
+    c1, c2 = C(o), C(o)
+    check_tokenize(o, c1, o)
+    assert c1.tok
+    # Test context variable cleanup
+    with pytest.raises(LookupError):
+        _seen.get()
+
+    assert check_tokenize(c1) == check_tokenize(c2)
 
 
 def test_tokenize_dict():


### PR DESCRIPTION
- Add optional parameter to `tokenize(ensure_deterministic=True)` to force raising exception
- Can now run `test_tokenize.py` with either value for the config variable
- Subclass RuntimeError to restrict exception catching (we're calling pickle internally, which is very complex)
- Better tests for the `_seen` variable
