### PR TITLE
Prune conda nightlies on release

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -24,9 +24,25 @@ defaults:
     shell: bash -l {0}
 
 jobs:
+  check_tag:
+    runs-on: ubuntu-latest
+    outputs:
+      is_tagged_commit: ${{ steps.check_tag.outputs.is_tagged_commit }}
+    steps:
+      - uses: actions/checkout@v4.1.5
+      - name: Check if the latest commit is tagged
+        id: check_tag
+        run: |
+          if git describe --tags --exact-match HEAD > /dev/null 2>&1; then
+            echo "is_tagged_commit=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_tagged_commit=false" >> $GITHUB_OUTPUT
+          fi
   conda:
     name: Build (and upload)
     runs-on: ubuntu-latest
+    needs: check_tag
+    if: startsWith(github.ref, 'refs/tags/') || needs.check_tag.outputs.is_tagged_commit == 'false'
     steps:
       - uses: actions/checkout@v4.1.5
         with:

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     tags:
-      - "*"
+      - "*.*.*"
   pull_request:
     paths:
       - setup.py
@@ -38,6 +38,15 @@ jobs:
           use-mamba: true
           python-version: 3.9
           channel-priority: strict
+      - name: Remove outdated conda nightlies
+        if: github.event_name == 'push' && github.repository == 'dask/dask' && startsWith(github.ref, 'refs/tags/')
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.DASK_CONDA_TOKEN }}
+        run: |
+          # install anaconda for removal
+          mamba install -c conda-forge anaconda-client
+
+          anaconda remove dask/dask-core --force
       - name: Install dependencies
         run: |
           mamba install -c conda-forge boa conda-verify


### PR DESCRIPTION
Contributes to https://github.com/dask/community/issues/394

This PR makes the following changes to our conda nightly workflow:

- on tag pushes that trigger the workflow, we now run `anaconda remove dask/dask-core` to prune out all existing nightlies prior to uploading a new one
- adds a `check_tag` job, which is used to conditionally skip building/uploading on pushes to `main` that are tagged, since at this point the same workflow should've already been triggered by the tag push itself

