### PR TITLE
Force initializing the random seed with the same byte order interpret…

### DIFF
--- a/dask/utils.py
+++ b/dask/utils.py
@@ -557,7 +557,7 @@ def random_state_data(n: int, random_state=None) -> list:
         random_state = np.random.RandomState(random_state)
 
     random_data = random_state.bytes(624 * n * 4)  # `n * 624` 32-bit integers
-    l = list(np.frombuffer(random_data, dtype=np.uint32).reshape((n, -1)))
+    l = list(np.frombuffer(random_data, dtype="<u4").reshape((n, -1)))
     assert len(l) == n
     return l
 


### PR DESCRIPTION
…ation as on x86

- [x] Closes #10423
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
