### PR TITLE
Update GPU CI `RAPIDS_VER` to 24.06, disable query planning 

### DIFF
--- a/continuous_integration/gpuci/axis.yaml
+++ b/continuous_integration/gpuci/axis.yaml
@@ -9,6 +9,6 @@ LINUX_VER:
 - ubuntu20.04
 
 RAPIDS_VER:
-- "24.04"
+- "24.06"
 
 excludes:

--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -23,6 +23,9 @@ cd "$WORKSPACE"
 # Determine CUDA release version
 export CUDA_REL=${CUDA_VERSION%.*}
 
+# TODO: remove once RAPIDS 24.06 has full support for dask-expr
+export DASK_DATAFRAME__QUERY_PLANNING=false
+
 ################################################################################
 # SETUP - Check environment
 ################################################################################

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -6435,23 +6435,12 @@ def test_pyarrow_conversion_dispatch(self_destruct):
 
 @pytest.mark.gpu
 def test_pyarrow_conversion_dispatch_cudf():
-    # NOTE: This test can probably be removed (or simplified) once
-    # the to_pyarrow_table_dispatch and from_pyarrow_table_dispatch
-    # are registered to `cudf` in `dask_cudf`.
     from dask.dataframe.dispatch import (
         from_pyarrow_table_dispatch,
         to_pyarrow_table_dispatch,
     )
 
     cudf = pytest.importorskip("cudf")
-
-    @to_pyarrow_table_dispatch.register(cudf.DataFrame)
-    def _cudf_to_table(obj, preserve_index=True):
-        return obj.to_arrow(preserve_index=preserve_index)
-
-    @from_pyarrow_table_dispatch.register(cudf.DataFrame)
-    def _table_to_cudf(obj, table, self_destruct=False):
-        return obj.from_arrow(table)
 
     df1 = cudf.DataFrame(np.random.randn(10, 3), columns=list("abc"))
     df2 = from_pyarrow_table_dispatch(df1, to_pyarrow_table_dispatch(df1))


### PR DESCRIPTION
As we're waiting on full support for RAPIDS / dask-expr integration, I'm interested in what GPU CI currently looks like with the latest RAPIDS packages and query planning disabled.