### PR TITLE
Implement task-based array shuffle

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -32,6 +32,7 @@ def _array_expr_enabled() -> bool:
 
 try:
     from dask.array import backends, fft, lib, linalg, ma, overlap, random
+    from dask.array._shuffle import shuffle
     from dask.array.blockwise import atop, blockwise
     from dask.array.chunk_types import register_chunk_type
     from dask.array.core import (

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -96,15 +96,13 @@ def shuffle(x, indexer: list[list[int]], axis):
                 merge_keys.append(name)
 
             merge_suffix = convert_key(chunk_tuple, new_chunk_idx, axis)
-            if len(merge_keys) > 1:
+            if len(merge_keys) >= 1:
                 merges[(merge_name,) + merge_suffix] = (
                     concatenate_arrays,
                     merge_keys,
                     sorter,
                     axis,
                 )
-            elif len(merge_keys) == 1:
-                merges[(merge_name,) + merge_suffix] = merge_keys[0]  # type: ignore[assignment]
             else:
                 raise NotImplementedError
 

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -89,7 +89,7 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
         )
 
     chunksize_tolerance = config.get("array.shuffle.chunksize-tolerance")
-    average_chunk_size = int(
+    chunk_size_limit = int(
         sum(chunks[axis]) / len(chunks[axis]) * chunksize_tolerance
     )
 

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -89,22 +89,17 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
         )
 
     chunksize_tolerance = config.get("array.shuffle.chunksize-tolerance")
-    chunk_size_limit = int(
-        sum(chunks[axis]) / len(chunks[axis]) * chunksize_tolerance
-    )
+    chunk_size_limit = int(sum(chunks[axis]) / len(chunks[axis]) * chunksize_tolerance)
 
     # Figure out how many groups we can put into one chunk
     current_chunk, new_chunks = [], []
     for idx in indexer:
-        if (
-            len(current_chunk) + len(idx) > average_chunk_size
-            and len(current_chunk) > 0
-        ):
+        if len(current_chunk) + len(idx) > chunk_size_limit and len(current_chunk) > 0:
             new_chunks.append(current_chunk)
             current_chunk = idx.copy()
         else:
             current_chunk.extend(idx)
-            if len(current_chunk) > average_chunk_size / 1.25:
+            if len(current_chunk) > chunk_size_limit / chunksize_tolerance:
                 new_chunks.append(current_chunk)
                 current_chunk = []
     if len(current_chunk) > 0:

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from itertools import count, product
 
 import numpy as np
@@ -87,6 +88,7 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
         raise IndexError(
             f"Indexer contains out of bounds index. Dimension only has {sum(chunks[axis])} elements."
         )
+    indexer = copy.deepcopy(indexer)
 
     chunksize_tolerance = config.get("array.shuffle.chunksize-tolerance")
     chunk_size_limit = int(sum(chunks[axis]) / len(chunks[axis]) * chunksize_tolerance)

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -33,7 +33,7 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
             f"Axis {axis} is out of bounds for array with {len(chunks)} axes"
         )
 
-    if max(map(max, indexer)) >= sum(chunks[axis]):  # type: ignore[arg-type]
+    if max(map(max, indexer)) >= sum(chunks[axis]):
         raise IndexError(
             f"Indexer contains out of bounds index. Dimension only has {sum(chunks[axis])} elements."
         )
@@ -41,7 +41,7 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
     average_chunk_size = int(sum(chunks[axis]) / len(chunks[axis]) * 1.25)
 
     # Figure out how many groups we can put into one chunk
-    current_chunk, new_chunks = [], []  # type: ignore[var-annotated]
+    current_chunk, new_chunks = [], []
     for idx in indexer:
         if (
             len(current_chunk) + len(idx) > average_chunk_size
@@ -75,7 +75,7 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
         old_blocks[old_index] = (in_name,) + old_index
 
     for new_chunk_idx, new_chunk_taker in enumerate(new_chunks):
-        new_chunk_taker = np.array(new_chunk_taker)  # type: ignore[assignment]
+        new_chunk_taker = np.array(new_chunk_taker)
         sorter = np.argsort(new_chunk_taker)
         sorted_array = new_chunk_taker[sorter]
         source_chunk_nr, taker_boundary = np.unique(

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -27,7 +27,7 @@ def shuffle(x, indexer: list[list[int]], axis):
     x: dask array
         Array to be shuffled.
     indexer:  list[list[int]]
-        The indexer that determins which elements along the dimension will end up in the
+        The indexer that determines which elements along the dimension will end up in the
         same chunk. Multiple groups can be in the same chunk to avoid fragmentation, but
         each group will end up in exactly one chunk.
     axis: int

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -4,6 +4,7 @@ from itertools import count, product
 
 import numpy as np
 
+from dask import config
 from dask.array.chunk import getitem
 from dask.array.core import Array, unknown_chunk_message
 from dask.base import tokenize
@@ -11,10 +12,59 @@ from dask.highlevelgraph import HighLevelGraph
 
 
 def shuffle(x, indexer: list[list[int]], axis):
+    """
+    Reorders one dimensions of a Dask Array based on an indexer.
+
+    The indexer defines a list of positional groups that will end up in the same chunk
+    together. A single group is in at most one chunk on this dimension, but a chunk
+    might contain multiple groups to avoid fragmentation of the array.
+
+    The algorithm tries to balance the chunksizes as much as possible to ideally keep the
+    number of chunks consistent or at least manageable.
+
+    Parameters
+    ----------
+    x: dask array
+        Array to be shuffled.
+    indexer:  list[list[int]]
+        The indexer that determins which elements along the dimension will end up in the
+        same chunk. Multiple groups can be in the same chunk to avoid fragmentation, but
+        each group will end up in exactly one chunk.
+    axis: int
+        The axis to shuffle along.
+
+    Examples
+    --------
+    >>> import dask.array as da
+    >>> import numpy as np
+    >>> arr = np.array([[1, 2, 3, 4, 5, 6, 7, 8], [9, 10, 11, 12, 13, 14, 15, 16]])
+    >>> x = da.from_array(arr, chunks=(2, 4))
+
+    Separate the elements in different groups.
+
+    >>> y = x.shuffle([[6, 5, 2], [4, 1], [3, 0, 7]], axis=1)
+
+    The shuffle algorihthm will combine the first 2 groups into a single chunk to keep
+    the number of chunks small.
+
+    The tolerance of increasing the chunk size is controlled by the configuration
+    "array.shuffle.chunksize-tolerance". The default value is 1.25.
+
+    >>> y.chunks
+    ((2,), (5, 3))
+
+    The array was reordered along axis 1 according to the positional indexer that was given.
+
+    >>> y.compute()
+    [[ 7  6  3  5  2  4  1  8]
+    [15 14 11 13 10 12  9 16]]
+    """
     if np.isnan(x.shape).any():
         raise ValueError(
             f"Shuffling only allowed with known chunk sizes. {unknown_chunk_message}"
         )
+    assert isinstance(axis, int), "axis must be an integer"
+
     token = tokenize(x, indexer, axis)
     out_name = f"shuffle-{token}"
 
@@ -38,7 +88,10 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
             f"Indexer contains out of bounds index. Dimension only has {sum(chunks[axis])} elements."
         )
 
-    average_chunk_size = int(sum(chunks[axis]) / len(chunks[axis]) * 1.25)
+    chunksize_tolerance = config.get("array.shuffle.chunksize-tolerance")
+    average_chunk_size = int(
+        sum(chunks[axis]) / len(chunks[axis]) * chunksize_tolerance
+    )
 
     # Figure out how many groups we can put into one chunk
     current_chunk, new_chunks = [], []

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -25,7 +25,7 @@ def shuffle(x, indexer: list[list[int]], axis):
             f"Axis {axis} is out of bounds for array with {len(x.chunks)} axes"
         )
 
-    if max(map(max, indexer)) >= sum(x.chunks[axis]):
+    if max(map(max, indexer)) >= sum(x.chunks[axis]):  # type: ignore[arg-type]
         raise IndexError(
             f"Indexer contains out of bounds index. Dimension only has {sum(x.chunks[axis])} elements."
         )

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from itertools import count, product
+
+import numpy as np
+import toolz
+
+from dask.array.chunk import getitem
+from dask.array.core import Array, concatenate3
+from dask.base import tokenize
+from dask.highlevelgraph import HighLevelGraph
+
+
+def shuffle(
+    x,
+    indexer: list[list[int]],
+    axis,
+):
+    average_chunk_size = int(sum(x.chunks[axis]) / len(x.chunks[axis]) * 1.25)
+
+    # Figure out how many groups we can put into one chunk
+    current_bucket, buckets = [], []
+    for index in indexer:
+        if (
+            len(current_bucket) + len(index) > average_chunk_size
+            and len(current_bucket) > 0
+        ):
+            buckets.append(current_bucket)
+            current_bucket = index.copy()
+        else:
+            current_bucket.extend(index)
+            if len(current_bucket) > average_chunk_size / 1.25:
+                buckets.append(current_bucket)
+                current_bucket = []
+    if len(current_bucket) > 0:
+        buckets.append(current_bucket)
+
+    chunk_borders = np.cumsum(x.chunks[axis])
+    new_index = list(
+        product(*(range(len(c)) for i, c in enumerate(x.chunks) if i != axis))
+    )
+
+    intermediates = dict()
+    merges = dict()
+    token = tokenize(x, indexer, axis)
+    split_name = f"shuffle-split-{token}"
+    merge_name = f"shuffle-merge-{token}"
+    slices = (slice(None),) * (len(x.chunks) - 1)
+    split_name_suffixes = count()
+
+    old_blocks = np.empty([len(c) for c in x.chunks], dtype="O")
+    for index in np.ndindex(old_blocks.shape):
+        old_blocks[index] = (x.name,) + index
+
+    for final_chunk, bucket in enumerate(buckets):
+        arr = np.array(bucket)
+        sorter = np.argsort(arr)
+        sorted_array = arr[sorter]
+        chunk_nrs, borders = np.unique(
+            np.searchsorted(chunk_borders, sorted_array, side="right"),
+            return_index=True,
+        )
+        borders = borders.tolist()
+        borders.append(len(bucket))
+
+        for nidx in new_index:
+            keys = []
+
+            for i, (c, b_start, b_end) in enumerate(
+                zip(chunk_nrs, borders[:-1], borders[1:])
+            ):
+                key = convert_key(nidx, c, axis)
+                name = (split_name, next(split_name_suffixes))
+                intermediates[name] = (
+                    getitem,
+                    old_blocks[key],
+                    convert_key(
+                        slices,
+                        sorted_array[b_start:b_end]
+                        - (chunk_borders[c - 1] if c > 0 else 0),
+                        axis,
+                    ),
+                )
+                keys.append(name)
+
+            final_suffix = convert_key(nidx, final_chunk, axis)
+            if len(keys) > 1:
+                merges[(merge_name,) + final_suffix] = (
+                    concatenate_arrays,
+                    keys,
+                    sorter,
+                    axis,
+                )
+            elif len(keys) == 1:
+                merges[(merge_name,) + final_suffix] = keys[0]
+            else:
+                raise NotImplementedError
+
+    layer = toolz.merge(merges, intermediates)
+    graph = HighLevelGraph.from_collections(merge_name, layer, dependencies=[x])
+
+    chunks = []
+    for i, c in enumerate(x.chunks):
+        if i == axis:
+            chunks.append(tuple(map(len, buckets)))
+        else:
+            chunks.append(c)
+
+    return Array(graph, merge_name, chunks, meta=x)
+
+
+def concatenate_arrays(arrs, sorter, axis):
+    return np.take(np.concatenate(arrs, axis=axis), np.argsort(sorter), axis=axis)
+
+
+def convert_key(key, chunk, axis):
+    key = list(key)
+    key.insert(axis, chunk)
+    return tuple(key)

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -56,8 +56,8 @@ def shuffle(x, indexer: list[list[int]], axis):
     The array was reordered along axis 1 according to the positional indexer that was given.
 
     >>> y.compute()
-    [[ 7  6  3  5  2  4  1  8]
-    [15 14 11 13 10 12  9 16]]
+    array([[ 7,  6,  3,  5,  2,  4,  1,  8],
+           [15, 14, 11, 13, 10, 12,  9, 16]])
     """
     if np.isnan(x.shape).any():
         raise ValueError(

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -417,7 +417,7 @@ def getitem(obj, index):
 
     """
     try:
-        result = obj[index]
+        result = obj[*index]
     except IndexError as e:
         raise ValueError(
             "Array chunk size or shape is unknown. "

--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -417,7 +417,7 @@ def getitem(obj, index):
 
     """
     try:
-        result = obj[*index]
+        result = obj[index]
     except IndexError as e:
         raise ValueError(
             "Array chunk size or shape is unknown. "

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2767,6 +2767,14 @@ class Array(DaskMethodsMixin):
         indexer: list[list[int]],
         axis,
     ):
+        """Convert blocks in dask array x for new chunks.
+
+        Refer to :func:`dask.array.shuffle` for full documentation.
+
+        See Also
+        --------
+        dask.array.shuffle : equivalent function
+        """
         from dask.array._shuffle import shuffle
 
         return shuffle(self, indexer, axis)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2767,7 +2767,7 @@ class Array(DaskMethodsMixin):
         indexer: list[list[int]],
         axis,
     ):
-        """Convert blocks in dask array x for new chunks.
+        """Reorders one dimensions of a Dask Array based on an indexer.
 
         Refer to :func:`dask.array.shuffle` for full documentation.
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2762,6 +2762,15 @@ class Array(DaskMethodsMixin):
 
         return rechunk(self, chunks, threshold, block_size_limit, balance, method)
 
+    def shuffle(
+        self,
+        indexer: list[list[int]],
+        axis,
+    ):
+        from dask.array._shuffle import shuffle
+
+        return shuffle(self, indexer, axis)
+
     @property
     def real(self):
         from dask.array.ufunc import real

--- a/dask/array/tests/test_shuffle.py
+++ b/dask/array/tests/test_shuffle.py
@@ -36,12 +36,12 @@ def test_shuffle(arr, darr, indexer, chunks):
     assert result.chunks[1] == chunks
 
 
-def test_shuffle_config_tolerance(arr, darr):
+@pytest.mark.parametrize("tol, chunks", ((1, (3, 2, 3)), (1.4, (5, 3))))
+def test_shuffle_config_tolerance(arr, darr, tol, chunks):
     indexer = [[1, 5, 6], [0, 3], [4, 2, 7]]
-    chunks = (3, 2, 3)
-    with dask.config.set({"array.shuffle.chunksize-tolerance": 1}):
+    with dask.config.set({"array.shuffle.chunksize-tolerance": tol}):
         result = darr.shuffle(indexer, axis=1)
-    expected = arr[:, list(flatten(indexer))]
+    expected = arr[:, [1, 5, 6, 0, 3, 4, 2, 7]]
     assert_eq(result, expected)
     assert result.chunks[0] == darr.chunks[0]
     assert result.chunks[1] == chunks

--- a/dask/array/tests/test_shuffle.py
+++ b/dask/array/tests/test_shuffle.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import dask.array as da
+from dask.array import assert_eq
+from dask.core import flatten
+
+
+@pytest.fixture()
+def arr():
+    return np.arange(0, 24).reshape(8, 3).T.copy()
+
+
+@pytest.fixture()
+def darr(arr):
+    return da.from_array(arr, chunks=((2, 1), (4, 4)))
+
+
+@pytest.mark.parametrize(
+    "indexer, chunks",
+    [
+        ([[1, 5, 6], [0, 2, 3, 4, 7]], (3, 5)),
+        ([[1, 5, 6], [0, 3], [4, 2, 7]], (5, 3)),
+        ([[1], [0, 6, 5, 3, 2, 4], [7]], (1, 6, 1)),
+        ([[1, 5, 1, 5, 1, 5], [1, 6, 4, 2, 7]], (6, 5)),
+    ],
+)
+def test_shuffle(arr, darr, indexer, chunks):
+    result = darr.shuffle(indexer, axis=1)
+    expected = arr[:, list(flatten(indexer))]
+    assert_eq(result, expected)
+    assert result.chunks[0] == darr.chunks[0]
+    assert result.chunks[1] == chunks
+
+
+def test_shuffle_larger_array():
+    arr = da.random.random((15, 15, 15), chunks=(5, 5, 5))
+    indexer = np.arange(0, 15)
+    np.random.shuffle(indexer)
+    indexer = [indexer[0:6], indexer[6:8], indexer[8:9], indexer[9:]]
+    indexer = list(map(list, indexer))
+    take_indexer = list(flatten(indexer))
+    assert_eq(arr.shuffle(indexer, axis=1), arr[..., take_indexer, :])
+
+
+def test_incompatible_indexer(darr):
+    with pytest.raises(ValueError, match="indexer must be a list of lists"):
+        darr.shuffle("s", axis=1)
+
+    with pytest.raises(ValueError, match="indexer must be a list of lists"):
+        darr.shuffle([1], axis=1)
+
+
+def test_unknown_chunk_sizes(darr):
+    darr._chunks = ((np.nan, 1), (4, 4))
+    with pytest.raises(
+        ValueError, match="Shuffling only allowed with known chunk sizes"
+    ):
+        darr.shuffle([[1]], axis=1)
+
+
+def test_oob_axis(darr):
+    with pytest.raises(ValueError, match="is out of bounds"):
+        darr.shuffle([[1]], axis=5)
+
+
+def test_oob_indexer(darr):
+    with pytest.raises(IndexError, match="Indexer contains out of bounds index"):
+        darr.shuffle([[16]], axis=1)

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -135,6 +135,17 @@ properties:
               The graph growth factor above which task-based shuffling introduces
               an intermediate step.
 
+      shuffle:
+        type: object
+        properties:
+
+          chunksize-tolerance:
+            type: number
+            description: |
+              Tolerance for the shuffle algorithm when creating output chunks.
+              Default is 1.25. This means that the shuffle algorithm can exceed
+              the average input chunk size along this dimension by 25%.
+
       svg:
         type: object
         properties:

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -142,7 +142,7 @@ properties:
           chunksize-tolerance:
             type: number
             description: |
-              Tolerance for the shuffle algorithm when creating output chunks.
+              Upper tolerance for the shuffle algorithm when creating output chunks.
               Default is 1.25. This means that the shuffle algorithm can exceed
               the average input chunk size along this dimension by 25%.
 

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -24,6 +24,8 @@ array:
   rechunk:
     method: "tasks"  # Rechunking method to use
     threshold: 4
+  shuffle:
+    chunksize-tolerance: 1.25  # Tolerance for the shuffle algorithm when creating output chunks.
   svg:
     size: 120  # pixels
   slicing:

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -207,6 +207,7 @@ Top level functions
    searchsorted
    select
    shape
+   shuffle
    sign
    signbit
    sin
@@ -300,6 +301,7 @@ Array
    Array.reshape
    Array.round
    Array.shape
+   Array.shuffle
    Array.size
    Array.squeeze
    Array.std


### PR DESCRIPTION
- [ ] xref #11257
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

This is a first rough implementation of an array-based shuffle that uses the task implementation. Not polished and probably has a few edge cases that aren't covered yet.

TLDR: We are preserving chunk sizes (roughly) compared to take but we still have a very large graph, which strains the scheduler pretty heavily. Subsequent results are easier to process though in case of a random access pattern because the chunks stay reasonable. An improvement over random access take generally speaking, but still not very good


Let's mess around with a toy example:

```
import dask.array as da

n = 1500
arr = da.random.random((n, n, n), chunks=
(50, 50, 50))
arr
```

<img width="665" alt="Screenshot 2024-07-31 at 11 57 00" src="https://github.com/user-attachments/assets/826d3645-374e-49e9-bb2b-1863e01da591">

Our indexer has a random access pattern (and we access 5 elements at a time, but we could do random stuff here).

```
import numpy as np
from dask.core import flatten

idx = np.arange(0, n)
np.random.shuffle(idx)

indexer = []
for i in range(0, n, 5):
    indexer.append(idx[i:i+5].tolist())
take_indexer = list(flatten(indexer))

indexer
```

```
result = arr.shuffle(indexer, axis=1)
result
```

<img width="734" alt="Screenshot 2024-07-31 at 11 57 21" src="https://github.com/user-attachments/assets/f228e8a4-5b7b-4ac9-9f53-fd767bd9a05e">

Shuffling keeps the number of chunks consistent. Doing the equivalent take blows up the number of chunks

```
expected = arr[slice(None), take_indexer, slice(None)]
expected
```

<img width="662" alt="Screenshot 2024-07-31 at 11 57 35" src="https://github.com/user-attachments/assets/9531dcaf-34f4-4cdb-b9cc-b0faf03adfd8">

The number of tasks are in the same ballpark though, the growth is still exponential in a case of an all to all pattern.

 
<img width="277" alt="Screenshot 2024-07-31 at 11 57 54" src="https://github.com/user-attachments/assets/6c7d399c-ce65-4480-a1b7-db192ee07a0b">


Generating close to a million tasks for a 27k chunks array is not great.