### PR TITLE
Don't draft release notes for tagged commits

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,7 +17,15 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required to get tag history
+      - name: Check if release commit
+        id: check_release_commit
+        run: git describe --exact-match --tags $(git rev-parse HEAD)
+        continue-on-error: true
       - uses: release-drafter/release-drafter@v6
+        if: steps.check_release_commit.outcome != 'success'
         with:
           disable-autolabeler: true
         env:


### PR DESCRIPTION
Closes #11134 

The release process here involves creating an empty commit and tagging it, then pushing that directly onto `main`. This triggers both the release notes drafter and release notes publish workflows at the same time. This causes a race condition that can result in the release notes not being published correctly, see #11134.

This PR adds a check to the release notes drafting workflow to see if the commit has been tagged. If it is a tagged commit it skips drafting the release notes. This avoids the conflict with the release publish workflow which will be running at the same time.

I've tested this in [a separate repository](https://github.com/jacobtomlinson/release-drafter-experiments) to ensure the workflow works as expected:

- In [this run](https://github.com/jacobtomlinson/release-drafter-experiments/actions/runs/9170979546/job/25214317620) on a regular commit you can see the tagged commit check fails, so the draft release runs. 
- But in [this run](https://github.com/jacobtomlinson/release-drafter-experiments/actions/runs/9170992504/job/25214359217) on the tagged release commit the check passes, so the draft release is skipped.

cc @jrbourbeau 