### PR TITLE
Ensure that dask expr DataFrames are optimized when put into delayed

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -95,6 +95,10 @@ def unpack_collections(expr):
         return expr._key, (expr,)
 
     if is_dask_collection(expr):
+        if hasattr(expr, "optimize"):
+            # Optimize dask-expr collections
+            expr = expr.optimize()
+
         finalized = finalize(expr)
         return finalized._key, (finalized,)
 


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
