### PR TITLE
Python 3.13 fixes

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -141,16 +141,17 @@ def unpack_collections(expr):
                 if hasattr(expr, f.name)
             }
             replace(expr, **_fields)
-        except TypeError as e:
-            raise TypeError(
-                f"Failed to unpack {typ} instance. "
-                "Note that using a custom __init__ is not supported."
-            ) from e
-        except ValueError as e:
-            raise ValueError(
-                f"Failed to unpack {typ} instance. "
-                "Note that using fields with `init=False` are not supported."
-            ) from e
+        except (TypeError, ValueError) as e:
+            if isinstance(e, ValueError) or "is declared with init=False" in str(e):
+                raise ValueError(
+                    f"Failed to unpack {typ} instance. "
+                    "Note that using fields with `init=False` are not supported."
+                ) from e
+            else:
+                raise TypeError(
+                    f"Failed to unpack {typ} instance. "
+                    "Note that using a custom __init__ is not supported."
+                ) from e
         return (apply, typ, (), (dict, args)), collections
 
     if is_namedtuple_instance(expr):

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -600,7 +600,7 @@ def test_derived_from():
     assert "not supported" in b_arg.lower()
     assert "dask" in b_arg.lower()
 
-    assert "  extra docstring\n\n" in Zap.f.__doc__
+    assert "extra docstring\n\n" in Zap.f.__doc__
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- [X] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

This fixes two failures when running the test suite on Python 3.13.

* `dataclasses.replace()` changed the type of the exception it raises in a couple of cases, one of which causes us to also raise a different exception type with a misleading message. We *could* adopt the same exception type change and just make sure we use the correct message, I guess, but that seems like an interface change, this keeps the behaviour the same as it was before.
* As per [the what's new page](https://docs.python.org/3.13/whatsnew/3.13.html#other-language-changes), "Compiler now strip indents from docstrings." This broke the expectation of `test_derived_from`. We can fix it just by not expecting the indentation, I don't think we really need to enforce that it's there for older Python versions, we're just checking that our extra docstring text got in there, not policing indentation.