### PR TITLE
Fixes for ``d`` freq deprecation in ``pandas=3``

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2397,7 +2397,7 @@ def test_roundtrip_arrow(tmpdir, df):
 def test_datasets_timeseries(tmpdir, engine):
     tmp_path = str(tmpdir)
     df = dask.datasets.timeseries(
-        start="2000-01-01", end="2000-01-10", freq="1d"
+        start="2000-01-01", end="2000-01-10", freq="1D"
     ).persist()
     df.to_parquet(tmp_path, engine=engine)
 

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -281,20 +281,20 @@ def test_meta_nonempty_index():
     assert type(res) is pd.Index
     assert res.name == idx.name
 
-    idx = pd.DatetimeIndex(["1970-01-01"], freq="d", tz="America/New_York", name="foo")
+    idx = pd.DatetimeIndex(["1970-01-01"], freq="D", tz="America/New_York", name="foo")
     res = meta_nonempty(idx)
     assert type(res) is pd.DatetimeIndex
     assert res.tz == idx.tz
     assert res.freq == idx.freq
     assert res.name == idx.name
 
-    idx = pd.PeriodIndex(["1970-01-01"], freq="d", name="foo")
+    idx = pd.PeriodIndex(["1970-01-01"], freq="D", name="foo")
     res = meta_nonempty(idx)
     assert type(res) is pd.PeriodIndex
     assert res.freq == idx.freq
     assert res.name == idx.name
 
-    idx = pd.TimedeltaIndex([pd.Timedelta(1, "D")], freq="d", name="foo")
+    idx = pd.TimedeltaIndex([pd.Timedelta(1, "D")], freq="D", name="foo")
     res = meta_nonempty(idx)
     assert type(res) is pd.TimedeltaIndex
     assert res.freq == idx.freq

--- a/dask/datasets.py
+++ b/dask/datasets.py
@@ -11,7 +11,7 @@ def timeseries(
     start="2000-01-01",
     end="2000-01-31",
     freq="1s",
-    partition_freq="1d",
+    partition_freq="1D",
     dtypes=None,
     seed=None,
     **kwargs,


### PR DESCRIPTION
We're getting several 

```
FutureWarning: 'd' is deprecated and will be removed in a future version, please use 'D'  instead.
```

warnings (elevated to errors) when running tests against the nightly version of `pandas`.

This PR switches to `D` instead of `d` (should be backwards compatible) throughout the codebase and adds a small test to make sure `dask` is surfacing a similar deprecation as `pandas` at graph construction time. 

xref https://github.com/dask/dask/issues/11111