### PR TITLE
Add tests to cover more cases of new reshape implementation

### DIFF
--- a/dask/array/tests/test_rechunk.py
+++ b/dask/array/tests/test_rechunk.py
@@ -1172,3 +1172,22 @@ def test_old_to_new_with_zero():
         [[(0, slice(0, 4))], [(2, slice(0, 0))], [(2, slice(0, 2))], [(2, slice(2, 4))]]
     ]
     assert result == expected
+
+
+def test_rechunk_non_perfect_slicing_of_dimensions():
+    # GH#7859
+    # this matters -- 1060 and 1058 work
+    shape = (200, 100, 1059)
+    final_chunks = (64, 64, 64)
+
+    arr = da.coarsen(
+        da.mean,
+        da.zeros(shape, chunks=(1, -1, -1)),
+        {0: 2, 1: 2, 2: 2},
+        trim_excess=True,
+    )
+    result = arr.rechunk(*final_chunks)
+    assert_eq(arr, result)
+    result_b = arr.rechunk(final_chunks)
+    assert_eq(arr, result)
+    assert result.chunks == result_b.chunks

--- a/dask/array/tests/test_reshape.py
+++ b/dask/array/tests/test_reshape.py
@@ -323,3 +323,10 @@ def test_reshape_split_out_chunks():
         (1, 1, 1, 1),
         (80, 80, 80, 80, 80, 80, 80, 80, 80, 80, 80, 80, 80, 80, 80),
     )
+
+
+def test_argwhere_reshaping_not_concating_chunks():
+    # GH#10080
+    arr = da.random.random((500, 500, 500), chunks=(100, 100, 100)) < 0
+    result = da.argwhere(arr)
+    assert result.chunks == ((np.nan,) * 125, (1, 1, 1))


### PR DESCRIPTION
- [ ] Closes #7859
- [ ] Closes #10080
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

added 2 tests of cases that had weird errors but are fixed now that came up in reshaping discussions