### PR TITLE
Fixing TypeError

### DIFF
--- a/dask/multiprocessing.py
+++ b/dask/multiprocessing.py
@@ -61,7 +61,7 @@ class RemoteException(Exception):
         self.traceback = traceback
 
     def __str__(self):
-        return str(self.exception) + "\n\nTraceback\n---------\n" + self.traceback
+        return str(self.exception) + "\n\nTraceback\n---------\n" + str(self.traceback)
 
     def __dir__(self):
         return sorted(set(dir(type(self)) + list(self.__dict__) + dir(self.exception)))


### PR DESCRIPTION
---> 64     return str(self.exception) + "\n\nTraceback\n---------\n" + self.traceback

TypeError: can only concatenate str (not "traceback") to str

- [ ] Closes #11101
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
