### PR TITLE
Add section about futures and variables

### DIFF
--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -343,7 +343,7 @@ part of a function:
 Submit task and retrieve results from a different process
 ---------------------------------------------------------
 
-Sometimes a we care about retrieving a result but not necessarily from the same process.
+Sometimes we care about retrieving a result but not necessarily from the same process.
 
 .. code-block:: python
 

--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -340,6 +340,30 @@ part of a function:
         process(filename)
 
 
+Submit task and retrieve results from a different process
+---------------------------------------------------------
+
+Sometimes a we care about retrieving a result but not necessarily from the same process.
+
+.. code-block:: python
+
+   from distributed import Variable
+
+   var = Variable("my-result")
+   fut = client.submit(...)
+   var.set(fut)
+
+Using a ``Variable`` instructs dask to remember the result of this task under
+the given name so that it can be retrieved later without having to keep the
+Client alive in the meantime.
+
+.. code-block:: python
+
+   var = Variable("my-result")
+   fut = var.get()
+   result = fut.result()
+
+
 Submit Tasks from Tasks
 -----------------------
 


### PR DESCRIPTION
This is a poorly advertised but very useful feature.

The only reference to this capability so far is in the docstring of the `Variable`, see https://distributed.dask.org/en/stable/api.html#distributed.Variable
 
which I believe is pretty hidden for such a powerful feature. I don't love the structure of this document but refactoring it is out of scope for this PR.

This PR simply adds another section below "fire and forget" which is I think where this fits in the best.