### PR TITLE
Test ordering on distributed scheduler

### DIFF
--- a/dask/order.py
+++ b/dask/order.py
@@ -546,7 +546,6 @@ def order(
 
         # A. Build the critical path
         target = get_target(longest_path=longest_path)
-        next_deps = dependencies[target]
         path_append(target)
 
         if deps_target := dependencies[target]:

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -42,6 +42,8 @@ def order(dsk, *args, **kwargs):
 
     GRAPHS_FOR_DISTRIBUTED.append((inspect.stack()[1][3], dsk))
 
+    assert _order(dsk, *args, **kwargs) == _order(dsk, *args, **kwargs)
+
     return _order(dsk, *args, **kwargs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ xfail_strict = true
 timeout_method = "thread"
 # This should not be reduced; Windows CI has been observed to be occasionally
 # exceptionally slow.
-timeout = 300
+timeout = 3000
 
 [tool.mypy]
 # Silence errors about Python 3.9-style delayed type annotations on Python 3.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ xfail_strict = true
 timeout_method = "thread"
 # This should not be reduced; Windows CI has been observed to be occasionally
 # exceptionally slow.
-timeout = 3000
+timeout = 300
 
 [tool.mypy]
 # Silence errors about Python 3.9-style delayed type annotations on Python 3.8


### PR DESCRIPTION
This introduces a test that ensures that ordering on the distributed scheduler TaskStates is identical to the ordering that is generated by dask.order.

This protects from a regression that was likely introduced in https://github.com/dask/distributed/pull/7564 and fixed in https://github.com/dask/distributed/pull/8818

To allow this kind of test we have to ensure that dask.order is in fact absolutely deterministic. There have been a couple of places where there was some ambiguity. I don't think that resolving this ambiguity will cause any real impact on ordering since those cases should've caused similar but not identical orders.

TODO: benchmark + micro benchmark (I didn't introduce those orderings back in the day for perf reasons so we should double check how bad this is)