### PR TITLE
DOC: intersphinx, don't link to click dev version.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -349,7 +349,7 @@ intersphinx_mapping = {
         "https://filesystem-spec.readthedocs.io/en/latest/",
         "https://filesystem-spec.readthedocs.io/en/latest/objects.inv",
     ),
-    "click": ("https://click.palletsprojects.com/en/latest/", None),
+    "click": ("https://click.palletsprojects.com/", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
 }
 


### PR DESCRIPTION
/en/latest is the dev version and have banner warning on top.

My guess is docs is meant to link to stable click's docs. The domain does a proper redirect, currently to /en/8.1.x
