### PR TITLE
Implement automatic rechunking for shuffle

### DIFF
--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -107,7 +107,8 @@ def _resize_other_dimensions(
 
         new_chunksizes = []
         # calculate what the max chunk size in this dimension is and split every
-        # chunk that is larger than that
+        # chunk that is larger than that. We split the increase factor evenly
+        # between all dimensions that are not shuffled.
         up_chunksize_limit_for_dim = max(x.chunks[i]) / (
             chunksize_inc_factor ** (1 / (len(x.chunks) - 1))
         )

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -15,7 +15,7 @@ from dask.base import tokenize
 from dask.highlevelgraph import HighLevelGraph
 
 
-def shuffle(x, indexer: list[list[int]], axis, chunks="auto"):
+def shuffle(x, indexer: list[list[int]], axis: int, chunks: Literal["auto"]="auto"):
     """
     Reorders one dimensions of a Dask Array based on an indexer.
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2766,7 +2766,7 @@ class Array(DaskMethodsMixin):
         self,
         indexer: list[list[int]],
         axis: int,
-        chunks: Literal["auto"],
+        chunks: Literal["auto"] = "auto",
     ):
         """Reorders one dimensions of a Dask Array based on an indexer.
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -17,7 +17,7 @@ from itertools import product, zip_longest
 from numbers import Integral, Number
 from operator import add, mul
 from threading import Lock
-from typing import Any, TypeVar, Union, cast
+from typing import Any, Literal, TypeVar, Union, cast
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -2765,7 +2765,8 @@ class Array(DaskMethodsMixin):
     def shuffle(
         self,
         indexer: list[list[int]],
-        axis,
+        axis: int,
+        chunks: Literal["auto"],
     ):
         """Reorders one dimensions of a Dask Array based on an indexer.
 
@@ -2777,7 +2778,7 @@ class Array(DaskMethodsMixin):
         """
         from dask.array._shuffle import shuffle
 
-        return shuffle(self, indexer, axis)
+        return shuffle(self, indexer, axis, chunks)
 
     @property
     def real(self):

--- a/dask/array/tests/test_shuffle.py
+++ b/dask/array/tests/test_shuffle.py
@@ -6,6 +6,7 @@ import pytest
 import dask
 import dask.array as da
 from dask.array import assert_eq, shuffle
+from dask.array._shuffle import _resize_other_dimensions
 from dask.core import flatten
 
 
@@ -20,19 +21,19 @@ def darr(arr):
 
 
 @pytest.mark.parametrize(
-    "indexer, chunks",
+    "indexer, chunks, other_chunks",
     [
-        ([[1, 5, 6], [0, 2, 3, 4, 7]], (3, 5)),
-        ([[1, 5, 6], [0, 3], [4, 2, 7]], (5, 3)),
-        ([[1], [0, 6, 5, 3, 2, 4], [7]], (1, 6, 1)),
-        ([[1, 5, 1, 5, 1, 5], [1, 6, 4, 2, 7]], (6, 5)),
+        ([[1, 5, 6], [0, 2, 3, 4, 7]], (3, 5), (2, 1)),
+        ([[1, 5, 6], [0, 3], [4, 2, 7]], (5, 3), (2, 1)),
+        ([[1], [0, 6, 5, 3, 2, 4], [7]], (1, 6, 1), (1, 1, 1)),
+        ([[1, 5, 1, 5, 1, 5], [1, 6, 4, 2, 7]], (6, 5), (1, 1, 1)),
     ],
 )
-def test_shuffle(arr, darr, indexer, chunks):
+def test_shuffle(arr, darr, indexer, chunks, other_chunks):
     result = darr.shuffle(indexer, axis=1)
     expected = arr[:, list(flatten(indexer))]
     assert_eq(result, expected)
-    assert result.chunks[0] == darr.chunks[0]
+    assert result.chunks[0] == other_chunks
     assert result.chunks[1] == chunks
 
 
@@ -93,4 +94,20 @@ def test_shuffle_no_op_with_correct_indexer():
     ]
     result = arr.shuffle(indexer, axis=0)
     assert result.dask == arr.dask
+    assert_eq(arr, result)
+
+
+def test_resize_other_dimensions():
+    arr = da.random.random((250, 50), chunks=((45, 100, 38, 67), 10))
+    result = _resize_other_dimensions(arr, 20, 1, "auto")
+    assert result.chunks == ((45, 50, 50, 38, 34, 33), (10,) * 5)
+    assert_eq(arr, result)
+
+    arr = da.random.random((250, 50, 20), chunks=((45, 100, 38, 67), 10, 10))
+    result = _resize_other_dimensions(arr, 20, 1, "auto")
+    assert result.chunks == ((45, 50, 50, 38, 67), (10,) * 5, (5,) * 4)
+    assert_eq(arr, result)
+
+    result = _resize_other_dimensions(arr, 40, 1, "auto")
+    assert result.chunks == ((45, 50, 50, 38, 34, 33), (10,) * 5, (5,) * 4)
     assert_eq(arr, result)

--- a/dask/array/tests/test_shuffle.py
+++ b/dask/array/tests/test_shuffle.py
@@ -6,7 +6,7 @@ import pytest
 import dask
 import dask.array as da
 from dask.array import assert_eq, shuffle
-from dask.array._shuffle import _resize_other_dimensions
+from dask.array._shuffle import _rechunk_other_dimensions
 from dask.core import flatten
 
 
@@ -99,20 +99,20 @@ def test_shuffle_no_op_with_correct_indexer():
 
 def test_resize_other_dimensions():
     arr = da.random.random((250, 50), chunks=((45, 100, 38, 67), 10))
-    result = _resize_other_dimensions(arr, 20, 1, "auto")
+    result = _rechunk_other_dimensions(arr, 20, 1, "auto")
     assert result.chunks == ((45, 50, 50, 38, 34, 33), (10,) * 5)
     assert_eq(arr, result)
 
     arr = da.random.random((250, 50, 20), chunks=((45, 100, 38, 67), 10, 10))
-    result = _resize_other_dimensions(arr, 20, 1, "auto")
+    result = _rechunk_other_dimensions(arr, 20, 1, "auto")
     assert result.chunks == ((45, 50, 50, 38, 67), (10,) * 5, (5,) * 4)
     assert_eq(arr, result)
 
-    result = _resize_other_dimensions(arr, 40, 1, "auto")
+    result = _rechunk_other_dimensions(arr, 40, 1, "auto")
     assert result.chunks == ((45, 50, 50, 38, 34, 33), (10,) * 5, (5,) * 4)
     assert_eq(arr, result)
 
     arr = da.random.random((250, 50, 5), chunks=((45, 100, 38, 67), 10, 1))
-    result = _resize_other_dimensions(arr, 40, 1, "auto")
+    result = _rechunk_other_dimensions(arr, 40, 1, "auto")
     assert result.chunks == ((45, 50, 50, 38, 34, 33), (10,) * 5, (1,) * 5)
     assert_eq(arr, result)

--- a/dask/array/tests/test_shuffle.py
+++ b/dask/array/tests/test_shuffle.py
@@ -111,3 +111,8 @@ def test_resize_other_dimensions():
     result = _resize_other_dimensions(arr, 40, 1, "auto")
     assert result.chunks == ((45, 50, 50, 38, 34, 33), (10,) * 5, (5,) * 4)
     assert_eq(arr, result)
+
+    arr = da.random.random((250, 50, 5), chunks=((45, 100, 38, 67), 10, 1))
+    result = _resize_other_dimensions(arr, 40, 1, "auto")
+    assert result.chunks == ((45, 50, 50, 38, 34, 33), (10,) * 5, (1,) * 5)
+    assert_eq(arr, result)


### PR DESCRIPTION
- [ ] Closes #11282
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

This makes the shuffle automatically split the other dimensions by a dynamic factor so that the maximum chunksize stays the same after the shuffle. The implementation ensures that we only split chunks along the other dimensions so that we can avoid different input chunks having to communicate with each other

cc @dcherian is this roughly what you imagined? We can add the option to customise how we split as a follow up