### PR TITLE
Fix ``test_dt_accessor`` with query planning disabled

### DIFF
--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -95,9 +95,7 @@ def df_ddf():
     return df, ddf
 
 
-@pytest.mark.skipif(
-    not PANDAS_GE_210 or PANDAS_GE_300, reason="warning is None|divisions are incorrect"
-)
+@pytest.mark.xfail(PANDAS_GE_300, reason="divisions are incorrect")
 def test_dt_accessor(df_ddf):
     df, ddf = df_ddf
 
@@ -106,7 +104,10 @@ def test_dt_accessor(df_ddf):
     # pandas loses Series.name via datetime accessor
     # see https://github.com/pydata/pandas/issues/10712
     assert_eq(ddf.dt_col.dt.date, df.dt_col.dt.date, check_names=False)
-    warning_ctx = pytest.warns(FutureWarning, match="will return a Series")
+    if PANDAS_GE_210:
+        warning_ctx = pytest.warns(FutureWarning, match="will return a Series")
+    else:
+        warning_ctx = contextlib.nullcontext()
     # to_pydatetime returns a numpy array in pandas, but a Series in dask
     # pandas will start returning a Series with 3.0 as well
     with warning_ctx:

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -122,9 +122,9 @@ def test_dt_accessor(df_ddf):
         # The warnings is raised during construction of the expression, not the
         # materialization of the graph. Therefore, the singleton approach of
         # dask-expr avoids another warning
-        ctx = contextlib.nullcontext()
+        warning_ctx = contextlib.nullcontext()
 
-    with ctx:
+    with warning_ctx:
         assert set(ddf.dt_col.dt.to_pydatetime().dask) == set(
             ddf.dt_col.dt.to_pydatetime().dask
         )


### PR DESCRIPTION
The variable was added in https://github.com/dask/dask/pull/10880 but accidentally partially renamed in https://github.com/dask/dask/pull/10989, which is why we sometimes see the ``UnboundLocalError``. 

I think this went undetected because we started skipping this test on older `pandas` versions in https://github.com/dask/dask/pull/10868. I don't think that's quite right and instead am proposing we run for all `pandas` versions (`xfail`ing for pandas 3 as divisions aren't correct -- @phofl do you know if there's an issue for this already?)

Closes https://github.com/dask/dask/issues/11176