### PR TITLE
Add lazy "cudf" registration for p2p-related dispatch functions

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -771,13 +771,15 @@ dataframe_creation_dispatch.register_backend("pandas", PandasBackendEntrypoint()
 
 
 @concat_dispatch.register_lazy("cudf")
-@hash_object_dispatch.register_lazy("cudf")
+@from_pyarrow_table_dispatch.register_lazy("cudf")
 @group_split_dispatch.register_lazy("cudf")
 @get_parallel_type.register_lazy("cudf")
+@hash_object_dispatch.register_lazy("cudf")
 @meta_nonempty.register_lazy("cudf")
 @make_meta_dispatch.register_lazy("cudf")
 @make_meta_obj.register_lazy("cudf")
 @percentile_lookup.register_lazy("cudf")
+@to_pyarrow_table_dispatch.register_lazy("cudf")
 @tolist_dispatch.register_lazy("cudf")
 def _register_cudf():
     import dask_cudf  # noqa: F401


### PR DESCRIPTION
While debugging some p2p failures in RAPIDS, I discovered that some workers occasionally hit the `from_pyarrow_table_dispatch` without having `dask_cudf` imported. This scenario is a bit hard to test, but the best way to avoid it is to have these p2p-related dispatch functions registered for a "lazy" `dask_cudf` import in dask.
