### PR TITLE
Avoid ``pytest`` error when skipping NumPy 2.0 tests 

### DIFF
--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -447,8 +447,14 @@ def test_modification_time_read_bytes(s3, s3so):
     ]
 )
 def engine(request):
-    pytest.importorskip(request.param)
     import dask.dataframe as dd
+    from dask.array.numpy_compat import NUMPY_GE_200
+
+    if NUMPY_GE_200 and request.param == "fastparquet":
+        # https://github.com/dask/fastparquet/issues/923
+        pytest.skip("fastparquet doesn't work with Numpy 2")
+
+    pytest.importorskip(request.param)
 
     if dd._dask_expr_enabled() and request.param == "fastparquet":
         pytest.skip("not supported")
@@ -460,12 +466,6 @@ def test_parquet(s3, engine, s3so, metadata_file):
     dd = pytest.importorskip("dask.dataframe")
     pd = pytest.importorskip("pandas")
     np = pytest.importorskip("numpy")
-
-    from dask.array.numpy_compat import NUMPY_GE_200
-
-    if NUMPY_GE_200 and engine == "fastparquet":
-        # https://github.com/dask/fastparquet/issues/923
-        pytest.skip("fastparquet doesn't work with Numpy 2")
 
     url = "s3://%s/test.parquet" % test_bucket_name
     data = pd.DataFrame(
@@ -562,11 +562,6 @@ def test_parquet_append(s3, engine, s3so):
     dd = pytest.importorskip("dask.dataframe")
     pd = pytest.importorskip("pandas")
     np = pytest.importorskip("numpy")
-    from dask.array.numpy_compat import NUMPY_GE_200
-
-    if NUMPY_GE_200 and engine == "fastparquet":
-        # https://github.com/dask/fastparquet/issues/923
-        pytest.skip("fastparquet doesn't work with Numpy 2")
 
     url = "s3://%s/test.parquet.append" % test_bucket_name
 
@@ -620,12 +615,6 @@ def test_parquet_wstoragepars(s3, s3so, engine):
     dd = pytest.importorskip("dask.dataframe")
     pd = pytest.importorskip("pandas")
     np = pytest.importorskip("numpy")
-
-    from dask.array.numpy_compat import NUMPY_GE_200
-
-    if NUMPY_GE_200 and engine == "fastparquet":
-        # https://github.com/dask/fastparquet/issues/923
-        pytest.skip("fastparquet doesn't work with Numpy 2")
 
     url = "s3://%s/test.parquet" % test_bucket_name
 


### PR DESCRIPTION
This fixes errors like 

```
ERROR dask/bytes/tests/test_s3.py::test_parquet[fastparquet-True] - pytest.PytestDeprecationWarning: 
Module 'fastparquet' was found, but when imported by pytest it raised:
    ImportError("numpy.core.multiarray failed to import (auto-generated because you didn't call 'numpy.import_array()' after cimporting numpy; use '<void>numpy._import_array' to disable if you are certain you don't need it).")
In pytest 9.1 this warning will become an error by default.
You can fix the underlying problem, or alternatively overwrite this behavior and silence this warning by passing exc_type=ImportError explicitly.
See https://docs.pytest.org/en/stable/deprecations.html#pytest-importorskip-default-behavior-regarding-importerror
```

in the upstream build 

EDIT: Closes https://github.com/dask/dask/issues/10855