### PR TITLE
raise ImportError instead of ValueError when dask-expr cannot be imported

### DIFF
--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -30,7 +30,7 @@ This will raise in a future version.
         if use_dask_expr is None:
             warnings.warn(msg, FutureWarning)
         else:
-            raise ValueError(msg)
+            raise ImportError(msg)
     return True
 
 


### PR DESCRIPTION
#10634 introduced an import-time check that ensures that a statement like this:

```python
import dask.dataframe
```

will raise an exception under the following conditions:

* a sufficiently-new version of `pandas` exists in the environment
* Dask config `"dataframe.query-planning"` is `True`
* `dask_expr` cannot be imported

That exception is currently a `ValueError`. This proposes changing it to an `ImportError`.

### Benefits of this change

Allows the use of this pattern to conditionally import `dask.dataframe`:

```python
try:
    import dask.dataframe
except ImportError:
    # ... do something if loading dask.dataframe failed ...
```

That's the same pattern `dask` itself uses to conditionally import dependencies, for example:

https://github.com/dask/dask/blob/f9310c440b661f1ae96ffd8726404d3c3fe32edc/dask/dataframe/__init__.py#L83-L86

And I think it's common enough across other Python projects that Dask should support it unless there's a compelliing reason to use `ValueError` instead. Some examples:

* `prefect` ([code link](https://github.com/PrefectHQ/prefect/blob/b40569482ec269b20d4b89110e818cc764bc14cd/src/prefect/_internal/pytz.py#L16-L21))
* `scikit-learn` ([code link](https://github.com/scikit-learn/scikit-learn/blob/082b5884faccbcc5509a64a347fec55788b2f984/sklearn/utils/fixes.py#L64-L69))
* `xgboost` ([code link](https://github.com/dmlc/xgboost/blob/53fc17578f88a33e6265772837676cdf911f793e/python-package/xgboost/compat.py#L33-L43))

### Notes for Reviewers

I think (but don't know with certainty) that this change would help other projects that rely on `dask.dataframe` but aren't yet supporting `dask-expr`. It might help with  https://github.com/dask/dask-expr/issues/904, for example.

I'm certain it would help `lightgbm`. `dask` is an optional dependency of that library, but as of `dask==2024.3.1`, this use of `ValueError` would break `import lightgbm` *even if you do not intend to use any of LightGBM's Dask features*.

```shell
docker run \
    --rm \
    -v $(pwd):/opt/LightGBM \
    -w /opt/LightGBM \
    -it python:3.11 \
    bash

pip install \
    'dask==2024.3.1' \
    'lightgbm>=4.3.0' \
    'pandas==2.2.1' \
    'pyyaml'

DASK_DATAFRAME__QUERY_PLANNING=true \
python -c "import lightgbm"
```

<details><summary>traceback (click me)</summary>

```text
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/dask/dataframe/__init__.py", line 22, in _dask_expr_enabled
    import dask_expr  # noqa: F401
    ^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'dask_expr'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.11/site-packages/lightgbm/__init__.py", line 8, in <module>
    from .basic import Booster, Dataset, Sequence, register_logger
  File "/usr/local/lib/python3.11/site-packages/lightgbm/basic.py", line 21, in <module>
    from .compat import (PANDAS_INSTALLED, PYARROW_INSTALLED, arrow_cffi, arrow_is_floating, arrow_is_integer, concat,
  File "/usr/local/lib/python3.11/site-packages/lightgbm/compat.py", line 155, in <module>
    from dask.dataframe import DataFrame as dask_DataFrame
  File "/usr/local/lib/python3.11/site-packages/dask/dataframe/__init__.py", line 96, in <module>
    if _dask_expr_enabled():
       ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/dask/dataframe/__init__.py", line 33, in _dask_expr_enabled
    raise ValueError(msg)
ValueError: 
Dask dataframe query planning is disabled because dask-expr is not installed.

You can install it with `pip install dask[dataframe]` or `conda install dask`.
This will raise in a future version.
```

</details>

Mentioning #10995 here as well, to link this to that issue that is collecting feedback on the dask-expr rollout.

Thanks very much for your time and consideration.