### PR TITLE
Enable custom expressions in ``dask_cudf``

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -235,7 +235,7 @@ def is_dask_collection(x) -> bool:
         return False
 
     pkg_name = getattr(type(x), "__module__", "").split(".")[0]
-    if pkg_name == "dask_expr":
+    if pkg_name in ("dask_expr", "dask_cudf"):
         # Temporary hack to avoid graph materialization. Note that this won't work with
         # dask_expr.array objects wrapped by xarray or pint. By the time dask_expr.array
         # is published, we hope to be able to rewrite this method completely.


### PR DESCRIPTION
Right now it is not always possible for down-stream libraries to implement/use their own `Expr` classes with dask/dask-expr. This is because `is_dask_collection` [includes a hack](https://github.com/dask/dask/blob/f9310c440b661f1ae96ffd8726404d3c3fe32edc/dask/base.py#L238) to avoid graph materialization only when the package starts with `dask_expr`. Materializing the graph is obviously a performance issue. However, it is also impossible to do for "abstract" expressions that have yet to be lowered/optimized.

Could we temporarily include `"dask_cudf"` as a package for whice we will avoid materialization? I realize we need a more general solution in the long run, but since the current solution is already a hack, I'm hoping we can unblock dask-cudf by doing something simple like this.
