### PR TITLE
Make python 3.11.9 fix a bit safer

### DIFF
--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -35,7 +35,7 @@ def _bind_property(cls, pd_cls, attr, min_version=None):
     elif isinstance(original_prop, functools.cached_property):
         method = original_prop.func
     else:
-        raise TypeError("bind_property expects original class to provide a property")
+        method = original_prop
     try:
         func.__wrapped__ = method
     except Exception:


### PR DESCRIPTION
I don't have an explicit reproducer to demonstrate that the original fix in https://github.com/dask/dask/pull/11035 is too strict. However, I think we should relax the fix a bit to be safe.
