### PR TITLE
Preserve timestamp unit during meta creation

### DIFF
--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -436,7 +436,7 @@ def _nonempty_series(s, idx=None):
         data = [s.iloc[0]] * 2
     elif isinstance(dtype, pd.DatetimeTZDtype):
         entry = pd.Timestamp("1970-01-01", tz=dtype.tz)
-        data = [entry, entry]
+        data = pd.array([entry, entry], dtype=dtype)
     elif isinstance(dtype, pd.CategoricalDtype):
         if len(s.cat.categories):
             data = [s.cat.categories[0]] * 2

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -36,6 +36,7 @@ from dask.dataframe.core import (
     repartition_divisions,
     total_mem_usage,
 )
+from dask.dataframe.dispatch import meta_nonempty
 from dask.dataframe.utils import (
     assert_eq,
     assert_eq_dtypes,
@@ -6306,6 +6307,20 @@ def test_enforce_runtime_divisions():
             RuntimeError, match="`enforce_runtime_divisions` failed for partition 1"
         ):
             ddf.enforce_runtime_divisions().compute()
+
+
+def test_preserve_ts_unit_in_meta_creation():
+    pdf = pd.DataFrame(
+        {
+            "a": [1],
+            "timestamp": pd.Series(
+                [pd.Timestamp.utcnow()], dtype="datetime64[us, UTC]"
+            ),
+        }
+    )
+    df = dd.from_pandas(pdf, npartitions=1)
+    dd.assert_eq(meta_nonempty(df._meta).dtypes, pdf.dtypes)
+    dd.assert_eq(df, pdf)
 
 
 def test_query_planning_config_warns():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -6319,8 +6319,8 @@ def test_preserve_ts_unit_in_meta_creation():
         }
     )
     df = dd.from_pandas(pdf, npartitions=1)
-    dd.assert_eq(meta_nonempty(df._meta).dtypes, pdf.dtypes)
-    dd.assert_eq(df, pdf)
+    assert_eq(meta_nonempty(df._meta).dtypes, pdf.dtypes)
+    assert_eq(df, pdf)
 
 
 def test_query_planning_config_warns():


### PR DESCRIPTION
- [x] Closes #11230
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
