### PR TITLE
Clean up ``percentiles_summary`` logic

### DIFF
--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -78,8 +78,10 @@ from pandas.api.types import is_datetime64_dtype, is_integer_dtype
 from tlz import merge, merge_sorted, take
 
 from dask.base import tokenize
+from dask.dataframe._compat import PANDAS_GE_150
 from dask.dataframe.core import Series
 from dask.dataframe.dispatch import tolist_dispatch
+from dask.dataframe.utils import is_series_like
 from dask.utils import is_cupy_type, random_state_data
 
 
@@ -430,16 +432,13 @@ def percentiles_summary(df, num_old, num_new, upsample, state):
     elif is_datetime64_dtype(data.dtype) or is_integer_dtype(data.dtype):
         interpolation = "nearest"
 
-    # FIXME: pandas quantile doesn't work with some data types (e.g. strings).
-    # We fall back to an ndarray as a workaround.
     try:
-        vals = data.quantile(q=qs / 100, interpolation=interpolation).values
+        # Plan A: Use `Series.quantile`
+        vals = data.quantile(q=qs / 100, interpolation=interpolation)
     except (TypeError, NotImplementedError):
-        try:
-            vals, _ = _percentile(array_safe(data, like=data.values), qs, interpolation)
-        except (TypeError, NotImplementedError):
-            # `data.values` doesn't work for cudf, so we need to
-            # use `quantile(..., method="table")` as a fallback
+        # Series.quantile doesn't work with some data types (e.g. strings)
+        if PANDAS_GE_150:
+            # Fall back to DataFrame.quantile with "nearest" interpolation
             interpolation = "nearest"
             vals = (
                 data.to_frame()
@@ -451,6 +450,18 @@ def percentiles_summary(df, num_old, num_new, upsample, state):
                 )
                 .iloc[:, 0]
             )
+        else:
+            # Fall back to ndarray (Not supported for cuDF)
+            vals, _ = _percentile(array_safe(data, like=data.values), qs, interpolation)
+
+    # Convert to array if necessary (and possible)
+    if is_series_like(vals):
+        try:
+            vals = vals.values
+        except (ValueError, TypeError):
+            # cudf->cupy won't work if nulls are present,
+            # or if this is a string dtype
+            pass
 
     if (
         is_cupy_type(data)


### PR DESCRIPTION
This is essentially a revision of https://github.com/dask/dask/pull/10551, which generalized the partition-wise `quantiles` logic used in `percentiles_summary` to work with both `cudf` and `pandas`-backed data. It turns out that those changes do not quite cover the case that a numerical column contains null values.

An additional problem with the current logic is that error handling for the `.values` operation is mixed with error handling for the `quantile` operation itself. This PR separates these steps a bit to make the logic less confusing.

Overview of the partition-wise `quantiles` logic after this PR:

1. We try to use the `Series.quantile` method (without calling `.values` yet)
2. If (1) fails, we use the more-robust `DataFrame.quantile(..., method="table")` method as if `pandas>=1.5`
3. If (1) fails and `pandas<1.5`, we fall back to `percentile` (this entire code path can be removed when pandas2+ is required)
4. After (1), (2) or (3) has succeeded, we try converting the result to an array with `.values`. Since `cudf->cupy` will fail to do this for string columns and/or null values, we simply `pass` if this step fails.
  - **NOTE**: It is not clear to me why we need to call  `.values` here at all. I believe NEP18 covers all necessary `Series` logic anyway. Perhaps we can remove this step?
