### PR TITLE
API: expose `np` dtypes in `dask.array` namespace

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -1,6 +1,22 @@
 from __future__ import annotations
 
 try:
+    from numpy import bool_ as bool
+    from numpy import (
+        complex64,
+        complex128,
+        float32,
+        float64,
+        int8,
+        int16,
+        int32,
+        int64,
+        uint8,
+        uint16,
+        uint32,
+        uint64,
+    )
+
     from dask.array import backends, fft, lib, linalg, ma, overlap, random
     from dask.array.blockwise import atop, blockwise
     from dask.array.chunk_types import register_chunk_type


### PR DESCRIPTION
- [x] Towards #10387
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Copying my comment from the linked issue:

> FWIW, exposing these would help with early adoption of Dask into SciPy. Now that we have `array_api_compat.dask.array`, we should be able to get our array-agnostic code working.
> 
> The slight problem at the minute is that in our tests, we make some assumptions about very basic things that NumPy, CuPy and PyTorch's main namespaces - and the standard - all have in common, such as `xp.float64`. This assumption has allowed us to reduce diffs quite a lot by avoiding (so far) unnecessary calls to get the wrapped namespaces.
> 
> I understand that resolution to this may be somewhat blocked on a resolution to whether converging the main namespace or adding a separate namespace is desirable in gh-8750. For now though, even just exposing the dtypes as @ogrisel suggested would be helpful. Thanks!

See https://github.com/scipy/scipy/pull/20956 for the failures caused in SciPy's test suite without this.