### PR TITLE
Deprecate split-large-chunks option

### DIFF
--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import math
+import warnings
 from functools import reduce
 from itertools import product
 from operator import mul
 
 import numpy as np
 
+from dask import config
 from dask.array.core import Array
 from dask.array.utils import meta_from_array
 from dask.base import tokenize
@@ -245,6 +247,15 @@ def reshape(x, shape, merge_chunks=True, limit=None):
 
     inchunks, outchunks = reshape_rechunk(x.shape, shape, x.chunks)
     x2 = x.rechunk(inchunks)
+
+    if config.get("array.slicing.split-large-chunks", None):
+        warnings.warn(
+            "The 'array.slicing.split-large-chunks' option is deprecated "
+            "and will be removed in a future release. Dask automatically "
+            "handles the chunksizes now.",
+            FutureWarning,
+            stacklevel=2,
+        )
 
     # Construct graph
     in_keys = list(product([x2.name], *[range(len(c)) for c in inchunks]))

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -11,7 +11,7 @@ from operator import itemgetter
 import numpy as np
 from tlz import concat, memoize, merge, pluck
 
-from dask import core
+from dask import config, core
 from dask.array.chunk import getitem
 from dask.base import is_dask_collection, tokenize
 from dask.highlevelgraph import HighLevelGraph
@@ -562,6 +562,15 @@ def take(outname, inname, chunks, index, axis=0):
     dask.config.array.chunk-size, we will split them to avoid
     growing chunksizes.
     """
+
+    if config.get("array.slicing.split-large-chunks", None):
+        warnings.warn(
+            "The 'array.slicing.split-large-chunks' option is deprecated "
+            "and will be removed in a future release. Dask automatically "
+            "handles the chunksizes now.",
+            FutureWarning,
+            stacklevel=2,
+        )
 
     if not np.isnan(chunks[axis]).any():
         from dask.array._shuffle import _shuffle

--- a/dask/array/tests/test_deprecations.py
+++ b/dask/array/tests/test_deprecations.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+import dask
+import dask.array as da
+
+
+def test_split_large_chunks_deprecation():
+    arr = da.random.random((100, 100), chunks=(10, 10))
+    with dask.config.set({"array.slicing.split-large-chunks": True}):
+        with pytest.warns(FutureWarning, match="deprecated"):
+            arr.reshape(10_000)
+        with pytest.warns(FutureWarning, match="deprecated"):
+            da.take(arr, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], axis=0)


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

That would be the places where we can deprecate this option
