### PR TITLE
Fix nightly Zarr installation in CI

### DIFF
--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -27,7 +27,7 @@ if [[ ${UPSTREAM_DEV} ]]; then
         git+https://github.com/dask/distributed \
         git+https://github.com/dask/dask-expr \
         git+https://github.com/dask/fastparquet \
-        git+https://github.com/zarr-developers/zarr-python
+        git+https://github.com/zarr-developers/zarr-python.git@main
     mamba uninstall --force numpy pandas scipy numexpr numba sparse scikit-image h5py
     python -m pip install --no-deps --pre --retries 10 \
         -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -28,6 +28,9 @@ if [[ ${UPSTREAM_DEV} ]]; then
         git+https://github.com/dask/dask-expr \
         git+https://github.com/dask/fastparquet \
         git+https://github.com/zarr-developers/zarr-python.git@main
+        # Zarr's default branch (`v3`) is still under development.
+        # Explicitly specify `main` until their default branch is ready.
+        # https://github.com/zarr-developers/zarr-python/issues/1922
     mamba uninstall --force numpy pandas scipy numexpr numba sparse scikit-image h5py
     python -m pip install --no-deps --pre --retries 10 \
         -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \


### PR DESCRIPTION
We recently started seeing some Zarr-related failures in our upstream CI build like this

```
FAILED dask/array/tests/test_array_core.py::test_zarr_return_stored[False] - AttributeError: module 'zarr' has no attribute 'create'
FAILED dask/array/tests/test_array_core.py::test_zarr_return_stored[True] - AttributeError: module 'zarr' has no attribute 'create'
FAILED dask/array/tests/test_array_core.py::test_zarr_inline_array[True] - TypeError: 'module' object is not callable
FAILED dask/array/tests/test_array_core.py::test_zarr_inline_array[False] - TypeError: 'module' object is not callable
FAILED dask/array/tests/test_array_core.py::test_zarr_existing_array - AttributeError: module 'zarr' has no attribute 'zeros_like'
FAILED dask/array/tests/test_array_core.py::test_read_zarr_chunks - AttributeError: module 'zarr' has no attribute 'create'
FAILED dask/array/tests/test_array_core.py::test_zarr_pass_mapper - ModuleNotFoundError: No module named 'zarr.storage'
FAILED dask/array/tests/test_array_core.py::test_zarr_group - AttributeError: module 'zarr' has no attribute 'create'
FAILED dask/array/tests/test_array_core.py::test_zarr_nocompute - AttributeError: module 'zarr' has no attribute 'create'
FAILED dask/array/tests/test_array_core.py::test_zarr_regions - AttributeError: module 'zarr' has no attribute 'zeros_like'
```

See [this build](https://github.com/dask/dask/actions/runs/9275496754/job/25520338198). 

It looks like if we explicitly install the Zarr `main` branch, those errors go away. I opened this upstream issue in `zarr-python` https://github.com/zarr-developers/zarr-python/issues/1922 