### PR TITLE
Getting Started layout

### DIFF
--- a/docs/source/10-minutes-to-dask.rst
+++ b/docs/source/10-minutes-to-dask.rst
@@ -1,5 +1,5 @@
-10 Minutes to Dask
-==================
+Dask Cookbook
+=============
 
 .. meta::
     :description: This is a short overview of Dask geared towards new users. Additional Dask information can be found in the rest of the Dask documentation.

--- a/docs/source/getting-started-array.rst
+++ b/docs/source/getting-started-array.rst
@@ -1,0 +1,4 @@
+Getting Started: Array
+======================
+
+TODO

--- a/docs/source/getting-started-bag.rst
+++ b/docs/source/getting-started-bag.rst
@@ -1,0 +1,4 @@
+Getting Started: Bags
+=====================
+
+TODO

--- a/docs/source/getting-started-dataframe.rst
+++ b/docs/source/getting-started-dataframe.rst
@@ -1,0 +1,4 @@
+Getting Started: DataFrame
+==========================
+
+TODO

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -1,0 +1,14 @@
+Getting Started
+===============
+
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   DataFrame <getting-started-dataframe.rst>
+   Array <getting-started-array.rst>
+   Bag <getting-started-bag.rst>
+
+
+TODO

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -331,6 +331,13 @@ able to help you have fun with your work.
    :hidden:
    :caption: Getting Started
 
+   getting-started.rst
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+   :caption: Future Reading
+
    Install Dask <install.rst>
    10-minutes-to-dask.rst
    deploying.rst


### PR DESCRIPTION
**Context:**

The getting started section is not good currently. It has tons of information that are completely irrelevant for someone who has heard the first time about Dask or just wants to run an example and play around a little bit. The information in there is mostly what I would expect from a 2nd step section.

It's pretty confusing where you should start looking if you are someone who has never done anything with Dask and seems very complex.


**Proposal:**

We create a dedicated getting started section for the most relevant use-cases (currently we have content for bags, dataframes and arrays). They take a user through:

-  Installing -> running a short example -> looking at the Dashboard -> How can I scale out

Descriptions are short and on point without introducing internals or stuff that is very Dask specific. Just get them to the point where they can run something and look at it on the Dashboard


The stuff that we have currently in the getting started section will be trimmed down a little and advertised as further reading (or something similar, I am not married to any of those terms).


This is not meant to be merged, just a proposal for a layout that we can then fill with content