### PR TITLE
Use ``to/from_legacy_dataframe`` instead of ``to/from_dask_dataframe``

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1624,12 +1624,12 @@ class Bag(DaskMethodsMixin):
         if not dd._dask_expr_enabled():
             return dd.DataFrame(dsk, dfs.name, meta, divisions)
         else:
-            from dask_expr import from_dask_dataframe
+            from dask_expr import from_legacy_dataframe
 
             from dask.dataframe.core import DataFrame
 
             df = DataFrame(dsk, dfs.name, meta, divisions)
-            return from_dask_dataframe(df)
+            return from_legacy_dataframe(df)
 
     def to_delayed(self, optimize_graph=True):
         """Convert into a list of ``dask.delayed`` objects, one per partition.

--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -119,10 +119,11 @@ if _dask_expr_enabled():
             concat,
             from_array,
             from_dask_array,
-            from_dask_dataframe,
+            from_dask_dataframe,  # TODO: Remove?
             from_delayed,
             from_dict,
             from_graph,
+            from_legacy_dataframe,
             from_map,
             from_pandas,
             get_dummies,

--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -119,7 +119,7 @@ if _dask_expr_enabled():
             concat,
             from_array,
             from_dask_array,
-            from_dask_dataframe,  # TODO: Remove?
+            from_dask_dataframe,
             from_delayed,
             from_dict,
             from_graph,

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -164,7 +164,7 @@ class _LocIndexer(_IndexerBase):
         )
 
     def _loc_array(self, iindexer, cindexer):
-        iindexer_series = iindexer.to_dask_dataframe("_", self.obj.index)
+        iindexer_series = iindexer.to_legacy_dataframe("_", self.obj.index)
         return self._loc_series(iindexer_series, cindexer)
 
     def _loc_list(self, iindexer, cindexer):

--- a/dask/dataframe/indexing.py
+++ b/dask/dataframe/indexing.py
@@ -164,7 +164,7 @@ class _LocIndexer(_IndexerBase):
         )
 
     def _loc_array(self, iindexer, cindexer):
-        iindexer_series = iindexer.to_legacy_dataframe("_", self.obj.index)
+        iindexer_series = iindexer.to_dask_dataframe("_", self.obj.index)
         return self._loc_series(iindexer_series, cindexer)
 
     def _loc_list(self, iindexer, cindexer):

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -130,6 +130,7 @@ DataFrame
     DataFrame.to_hdf
     DataFrame.to_html
     DataFrame.to_json
+    DataFrame.to_legacy_dataframe
     DataFrame.to_parquet
     DataFrame.to_records
     DataFrame.to_string


### PR DESCRIPTION
The ``to/from_dask_dataframe`` API name used for legacy <-> dask-expr conversion is overloaded (conflicts with APIs used in dask-array, dask-bag, dask-cudf, etc..). This PR makes the necessary changes to use ``to/from_legacy_dataframe`` instead.

- The original ``to/from_dask_dataframe`` API is still exposed (for now), and the dask-expr doc-string says that the API is deprecated. Dask-expr should also produce a warning when the deprecated API is used (coming soon).
