### PR TITLE
Apply ruff/flake8-implicit-str-concat rule ISC001

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3472,7 +3472,7 @@ def from_array(
     """
     if isinstance(x, Array):
         raise ValueError(
-            "Array is already a dask array. Use 'asarray' or " "'rechunk' instead."
+            "Array is already a dask array. Use 'asarray' or 'rechunk' instead."
         )
     elif is_dask_collection(x):
         warnings.warn(

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -354,7 +354,7 @@ def ensure_minimum_chunksize(size, chunks):
         output[-1] += new
     else:
         raise ValueError(
-            f"The overlapping depth {size} is larger than your " f"array {sum(chunks)}."
+            f"The overlapping depth {size} is larger than your array {sum(chunks)}."
         )
 
     return tuple(output)

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -2158,7 +2158,7 @@ def setitem(x, v, indices):
         x[tuple(indices)] = v
     except ValueError as e:
         raise ValueError(
-            "shape mismatch: value array could " "not be broadcast to indexing result"
+            "shape mismatch: value array could not be broadcast to indexing result"
         ) from e
 
     return x

--- a/dask/bytes/tests/test_local.py
+++ b/dask/bytes/tests/test_local.py
@@ -38,9 +38,9 @@ files = {
 
 
 csv_files = {
-    ".test.fakedata.1.csv": (b"a,b\n" b"1,2\n"),
-    ".test.fakedata.2.csv": (b"a,b\n" b"3,4\n"),
-    "subdir/.test.fakedata.2.csv": (b"a,b\n" b"5,6\n"),
+    ".test.fakedata.1.csv": (b"a,b\n1,2\n"),
+    ".test.fakedata.2.csv": (b"a,b\n3,4\n"),
+    "subdir/.test.fakedata.2.csv": (b"a,b\n5,6\n"),
 }
 
 

--- a/dask/cache.py
+++ b/dask/cache.py
@@ -35,7 +35,7 @@ class Cache(Callback):
             import cachey
         except ImportError as ex:
             raise ImportError(
-                'Cache requires cachey, "{ex}" problem ' "importing".format(ex=str(ex))
+                f'Cache requires cachey, "{str(ex)}" problem importing'
             ) from ex
         self._nbytes = cachey.nbytes
         if isinstance(cache, Number):

--- a/dask/dataframe/io/json.py
+++ b/dask/dataframe/io/json.py
@@ -73,9 +73,7 @@ def to_json(
     if lines is None:
         lines = orient == "records"
     if orient != "records" and lines:
-        raise ValueError(
-            "Line-delimited JSON is only available with" 'orient="records".'
-        )
+        raise ValueError('Line-delimited JSON is only available with orient="records".')
     kwargs["orient"] = orient
     kwargs["lines"] = lines and orient == "records"
     outfiles = open_files(
@@ -200,9 +198,7 @@ def read_json(
     if lines is None:
         lines = orient == "records"
     if orient != "records" and lines:
-        raise ValueError(
-            "Line-delimited JSON is only available with" 'orient="records".'
-        )
+        raise ValueError('Line-delimited JSON is only available with orient="records".')
     if blocksize and (orient != "records" or not lines):
         raise ValueError(
             "JSON file chunking only allowed for JSON-lines"

--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -102,13 +102,9 @@ Date,Open,High,Low,Close,Volume,Adj Close
 """.strip()
 
 csv_files = {
-    "2014-01-01.csv": (
-        b"name,amount,id\n" b"Alice,100,1\n" b"Bob,200,2\n" b"Charlie,300,3\n"
-    ),
+    "2014-01-01.csv": b"name,amount,id\nAlice,100,1\nBob,200,2\nCharlie,300,3\n",
     "2014-01-02.csv": b"name,amount,id\n",
-    "2014-01-03.csv": (
-        b"name,amount,id\n" b"Dennis,400,4\n" b"Edith,500,5\n" b"Frank,600,6\n"
-    ),
+    "2014-01-03.csv": b"name,amount,id\nDennis,400,4\nEdith,500,5\nFrank,600,6\n",
 }
 
 tsv_files = {k: v.replace(b",", b"\t") for (k, v) in csv_files.items()}

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -64,7 +64,7 @@ def test_empty(db):
 
 
 @pytest.mark.filterwarnings(
-    "ignore:The default dtype for empty Series " "will be 'object' instead of 'float64'"
+    "ignore:The default dtype for empty Series will be 'object' instead of 'float64'"
 )
 @pytest.mark.parametrize("use_head", [True, False])
 def test_single_column(db, use_head):


### PR DESCRIPTION
	ISC001 Implicitly concatenated string literals on one line

This rule is currently disabled because it conflicts with the ruff formatter:
	https://github.com/astral-sh/ruff/issues/8272

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
