### PR TITLE
Enh/take along axis

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -158,6 +158,7 @@ try:
         vstack,
         where,
     )
+    from dask.array.slicing import take_along_axis
     from dask.array.tiledb_io import from_tiledb, to_tiledb
     from dask.array.ufunc import (
         abs,

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -433,16 +433,38 @@ def getitem(obj, index):
     return result
 
 
-def take_along_axis_chunk(arr, indices, offset, x_size, axis):
-    # Needed when idx is unsigned
+def take_along_axis_chunk(
+    arr: np.ndarray, indices: np.ndarray, offset: np.ndarray, arr_size: int, axis: int
+):
+    """Slice an ndarray according to ndarray indices along an axis.
+
+    Parameters
+    ----------
+    arr: np.ndarray, dtype=Any
+        The data array.
+    indices: np.ndarray, dtype=int64
+        The indices of interest.
+    offset: np.ndarray, shape=(1, ), dtype=int64
+        Index of the first element along axis of the current chunk of arr
+    arr_size: int
+        Total size of the arr da.Array along axis
+    axis: int
+        The axis along which the indices are from.
+
+    Returns
+    -------
+    out: np.ndarray
+        The indexed arr.
+    """
+    # Needed when indices is unsigned
     indices = indices.astype(np.int64)
     # Normalize negative indices
-    indices = np.where(indices < 0, indices + x_size, indices)
+    indices = np.where(indices < 0, indices + arr_size, indices)
     # A chunk of the offset dask Array is a numpy array with shape (1, ).
     # It indicates the index of the first element along axis of the current
-    # chunk of x.
+    # chunk of arr.
     indices = indices - offset
-    # Drop elements of idx that do not fall inside the current chunk of x
+    # Drop elements of idx that do not fall inside the current chunk of arr.
     idx_filter = (indices >= 0) & (indices < arr.shape[axis])
     indices[~idx_filter] = 0
     res = np.take_along_axis(arr, indices, axis=axis)

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -431,3 +431,20 @@ def getitem(obj, index):
         pass
 
     return result
+
+
+def take_along_axis_chunk(arr, indices, offset, x_size, axis):
+    # Needed when idx is unsigned
+    indices = indices.astype(np.int64)
+    # Normalize negative indices
+    indices = np.where(indices < 0, indices + x_size, indices)
+    # A chunk of the offset dask Array is a numpy array with shape (1, ).
+    # It indicates the index of the first element along axis of the current
+    # chunk of x.
+    indices = indices - offset
+    # Drop elements of idx that do not fall inside the current chunk of x
+    idx_filter = (indices >= 0) & (indices < arr.shape[axis])
+    indices[~idx_filter] = 0
+    res = np.take_along_axis(arr, indices, axis=axis)
+    res[~idx_filter] = 0
+    return np.expand_dims(res, axis)

--- a/docs/source/array-slicing.rst
+++ b/docs/source/array-slicing.rst
@@ -10,6 +10,8 @@ supports the following:
 *  Slicing one :class:`~dask.array.Array` with an :class:`~dask.array.Array` of bools: ``x[x > 0]``
 *  Slicing one :class:`~dask.array.Array` with a zero or one-dimensional :class:`~dask.array.Array`
    of ints: ``a[b.argtopk(5)]``
+*  Slicing one :class:`~dask.array.Array` with a multi-dimensional :class:`~dask.array.Array` of ints.
+   This can be done using ``dask.array.slicing.take_along_axis``.
 
 However, it does not currently support the following:
 
@@ -19,7 +21,6 @@ However, it does not currently support the following:
    issue. Also, users interested in this should take a look at
    :attr:`~dask.array.Array.vindex`.
 
-*  Slicing one :class:`~dask.array.Array` with a multi-dimensional :class:`~dask.array.Array` of ints
 
 .. _array.slicing.efficiency:
 


### PR DESCRIPTION
This PR adds `take_along_axis` that works similarly to [numpy's take_along_axis](https://numpy.org/doc/stable/reference/generated/numpy.take_along_axis.html).

- [x] Closes #3663 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

# Credit
@zklaus for providing a working solution in [climix](https://git.smhi.se/climix/climix/-/blob/main/climix/dask_take_along_axis.py).

## Example of use
```python
from dask.array import take_along_axis

data: dask.array.Array 
top10_indices = data.argtopk(k=10, axis=-1)
top10 = take_along_axis(data, top10_indices, axis=-1)

# Equivalent to 
top10 = data.topk(k=10, axis=-1)
```

## Performances
This is just a basic benchmark I ran on my laptop to compare how this implementation prerforms against numpy's.
```python

import numpy as np
from dask.array import from_array
from dask.array.slicing import take_along_axis


random_arr = np.random.rand(1000,1000,1000)
dask_random_arr = from_array(random_arr)
top50 = dask_random_arr.argtopk(k=50, axis=0)
top50_np = top50.compute()

# Compute both argtopk and take_along_axis
%timeit take_along_axis(dask_random_arr, top50, axis=0).compute()
# 6.74 s ± 9.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit np.take_along_axis(random_arr, top50_np, axis=0)
# 864 ms ± 11.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

%timeit take_along_axis(dask_random_arr, from_array(top50_np), axis=0).compute()
# 2.3 s ± 9.04 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)


```
