### PR TITLE
Fix ``dask.dataframe`` import error  for Python 3.11.9

### DIFF
--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import warnings
 
 import numpy as np
@@ -28,8 +29,15 @@ def _bind_property(cls, pd_cls, attr, min_version=None):
 
     func.__name__ = attr
     func.__qualname__ = f"{cls.__name__}.{attr}"
+    original_prop = getattr(pd_cls, attr)
+    if isinstance(original_prop, property):
+        method = original_prop.fget
+    elif isinstance(original_prop, functools.cached_property):
+        method = original_prop.func
+    else:
+        raise TypeError("bind_property expects original class to provide a property")
     try:
-        func.__wrapped__ = getattr(pd_cls, attr)
+        func.__wrapped__ = method
     except Exception:
         pass
     setattr(cls, attr, property(derived_from(pd_cls, version=min_version)(func)))

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -940,7 +940,8 @@ def _derived_from(
         method_args = get_named_args(method)
         original_args = get_named_args(original_method)
         not_supported = [m for m in original_args if m not in method_args]
-    except ValueError:
+    except (TypeError, ValueError):
+        # Python 3.11.9 returns TypeError when method is a property
         not_supported = []
     if len(ua_args) > 0:
         not_supported.extend(ua_args)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -940,8 +940,7 @@ def _derived_from(
         method_args = get_named_args(method)
         original_args = get_named_args(original_method)
         not_supported = [m for m in original_args if m not in method_args]
-    except (TypeError, ValueError):
-        # Python 3.11.9 returns TypeError when method is a property
+    except ValueError:
         not_supported = []
     if len(ua_args) > 0:
         not_supported.extend(ua_args)


### PR DESCRIPTION
Using the 4/2/2024 release of Python 3.11.9, calling `import dask.dataframe` produces `TypeError` when dask tries to "bind" docstrings for the `DatetimeAccessor` properties. The problem is that 3.11.9 will throw a new `TypeError` when you try to inspect the arguments of a property. This PR updates the `try`/`except` block to include `TypeError`.


<details>
<summary>Error without this fix</summary>
<br>

```
>>> import dask.dataframe as dd
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/pyenv/versions/3.11.9/lib/python3.11/site-packages/dask/dataframe/__init__.py", line 98, in <module>
    from dask.dataframe import backends, dispatch, rolling
  File "/pyenv/versions/3.11.9/lib/python3.11/site-packages/dask/dataframe/backends.py", line 15, in <module>
    from dask.dataframe.core import DataFrame, Index, Scalar, Series, _Frame
  File "/pyenv/versions/3.11.9/lib/python3.11/site-packages/dask/dataframe/core.py", line 36, in <module>
    from dask.dataframe import methods
  File "/pyenv/versions/3.11.9/lib/python3.11/site-packages/dask/dataframe/methods.py", line 34, in <module>
    from dask.dataframe.utils import is_dataframe_like, is_index_like, is_series_like
  File "/pyenv/versions/3.11.9/lib/python3.11/site-packages/dask/dataframe/utils.py", line 20, in <module>
    from dask.dataframe import (  # noqa: F401 register pandas extension types
  File "/pyenv/versions/3.11.9/lib/python3.11/site-packages/dask/dataframe/_dtypes.py", line 9, in <module>
    from dask.dataframe.extensions import make_array_nonempty, make_scalar
  File "/pyenv/versions/3.11.9/lib/python3.11/site-packages/dask/dataframe/extensions.py", line 8, in <module>
    from dask.dataframe.accessor import (
  File "/pyenv/versions/3.11.9/lib/python3.11/site-packages/dask/dataframe/accessor.py", line 126, in <module>
    class DatetimeAccessor(Accessor):
  File "/pyenv/versions/3.11.9/lib/python3.11/site-packages/dask/dataframe/accessor.py", line 81, in __init_subclass__
    _bind_property(cls, pd_cls, attr, min_version)
  File "/pyenv/versions/3.11.9/lib/python3.11/site-packages/dask/dataframe/accessor.py", line 35, in _bind_property
    setattr(cls, attr, property(derived_from(pd_cls, version=min_version)(func)))
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pyenv/versions/3.11.9/lib/python3.11/site-packages/dask/utils.py", line 981, in wrapper
    method.__doc__ = _derived_from(
                     ^^^^^^^^^^^^^^
  File "/pyenv/versions/3.11.9/lib/python3.11/site-packages/dask/utils.py", line 934, in _derived_from
    method_args = get_named_args(method)
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/pyenv/versions/3.11.9/lib/python3.11/site-packages/dask/utils.py", line 695, in get_named_args
    s = inspect.signature(func)
        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/pyenv/versions/3.11.9/lib/python3.11/inspect.py", line 3263, in signature
    return Signature.from_callable(obj, follow_wrapped=follow_wrapped,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pyenv/versions/3.11.9/lib/python3.11/inspect.py", line 3011, in from_callable
    return _signature_from_callable(obj, sigcls=cls,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pyenv/versions/3.11.9/lib/python3.11/inspect.py", line 2599, in _signature_from_callable
    call = _descriptor_get(call, obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/pyenv/versions/3.11.9/lib/python3.11/inspect.py", line 2432, in _descriptor_get
    return get(descriptor, obj, type(obj))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: descriptor '__call__' for 'type' objects doesn't apply to a 'property' object
```

</details>