### PR TITLE
Rename chunksize-tolerance option

### DIFF
--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -50,7 +50,7 @@ def shuffle(x, indexer: list[list[int]], axis):
     the number of chunks small.
 
     The tolerance of increasing the chunk size is controlled by the configuration
-    "array.shuffle.chunksize-tolerance". The default value is 1.25.
+    "array.chunksize-tolerance". The default value is 1.25.
 
     >>> y.chunks
     ((2,), (5, 3))
@@ -105,7 +105,7 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
 
     indexer = copy.deepcopy(indexer)
 
-    chunksize_tolerance = config.get("array.shuffle.chunksize-tolerance")
+    chunksize_tolerance = config.get("array.chunksize-tolerance")
     chunk_size_limit = int(sum(chunks[axis]) / len(chunks[axis]) * chunksize_tolerance)
 
     # Figure out how many groups we can put into one chunk

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -94,7 +94,7 @@ def _rechunk_other_dimensions(
     x: Array, longest_group: int, axis: int, chunks: Literal["auto"]
 ) -> Array:
     assert chunks == "auto", "Only auto is supported for now"
-    chunksize_tolerance = config.get("array.shuffle.chunksize-tolerance")
+    chunksize_tolerance = config.get("array.chunksize-tolerance")
 
     if longest_group <= max(x.chunks[axis]) * chunksize_tolerance:
         # We are staying below our threshold, so don't rechunk

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -58,7 +58,7 @@ def shuffle(x, indexer: list[list[int]], axis: int, chunks: Literal["auto"] = "a
     the number of chunks small.
 
     The tolerance of increasing the chunk size is controlled by the configuration
-    "array.chunksize-tolerance". The default value is 1.25.
+    "array.chunk-size-tolerance". The default value is 1.25.
 
     >>> y.chunks
     ((2,), (5, 3))
@@ -94,7 +94,7 @@ def _rechunk_other_dimensions(
     x: Array, longest_group: int, axis: int, chunks: Literal["auto"]
 ) -> Array:
     assert chunks == "auto", "Only auto is supported for now"
-    chunksize_tolerance = config.get("array.chunksize-tolerance")
+    chunksize_tolerance = config.get("array.chunk-size-tolerance")
 
     if longest_group <= max(x.chunks[axis]) * chunksize_tolerance:
         # We are staying below our threshold, so don't rechunk
@@ -167,7 +167,7 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
 
     indexer = copy.deepcopy(indexer)
 
-    chunksize_tolerance = config.get("array.chunksize-tolerance")
+    chunksize_tolerance = config.get("array.chunk-size-tolerance")
     chunk_size_limit = int(sum(chunks[axis]) / len(chunks[axis]) * chunksize_tolerance)
 
     # Figure out how many groups we can put into one chunk

--- a/dask/array/tests/test_shuffle.py
+++ b/dask/array/tests/test_shuffle.py
@@ -40,7 +40,7 @@ def test_shuffle(arr, darr, indexer, chunks, other_chunks):
 @pytest.mark.parametrize("tol, chunks", ((1, (3, 2, 3)), (1.4, (5, 3))))
 def test_shuffle_config_tolerance(arr, darr, tol, chunks):
     indexer = [[1, 5, 6], [0, 3], [4, 2, 7]]
-    with dask.config.set({"array.chunksize-tolerance": tol}):
+    with dask.config.set({"array.chunk-size-tolerance": tol}):
         result = darr.shuffle(indexer, axis=1)
     expected = arr[:, [1, 5, 6, 0, 3, 4, 2, 7]]
     assert_eq(result, expected)

--- a/dask/array/tests/test_shuffle.py
+++ b/dask/array/tests/test_shuffle.py
@@ -39,7 +39,7 @@ def test_shuffle(arr, darr, indexer, chunks):
 @pytest.mark.parametrize("tol, chunks", ((1, (3, 2, 3)), (1.4, (5, 3))))
 def test_shuffle_config_tolerance(arr, darr, tol, chunks):
     indexer = [[1, 5, 6], [0, 3], [4, 2, 7]]
-    with dask.config.set({"array.shuffle.chunksize-tolerance": tol}):
+    with dask.config.set({"array.chunksize-tolerance": tol}):
         result = darr.shuffle(indexer, axis=1)
     expected = arr[:, [1, 5, 6, 0, 3, 4, 2, 7]]
     assert_eq(result, expected)

--- a/dask/config.py
+++ b/dask/config.py
@@ -721,6 +721,7 @@ deprecations: dict[str, str | None] = {
     "dataframe.shuffle.algorithm": "dataframe.shuffle.method",
     "dataframe.shuffle-compression": "dataframe.shuffle.compression",
     "admin.traceback.shorten.what": "admin.traceback.shorten",  # changed in 2023.9.0
+    "array.shuffle.chunksize-tolerance": "array.chunksize-tolerance",
 }
 
 

--- a/dask/config.py
+++ b/dask/config.py
@@ -721,7 +721,7 @@ deprecations: dict[str, str | None] = {
     "dataframe.shuffle.algorithm": "dataframe.shuffle.method",
     "dataframe.shuffle-compression": "dataframe.shuffle.compression",
     "admin.traceback.shorten.what": "admin.traceback.shorten",  # changed in 2023.9.0
-    "array.shuffle.chunksize-tolerance": "array.chunksize-tolerance",
+    "array.shuffle.chunksize-tolerance": "array.chunk-size-tolerance",
 }
 
 

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -119,6 +119,13 @@ properties:
         description: |
           The default chunk size to target. Default is "128MiB".
 
+      chunksize-tolerance:
+        type: number
+        description: |
+          Upper tolerance for different algorithms when creating output chunks.
+          Default is 1.25. This means that the algorithms can exceed
+          the average input chunk size along this dimension by 25%.
+
       rechunk:
         type: object
         properties:
@@ -134,17 +141,6 @@ properties:
             description: |
               The graph growth factor above which task-based shuffling introduces
               an intermediate step.
-
-      shuffle:
-        type: object
-        properties:
-
-          chunksize-tolerance:
-            type: number
-            description: |
-              Upper tolerance for the shuffle algorithm when creating output chunks.
-              Default is 1.25. This means that the shuffle algorithm can exceed
-              the average input chunk size along this dimension by 25%.
 
       svg:
         type: object

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -119,7 +119,7 @@ properties:
         description: |
           The default chunk size to target. Default is "128MiB".
 
-      chunksize-tolerance:
+      chunk-size-tolerance:
         type: number
         description: |
           Upper tolerance for different algorithms when creating output chunks.

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -21,7 +21,7 @@ dataframe:
 array:
   backend: "numpy"  # Backend array library for input IO and data creation
   chunk-size: "128MiB"
-  chunksize-tolerance: 1.25  # Tolerance for different algorithms when creating output chunks.
+  chunk-size-tolerance: 1.25  # Tolerance for different algorithms when creating output chunks.
   rechunk:
     method: "tasks"  # Rechunking method to use
     threshold: 4

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -21,11 +21,10 @@ dataframe:
 array:
   backend: "numpy"  # Backend array library for input IO and data creation
   chunk-size: "128MiB"
+  chunksize-tolerance: 1.25  # Tolerance for different algorithms when creating output chunks.
   rechunk:
     method: "tasks"  # Rechunking method to use
     threshold: 4
-  shuffle:
-    chunksize-tolerance: 1.25  # Tolerance for the shuffle algorithm when creating output chunks.
   svg:
     size: 120  # pixels
   slicing:


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

@dcherian rightfully pointed out that this option is applicable in other areas as well, so removing the shuffle part. I think we should be able to get away with this since it's only been one release?