### PR TITLE
Generalize ``clear_known_categories`` utility

### DIFF
--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -128,6 +128,16 @@ def test_concat_unions_categoricals():
     tm.assert_frame_equal(_concat(frames5), pd.concat(frames6))
 
 
+@pytest.mark.gpu
+def test_clear_known_categories_cudf():
+    pytest.importorskip("dask_cudf")
+
+    with dask.config.set({"dataframe.backend": "cudf"}):
+        ddf = dd.from_dict({"a": [0, 1, 0]}, npartitions=1)
+    ddf["a"] = ddf["a"].astype("category")
+    assert not ddf["a"].cat.known
+
+
 # TODO: Remove the filterwarnings below
 @pytest.mark.parametrize(
     "numeric_only",

--- a/dask/dataframe/tests/test_categorical.py
+++ b/dask/dataframe/tests/test_categorical.py
@@ -129,7 +129,9 @@ def test_concat_unions_categoricals():
 
 
 @pytest.mark.gpu
-def test_clear_known_categories_cudf():
+def test_unknown_categories_cudf():
+    # We should always start with unknown categories
+    # if `clear_known_categories` is working.
     pytest.importorskip("dask_cudf")
 
     with dask.config.set({"dataframe.backend": "cudf"}):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -283,9 +283,9 @@ def clear_known_categories(x, cols=None, index=True, dtype_backend=None):
         # categorical accessor is not yet available
         return x
 
-    if isinstance(x, (pd.Series, pd.DataFrame)):
+    if not is_index_like(x):
         x = x.copy()
-        if isinstance(x, pd.DataFrame):
+        if is_dataframe_like(x):
             mask = x.dtypes == "category"
             if cols is None:
                 cols = mask[mask].index
@@ -293,12 +293,12 @@ def clear_known_categories(x, cols=None, index=True, dtype_backend=None):
                 raise ValueError("Not all columns are categoricals")
             for c in cols:
                 x[c] = x[c].cat.set_categories([UNKNOWN_CATEGORIES])
-        elif isinstance(x, pd.Series):
-            if isinstance(x.dtype, pd.CategoricalDtype):
+        elif is_series_like(x):
+            if x.dtype == "category":
                 x = x.cat.set_categories([UNKNOWN_CATEGORIES])
-        if index and isinstance(x.index, pd.CategoricalIndex):
+        if index and x.index.is_categorical():
             x.index = x.index.set_categories([UNKNOWN_CATEGORIES])
-    elif isinstance(x, pd.CategoricalIndex):
+    elif x.is_categorical():
         x = x.set_categories([UNKNOWN_CATEGORIES])
     return x
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -23,6 +23,7 @@ from dask.dataframe import (  # noqa: F401 register pandas extension types
 )
 from dask.dataframe._compat import PANDAS_GE_150, tm  # noqa: F401
 from dask.dataframe.dispatch import (  # noqa : F401
+    is_categorical_dtype_dispatch,
     make_meta,
     make_meta_obj,
     meta_nonempty,
@@ -294,11 +295,11 @@ def clear_known_categories(x, cols=None, index=True, dtype_backend=None):
             for c in cols:
                 x[c] = x[c].cat.set_categories([UNKNOWN_CATEGORIES])
         elif is_series_like(x):
-            if x.dtype == "category":
+            if is_categorical_dtype_dispatch(x.dtype):
                 x = x.cat.set_categories([UNKNOWN_CATEGORIES])
-        if index and x.index.is_categorical():
+        if index and is_categorical_dtype_dispatch(x.index.dtype):
             x.index = x.index.set_categories([UNKNOWN_CATEGORIES])
-    elif x.is_categorical():
+    elif is_categorical_dtype_dispatch(x.dtype):
         x = x.set_categories([UNKNOWN_CATEGORIES])
     return x
 


### PR DESCRIPTION
Now that `query-planning` is enabled, the `clear_known_categories` utility is being used for "cudf"-backed data. Previously (using the legacy API),`meta_nonempty` was used in such a way that it was "okay" that `clear_known_categories` was not working properly.
