### PR TITLE
Don't error if dask_expr is not installed

### DIFF
--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -29,6 +29,7 @@ This will raise in a future version.
 """
         if use_dask_expr is None:
             warnings.warn(msg, FutureWarning)
+            return False
         else:
             raise ImportError(msg)
     return True


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

https://github.com/dask/dask/pull/11003 goal was to warn if `dask-expr` is not installed. However it will still errors:

MRE:
``` bash
mamba create -n tmp-dask python=3.11 dask-core pandas -y
mamba activate tmp-dask
python -c "import dask.dataframe"
```

``` python-traceback
/home/shh/miniconda3/envs/tmp-dask2/lib/python3.11/site-packages/dask/dataframe/__init__.py:31: FutureWarning:
Dask dataframe query planning is disabled because dask-expr is not installed.

You can install it with `pip install dask[dataframe]` or `conda install dask`.
This will raise in a future version.

  warnings.warn(msg, FutureWarning)
Traceback (most recent call last):
  File "/home/shh/miniconda3/envs/tmp-dask2/lib/python3.11/site-packages/dask/dataframe/__init__.py", line 97, in <module>
    import dask_expr as dd
ModuleNotFoundError: No module named 'dask_expr'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/shh/miniconda3/envs/tmp-dask2/lib/python3.11/site-packages/dask/dataframe/__init__.py", line 110, in <module>
    raise ImportError(msg) from e
ImportError: Dask dataframe requirements are not installed.

Please either conda or pip install as follows:

  conda install dask                     # either conda install
  python -m pip install "dask[dataframe]" --upgrade  # or python -m pip install
```

A small test could be added to verify this `import dask.dataframe` is importable without `dask-expr` and is not installable with something like this one:

<details>
  <summary>Pytest fixture </summary>

``` python
@pytest.fixture
def unimport(monkeypatch: pytest.MonkeyPatch) -> Callable[[str], None]:
    """
    Return a function for unimporting modules and preventing reimport.

    This will block any new modules from being imported.
    """

    def unimport_module(modname: str) -> None:
        # Remove if already imported
        monkeypatch.delitem(sys.modules, modname, raising=False)
        # Prevent import:
        monkeypatch.setattr(sys, "path", [])

    return unimport_module
```  

</details>