### PR TITLE
Fix numpy 2 compatibility with ogrid usage

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1097,7 +1097,7 @@ def _arg_combine(data, axis, argfunc, keepdims=False):
         arg = arg.ravel()[local_args]
     else:
         local_args = argfunc(vals, axis=axis)
-        inds = np.ogrid[tuple(map(slice, local_args.shape))]
+        inds = list(np.ogrid[tuple(map(slice, local_args.shape))])
         inds.insert(axis, local_args)
         inds = tuple(inds)
         vals = vals[inds]


### PR DESCRIPTION
Numpy 2 has changed the output of functions like `ogrid` to always return tuples instead of lists. This causes an exception in certain parts of dask. The one I ran into was:

<details>

```
 ../../../miniconda3/envs/test-environment/lib/python3.12/site-packages/dask/array/core.py:1700: in __array__
    x = self.compute()
../../../miniconda3/envs/test-environment/lib/python3.12/site-packages/dask/base.py:375: in compute
    (result,) = compute(self, traverse=False, **kwargs)
../../../miniconda3/envs/test-environment/lib/python3.12/site-packages/dask/base.py:661: in compute
    results = schedule(dsk, keys, **kwargs)
cytoolz/functoolz.pyx:518: in cytoolz.functoolz.Compose.__call__
    ???
../../../miniconda3/envs/test-environment/lib/python3.12/site-packages/dask/array/reductions.py:1145: in arg_combine
    arg, vals = _arg_combine(data, axis, argfunc, keepdims=True)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
data = array([[( True, 28), ( True, 29), ( True, 30), ( True, 31)],
       [( True, 28), ( True, 29), ( True, 30), ( True, 31...False, 31)],
       [(False, 28), (False, 29), (False, 30), (False, 31)]],
      dtype=[('vals', '?'), ('arg', '<i8')])
axis = 1, argfunc = <function argmax at 0x7f2e2a39f600>, keepdims = True
    def _arg_combine(data, axis, argfunc, keepdims=False):
        """Merge intermediate results from ``arg_*`` functions"""
        if isinstance(data, dict):
            # Array type doesn't support structured arrays (e.g., CuPy),
            # therefore `data` is stored in a `dict`.
            assert data["vals"].ndim == data["arg"].ndim
            axis = (
                None
                if len(axis) == data["vals"].ndim or data["vals"].ndim == 1
                else axis[0]
            )
        else:
            axis = None if len(axis) == data.ndim or data.ndim == 1 else axis[0]
    
        vals = data["vals"]
        arg = data["arg"]
        if axis is None:
            local_args = argfunc(vals, axis=axis, keepdims=keepdims)
            vals = vals.ravel()[local_args]
            arg = arg.ravel()[local_args]
        else:
            local_args = argfunc(vals, axis=axis)
            inds = np.ogrid[tuple(map(slice, local_args.shape))]
>           inds.insert(axis, local_args)
E           AttributeError: 'tuple' object has no attribute 'insert'
```

</details>

You can see the numpy pull request that made this change here:

https://github.com/numpy/numpy/pull/25570

And you can see the upstream failure in dask's CI here:

https://github.com/dask/dask/issues/10855

This is all towards my mission of making my own packages run on numpy 2.0 before it is released. :fearful: 

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
