### PR TITLE
Cast partitioning_index to smaller size

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -835,7 +835,10 @@ def partitioning_index(df, npartitions, cast_dtype=None):
         # Fixme: astype raises with strings in numeric columns, but raising
         # here might be very noisy
         df = df.astype(cast_dtype, errors="ignore")
-    return hash_object_dispatch(df, index=False) % int(npartitions)
+    res = hash_object_dispatch(df, index=False) % int(npartitions)
+    # Note: Use a signed integer since pandas is more efficient at handling
+    # this since there is not always a fastpath for uints
+    return res.astype(np.min_scalar_type(-(npartitions - 1)))
 
 
 def barrier(args):


### PR DESCRIPTION
The hash_object currently returns an uint64 array but after the modulo operation this is quite unnecessary and I suspect we can often make due with a 16bit integer so we can safe ourselves some memory.

Also, it appears that there are some missing optimizations in pandas for uint arrays, e.g. https://github.com/dask/distributed/issues/8530 so I am choosing to go for a signed integer here

@rjzamora is this kind of casting problematic for cudf?