### PR TITLE
Use nightly `h5py` in upstream CI build

### DIFF
--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -28,12 +28,13 @@ if [[ ${UPSTREAM_DEV} ]]; then
         git+https://github.com/dask/dask-expr \
         git+https://github.com/dask/fastparquet \
         git+https://github.com/zarr-developers/zarr-python
-    mamba uninstall --force numpy pandas scipy numexpr numba sparse
+    mamba uninstall --force numpy pandas scipy numexpr numba sparse h5py
     python -m pip install --no-deps --pre --retries 10 \
         -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
         numpy \
         pandas \
-        scipy
+        scipy \
+        h5py
 
     # Used when automatically opening an issue when the `upstream` CI build fails
     mamba install pytest-reportlog


### PR DESCRIPTION
This resolves some NumPy 2.0-related errors we're seeing in the upstream build

xref https://github.com/dask/dask/issues/11066#issuecomment-2094255205

