### PR TITLE
Unskip ``test_array_function_sparse`` with new ``sparse`` release

### DIFF
--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -100,7 +100,7 @@ def test_array_notimpl_function_dask(func):
 )
 def test_array_function_sparse(func):
     sparse = pytest.importorskip("sparse")
-    if Version(sparse.__version__) >= Version("0.15.2"):
+    if Version(sparse.__version__) == Version("0.15.2"):
         pytest.skip(reason="https://github.com/pydata/sparse/issues/682")
     x = da.random.default_rng().random((500, 500), chunks=(100, 100))
     x[x < 0.9] = 0


### PR DESCRIPTION
This PR relaxes when this test is skipped since https://github.com/pydata/sparse/issues/682 has been fixed upstream in `sparse`.

Closes https://github.com/dask/dask/issues/11130 