### PR TITLE
Use correct encoding for line terminator when reading CSV

### DIFF
--- a/dask/dataframe/io/csv.py
+++ b/dask/dataframe/io/csv.py
@@ -484,6 +484,15 @@ def read_pandas(
         kwargs["lineterminator"] = lineterminator
     else:
         lineterminator = "\n"
+    if "encoding" in kwargs:
+        b_lineterminator = lineterminator.encode(kwargs["encoding"])
+        empty_blob = "".encode(kwargs["encoding"])
+        if empty_blob:
+            # This encoding starts with a Byte Order Mark (BOM), so strip that from the
+            # start of the line terminator, since this value is not a full file.
+            b_lineterminator = b_lineterminator[len(empty_blob) :]
+    else:
+        b_lineterminator = lineterminator.encode()
     if include_path_column and isinstance(include_path_column, bool):
         include_path_column = "path"
     if "index" in kwargs or (
@@ -559,7 +568,6 @@ def read_pandas(
             "Setting ``sample=blocksize``"
         )
         sample = blocksize
-    b_lineterminator = lineterminator.encode()
     b_out = read_bytes(
         urlpath,
         delimiter=b_lineterminator,

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -1155,17 +1155,8 @@ def test_read_csv_with_datetime_index_partitions_n():
         assert_eq(df, ddf)
 
 
-xfail_pandas_100 = pytest.mark.xfail(reason="https://github.com/dask/dask/issues/5787")
-
-
-@pytest.mark.parametrize(
-    "encoding",
-    [
-        pytest.param("utf-16", marks=xfail_pandas_100),
-        pytest.param("utf-16-le", marks=xfail_pandas_100),
-        "utf-16-be",
-    ],
-)
+# utf-8-sig and utf-16 both start with a BOM.
+@pytest.mark.parametrize("encoding", ["utf-8-sig", "utf-16", "utf-16-le", "utf-16-be"])
 def test_encoding_gh601(encoding):
     ar = pd.Series(range(0, 100))
     br = ar % 7


### PR DESCRIPTION
Using `lineterminator.encode()` will almost-always produce a single byte encoding, which will break things if you have a 2-byte encoding like UTF-16-LE. It magically works with UTF-16-BE, because in that case the additional byte is before the encoded line terminator.

However, one has to be careful when encoding the line terminator, as it is intended to be in the middle of the file. But encodings that have a BOM will unintentionally insert the BOM to the encoded line terminator, causing line splitting to not work at all.

- [x] Fixes #5787
- [x] Fixes #6725
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
