### PR TITLE
Make sure nightly ``pyarrow`` is installed in upstream CI build

### DIFF
--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -11,7 +11,7 @@ if [[ ${UPSTREAM_DEV} ]]; then
     mamba uninstall --force bokeh
     mamba install -y -c bokeh/label/dev bokeh
 
-    mamba uninstall --force pyarrow
+    mamba uninstall --force pyarrow pyarrow-core
     python -m pip install --no-deps \
         --extra-index-url https://pypi.fury.io/arrow-nightlies/ \
         --prefer-binary --pre pyarrow


### PR DESCRIPTION
`pyarrow` on conda-forge recently had a packaging refactor and now there's a `pyarrow-core` package we also need to account for in our upstream CI build. This PR makes sure we're able to install the latest nightly version of `pyarrow`. 