### PR TITLE
Ensure tokenization of memmap doesn't materialize array in memory

### DIFF
--- a/dask/tests/test_tokenize.py
+++ b/dask/tests/test_tokenize.py
@@ -229,8 +229,7 @@ def test_tokenize_numpy_memmap():
         z = check_tokenize(np.load(fn, mmap_mode="r"))
 
     assert check_tokenize(x1) == check_tokenize(x2)
-    # Memory maps should behave similar to ordinary arrays
-    assert y == z
+    assert y != z
 
     with tmpfile(".npy") as fn:
         x = np.random.normal(size=(10, 10))


### PR DESCRIPTION
- [ ] Closes https://github.com/dask/dask/issues/11152

I don't truly know how to test this well in a way that is not incredibly slow or flaky on CI. I tested it locally and it does not load any data in memory but I am not aware of an API that would allow us to inspect the mmap and I don't think a test that measures RSS is very reliable
