### PR TITLE
fix: sort objects in dicts/sets by normalize_token rather than str

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -1062,7 +1062,7 @@ def normalize_type(typ):
 
 @normalize_token.register((dict, types.MappingProxyType))
 def normalize_dict(d):
-    return "dict", _normalize_seq_func(sorted(d.items(), key=str))
+    return "dict", _normalize_seq_func(sorted(d.items(), key=lambda x: tokenize(x[0])))
 
 
 @normalize_token.register(OrderedDict)
@@ -1075,7 +1075,7 @@ def normalize_set(s):
     # Note: in some Python version / OS combinations, set order changes every
     # time you recreate the set (even within the same interpreter).
     # In most other cases, set ordering is consistent within the same interpreter.
-    return "set", _normalize_seq_func(sorted(s, key=str))
+    return "set", _normalize_seq_func(sorted(s, key=tokenize))
 
 
 # Circular reference breaker used by _normalize_seq_func.

--- a/dask/tests/test_awkward.py
+++ b/dask/tests/test_awkward.py
@@ -1,13 +1,13 @@
-import json
-import awkward as ak
+from __future__ import annotations
 
 import pytest
-from dask.base import tokenize, normalize_token
+
+from dask.base import normalize_token, tokenize
 
 
 def test_tokenize_touching_data():
     ak = pytest.importorskip("awkward")
-    
+
     a = ak.Array([1, 2, 3, 4, 5])
     layout, report = ak.typetracer.typetracer_with_report(a.layout.form_with_key())
     b = ak.Array(layout)

--- a/dask/tests/test_awkward.py
+++ b/dask/tests/test_awkward.py
@@ -1,0 +1,20 @@
+import json
+import awkward as ak
+
+import pytest
+from dask.base import tokenize, normalize_token
+
+
+def test_tokenize_touching_data():
+    ak = pytest.importorskip("awkward")
+    
+    a = ak.Array([1, 2, 3, 4, 5])
+    layout, report = ak.typetracer.typetracer_with_report(a.layout.form_with_key())
+    b = ak.Array(layout)
+    d = {"key": b}
+
+    _ = normalize_token(d)
+    assert len(report.data_touched) == 0 and len(report.shape_touched) == 0
+
+    _ = tokenize(d)
+    assert len(report.data_touched) == 0 and len(report.shape_touched) == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ complete = [
 ]
 test = [
     "pandas[test]",
+    "awkward",
     "pytest",
     "pytest-cov",
     "pytest-rerunfailures",


### PR DESCRIPTION
This ensures that `__dask_tokenize__` is the *only* entrypoint that other modules need to care about when interacting with dask.base.tokenize.

- [x] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Closes https://github.com/dask-contrib/dask-awkward/issues/468