### PR TITLE
Enable list aggregation in dask-cudf

### DIFF
--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3038,6 +3038,20 @@ def test_groupby_apply_cudf(group_keys):
     assert_eq(res_dd, res_dc)
 
 
+@pytest.mark.gpu
+def test_groupby_collect_agg():
+    # Check the "collect" code path for cudf
+    pytest.importorskip("dask_cudf")  # noqa: F841
+    cudf = pytest.importorskip("cudf")
+
+    df = cudf.DataFrame({"a": [1, 2, 3, 1, 2, 3], "b": [4, 5, 6, 7, 8, 9]})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    expected = df.groupby("a").agg("collect")
+    result = ddf.groupby("a").agg("collect")
+    assert_eq(result, expected)
+
+
 @pytest.mark.parametrize("sort", [True, False])
 def test_groupby_dropna_with_agg(sort):
     # https://github.com/dask/dask/issues/6986


### PR DESCRIPTION
When query-planning is enabled, dask-cudf uses the native groupby-aggregation logic in dask-expr (rather than the custom logic used for the legacy API). In order to support `list` aggregations in cudf, a special `"collect"` code path is used. This PR adds minimal logic to `dask.dataframe.groupby` to effectively *recognize* "collect" as a supported aggregation type, and to utilize the proper `_build_agg_args_collect` setup function.

I was originally planning to keep the `"collect"` logic outside of `dask.dataframe`. However, it turns out that this PR is just a lot easier than adding a fragile/external workaround.

Note that I also considered making the `_build_agg_args_single` logic dispatch-able is some way, but (again) it didn't seem like it was worth the complexity.
