### PR TITLE
Correctly parse lowercase true/false config from CLI

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -268,10 +268,11 @@ def interpret_value(value: str) -> Any:
     try:
         return ast.literal_eval(value)
     except (SyntaxError, ValueError):
-        if value.lower() in ("none", "null"):
-            return None
-        else:
-            return value
+        pass
+
+    # Avoid confusion of YAML vs. Python syntax
+    hardcoded_map = {"none": None, "null": None, "false": False, "true": True}
+    return hardcoded_map.get(value.lower(), value)
 
 
 def ensure_file(

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -242,27 +242,16 @@ def test_env():
     assert res == expected
 
 
-def test_env_none_values():
-    env = {
-        "DASK_A": "None",
-        "DASK_B": "NONE",
-        "DASK_C": "none",
-        "DASK_D": "Null",
-        "DASK_E": "NULL",
-        "DASK_F": "null",
-    }
-
-    expected = {
-        "a": None,
-        "b": None,
-        "c": None,
-        "d": None,
-        "e": None,
-        "f": None,
-    }
-
+@pytest.mark.parametrize(
+    "preproc", [lambda x: x, lambda x: x.lower(), lambda x: x.upper()]
+)
+@pytest.mark.parametrize(
+    "v,out", [("None", None), ("Null", None), ("False", False), ("True", True)]
+)
+def test_env_special_values(preproc, v, out):
+    env = {"DASK_A": preproc(v)}
     res = collect_env(env)
-    assert res == expected
+    assert res == {"a": out}
 
 
 def test_collect():


### PR DESCRIPTION
Fix bug, affecting both `dask config set` as well as the parsing environment variables, where a YAML/JSON-style lowercase `true` or `false` would result in a literal string `"true"` instead of a boolean.

To make things worse, most of the code won't actually validate the type of the config variables, so this

```bash
dask config set dataframe.query_planning=false
```
or this
```
export DASK_DATAFRAME__QUERY_PLANNING=false
```
would both evaluate to True because `bool("false") == True`.