### PR TITLE
Reuse dask/dask groupby Aggregation

### DIFF
--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -18,7 +18,6 @@ def _dask_expr_enabled() -> bool:
 if _dask_expr_enabled():
     try:
         from dask_expr import (
-            Aggregation,
             DataFrame,
             Index,
             Series,
@@ -65,6 +64,7 @@ if _dask_expr_enabled():
         import dask.dataframe._pyarrow_compat
         from dask.base import compute
         from dask.dataframe import backends, dispatch
+        from dask.dataframe.groupby import Aggregation
         from dask.dataframe.io import demo
         from dask.dataframe.utils import assert_eq
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -938,8 +938,6 @@ def _build_agg_args(spec):
     aggs = {}
     finalizers = []
 
-    from dask.dataframe import Aggregation
-
     # a partial may contain some arguments, pass them down
     # https://github.com/dask/dask/issues/9615
     for result_column, func, input_column in spec:
@@ -970,8 +968,6 @@ def _build_agg_args(spec):
 
 
 def _build_agg_args_single(result_column, func, func_args, func_kwargs, input_column):
-    from dask.dataframe import Aggregation
-
     simple_impl = {
         "sum": (M.sum, M.sum),
         "min": (M.min, M.min),


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

This caused some weird import errors when used from outside, so we can reuse the classes