### PR TITLE
Fix API doc links for some dask-expr expressions

### DIFF
--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -555,15 +555,15 @@ Reshape DataFrames
 Concatenate DataFrames
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. currentmodule:: dask_expr._collection
+.. currentmodule:: dask_expr
 
 .. autosummary::
    :toctree: generated/
 
    DataFrame.merge
-   dask_expr.concat
-   dask_expr.merge
-   dask_expr.merge_asof
+   concat
+   merge
+   merge_asof
 
 
 Resampling


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
