### PR TITLE
Add GitHub Releases automation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,13 @@
+# These will be overridden by the publish workflow and set to the new tag
+name-template: 'Next Release'
+tag-template: 'next'
+
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+
+template: |
+  ## Changes
+
+  $CHANGES  
+
+  See the [Changelog](https://docs.dask.org/en/stable/changelog.html) for more information.

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # Write permission is required to create a GitHub release
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        with:
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   update_release_draft:
+    if: github.repository == 'dask/dask'
     permissions:
       # Write permission is required to create a GitHub release
       contents: write

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,32 @@
+name: Release Publisher
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish_release:
+    permissions:
+      # Write permission is required to publish a GitHub release
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set version env
+        # Use a little bit of bash to extract the tag name from the GitHub ref
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - uses: release-drafter/release-drafter@v5
+        with:
+          disable-autolabeler: true
+          # Override the Release name/tag/version with the actual tag name
+          name: ${{ env.RELEASE_VERSION }}
+          tag: ${{ env.RELEASE_VERSION }}
+          version: ${{ env.RELEASE_VERSION }}
+          # Publish the Release
+          publish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   publish_release:
+    if: github.repository == 'dask/dask'
     permissions:
       # Write permission is required to publish a GitHub release
       contents: write


### PR DESCRIPTION
- [x] Closes #10956
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

In Dask projects we create and push tags and update a changelog as part of our release process, but we don't create [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases). Releases are just a page linked to a git tag with a title, some markdown text containing release notes and optional build artifacts for download.

We don't make use of the build artifact distribution in the Python community because we have PyPI and Conda Forge, but some users have expressed interest in having GitHub Releases as they show up in feeds, can be subscribed to, and generally make it easier to discover new releases in the GitHub ecosystem. See #10956.

In this PR I've added a couple of GitHub Actions which will automatically create a GitHub Release when a new tag is pushed. The release notes will be populated with the titles of all the PRs that went into the release, and have a link to the main changelog at the bottom.

My goal here is to give value to the users who want Releases, but without adding any burden to the maintainer making the release. So this is pretty much set and forget once merged.

I've tested these actions in [another repo](https://github.com/jacobtomlinson/release-drafter-experiments) to make sure they work (I was also playing around with how it would work in a monorepo, in case you're wondering what's going on in there). I also wrote a [quick blog post](https://jacobtomlinson.dev/posts/2024/creating-github-releases-automatically-on-tags/) on this topic in case folks want to apply the same actions to other repos.