### PR TITLE
Reinstate try/except block in _bind_property

### DIFF
--- a/dask/dataframe/accessor.py
+++ b/dask/dataframe/accessor.py
@@ -29,16 +29,18 @@ def _bind_property(cls, pd_cls, attr, min_version=None):
 
     func.__name__ = attr
     func.__qualname__ = f"{cls.__name__}.{attr}"
-    original_prop = getattr(pd_cls, attr)
-    if isinstance(original_prop, property):
-        method = original_prop.fget
-    elif isinstance(original_prop, functools.cached_property):
-        method = original_prop.func
-    else:
-        method = original_prop
     try:
-        func.__wrapped__ = method
+        # Attempt to determine the method we are wrapping
+        original_prop = getattr(pd_cls, attr)
+        if isinstance(original_prop, property):
+            method = original_prop.fget
+        elif isinstance(original_prop, functools.cached_property):
+            method = original_prop.func
+        else:
+            method = original_prop
+            func.__wrapped__ = method
     except Exception:
+        # If we can't then no matter, the function still works.
         pass
     setattr(cls, attr, property(derived_from(pd_cls, version=min_version)(func)))
 


### PR DESCRIPTION
The change in #11035 to adapt _bind_property to Python 3.11.9 moved attribute access on the pandas class object around and therefore dropped exception handling. While it is not the case that we currently wrap attributes that don't exist, let's avoid an accidental breakage in the future by reinstating the old exception handling behaviour.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
