### PR TITLE
Ensure pickle does not change tokens

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -41,7 +41,7 @@ dependencies:
   - xarray
   - numexpr>=2.8  # Something is pinning it to 2.7
   - sqlalchemy
-  - pyarrow=10
+  - pyarrow
   - coverage
   - jsonschema
   # other -- IO

--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -41,7 +41,7 @@ dependencies:
   - xarray
   - numexpr>=2.8  # Something is pinning it to 2.7
   - sqlalchemy
-  - pyarrow
+  - pyarrow=10
   - coverage
   - jsonschema
   # other -- IO

--- a/continuous_integration/environment-mindeps-array.yaml
+++ b/continuous_integration/environment-mindeps-array.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.10
   - pyyaml=5.4.1
   - click=8.1
-  - cloudpickle=2.0.0
+  - cloudpickle=3.0.0
   - partd=1.4.0
   - fsspec=2021.09.0
   - importlib-metadata=4.13.0

--- a/continuous_integration/environment-mindeps-dataframe.yaml
+++ b/continuous_integration/environment-mindeps-dataframe.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.10
   - pyyaml=5.4.1
   - click=8.1
-  - cloudpickle=2.0.0
+  - cloudpickle=3.0.0
   - partd=1.4.0
   - fsspec=2021.09.0
   - importlib-metadata=4.13.0

--- a/continuous_integration/environment-mindeps-distributed.yaml
+++ b/continuous_integration/environment-mindeps-distributed.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.10
   - pyyaml=5.4.1
   - click=8.1
-  - cloudpickle=2.0.0
+  - cloudpickle=3.0.0
   - partd=1.4.0
   - fsspec=2021.09.0
   - importlib-metadata=4.13.0

--- a/continuous_integration/environment-mindeps-non-optional.yaml
+++ b/continuous_integration/environment-mindeps-non-optional.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.10
   - pyyaml=5.4.1
   - click=8.1
-  - cloudpickle=2.0.0
+  - cloudpickle=3.0.0
   - partd=1.4.0
   - fsspec=2021.09.0
   - importlib-metadata=4.13.0

--- a/continuous_integration/environment-mindeps-optional.yaml
+++ b/continuous_integration/environment-mindeps-optional.yaml
@@ -7,7 +7,7 @@ dependencies:
   - python=3.10
   - pyyaml=5.4.1
   - click=8.1
-  - cloudpickle=2.0.0
+  - cloudpickle=3.0.0
   - partd=1.4.0
   - fsspec=2021.09.0
   - importlib-metadata=4.13.0

--- a/continuous_integration/environment-mindeps-optional.yaml
+++ b/continuous_integration/environment-mindeps-optional.yaml
@@ -19,7 +19,7 @@ dependencies:
   - bokeh=2.4.2
   - jinja2=2.10.3
   # optional dependencies pulled in by pip install dask[complete]
-  - pyarrow=13.0
+  - pyarrow=7.0
   - lz4=4.3.2
   # optional dependencies used by dask
   - cachey=0.1.1

--- a/continuous_integration/environment-mindeps-optional.yaml
+++ b/continuous_integration/environment-mindeps-optional.yaml
@@ -19,7 +19,7 @@ dependencies:
   - bokeh=2.4.2
   - jinja2=2.10.3
   # optional dependencies pulled in by pip install dask[complete]
-  - pyarrow=7.0
+  - pyarrow=13.0
   - lz4=4.3.2
   # optional dependencies used by dask
   - cachey=0.1.1

--- a/dask/_compatibility.py
+++ b/dask/_compatibility.py
@@ -16,6 +16,10 @@ PY_VERSION = Version(".".join(map(str, sys.version_info[:3])))
 
 EMSCRIPTEN = sys.platform == "emscripten"
 
+LINUX = sys.platform == "linux"
+MACOS = sys.platform == "darwin"
+WINDOWS = sys.platform == "win32"
+
 
 def entry_points(group=None):
     warnings.warn(

--- a/dask/base.py
+++ b/dask/base.py
@@ -1421,7 +1421,7 @@ def register_numpy():
 
     @normalize_token.register(np.memmap)
     def normalize_mmap(mm):
-        return normalize_object(mm)
+        return hash_buffer_hex(np.ascontiguousarray(mm))
 
     @normalize_token.register(np.ufunc)
     def normalize_ufunc(func):

--- a/dask/base.py
+++ b/dask/base.py
@@ -1327,7 +1327,10 @@ def register_pandas():
 
     @normalize_token.register(pd.arrays.ArrowExtensionArray)
     def normalize_extension_array(arr):
-        return (type(arr), normalize_token(arr._pa_array))
+        try:
+            return (type(arr), normalize_token(arr._pa_array))
+        except AttributeError:
+            return (type(arr), normalize_token(arr._data))
 
     @normalize_token.register(pd.api.extensions.ExtensionArray)
     def normalize_extension_array(arr):

--- a/dask/base.py
+++ b/dask/base.py
@@ -6,7 +6,6 @@ import datetime
 import decimal
 import hashlib
 import inspect
-import os
 import pathlib
 import pickle
 import types

--- a/dask/dataframe/io/tests/test_io.py
+++ b/dask/dataframe/io/tests/test_io.py
@@ -1034,29 +1034,30 @@ def test_from_map_other_iterables(iterable):
     assert_eq(ddf.compute(), expect)
 
 
-@pytest.mark.xfail(DASK_EXPR_ENABLED, reason="hashing not deterministic")
+class MyFunc:
+    projected: list[str] = []
+
+    def __init__(self, columns=None):
+        self.columns = columns
+
+    def project_columns(self, columns):
+        return MyFunc(columns)
+
+    def __call__(self, t, columns=None):
+        cols = self.columns or columns
+        size = t[0] + 1
+        x = t[1]
+        df = pd.DataFrame({"A": [x] * size, "B": [10] * size})
+        if cols is None:
+            return df
+        MyFunc.projected.extend(cols)
+        return df[cols]
+
+
 def test_from_map_column_projection():
     # Test that column projection works
     # as expected with from_map when
     # enforce_metadata=True
-
-    projected = []
-
-    class MyFunc:
-        def __init__(self, columns=None):
-            self.columns = columns
-
-        def project_columns(self, columns):
-            return MyFunc(columns)
-
-        def __call__(self, t):
-            size = t[0] + 1
-            x = t[1]
-            df = pd.DataFrame({"A": [x] * size, "B": [10] * size})
-            if self.columns is None:
-                return df
-            projected.extend(self.columns)
-            return df[self.columns]
 
     ddf = dd.from_map(
         MyFunc(),
@@ -1072,7 +1073,7 @@ def test_from_map_column_projection():
         index=[0, 0, 1, 0, 1, 2],
     )
     assert_eq(ddf["A"], expect["A"])
-    assert set(projected) == {"A"}
+    assert set(MyFunc.projected) == {"A"}
     assert_eq(ddf, expect)
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import decimal
+import sys
 import warnings
 import weakref
 import xml.etree.ElementTree
@@ -21,6 +22,7 @@ import dask.array as da
 import dask.dataframe as dd
 import dask.dataframe.groupby
 from dask import delayed
+from dask._compatibility import WINDOWS
 from dask.base import compute_as_if_collection
 from dask.blockwise import fuse_roots
 from dask.dataframe import _compat, methods
@@ -635,6 +637,10 @@ def test_describe_for_possibly_unsorted_q():
             assert_eq(r["75%"], 75.0)
 
 
+@pytest.mark.skipif(
+    WINDOWS and sys.version_info < (3, 11),
+    reason="https://github.com/dask/dask/pull/11320#issuecomment-2293798597",
+)
 def test_cumulative():
     index = [f"row{i:03d}" for i in range(100)]
     df = pd.DataFrame(np.random.randn(100, 5), columns=list("abcde"), index=index)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import operator
+import sys
 import warnings
 from datetime import datetime
 from functools import partial
@@ -12,6 +13,7 @@ import pytest
 
 import dask
 import dask.dataframe as dd
+from dask._compatibility import WINDOWS
 from dask.dataframe import _compat
 from dask.dataframe._compat import (
     PANDAS_GE_210,
@@ -1667,6 +1669,10 @@ def test_series_groupby_multi_character_column_name():
     assert_eq(df.groupby("aa").aa.cumsum(), ddf.groupby("aa").aa.cumsum())
 
 
+@pytest.mark.skipif(
+    WINDOWS and sys.version_info < (3, 11),
+    reason="https://github.com/dask/dask/pull/11320#issuecomment-2293798597",
+)
 @pytest.mark.skipif(DASK_EXPR_ENABLED, reason="axis doesn't exist in dask-expr")
 @pytest.mark.parametrize("func", ["cumsum", "cumprod"])
 def test_cumulative_axis(func):
@@ -1850,6 +1856,10 @@ def test_groupby_agg_grouper_multiple(slice_):
     assert_eq(result, expected)
 
 
+@pytest.mark.skipif(
+    WINDOWS and sys.version_info < (3, 11),
+    reason="https://github.com/dask/dask/pull/11320#issuecomment-2293798597",
+)
 @pytest.mark.parametrize(
     "agg_func",
     [
@@ -3586,6 +3596,10 @@ def test_groupby_numeric_only_not_implemented(func, numeric_only):
         getattr(ddf.groupby("A"), func)(**kwargs)
 
 
+@pytest.mark.skipif(
+    WINDOWS and sys.version_info < (3, 11),
+    reason="https://github.com/dask/dask/pull/11320#issuecomment-2293798597",
+)
 @pytest.mark.parametrize(
     "func",
     [

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1643,6 +1643,10 @@ def test_groupby_numeric_column():
     assert_eq(ddf.groupby(ddf.A)[0].sum(), df.groupby(df.A)[0].sum())
 
 
+@pytest.mark.skipif(
+    WINDOWS and sys.version_info < (3, 11),
+    reason="https://github.com/dask/dask/pull/11320#issuecomment-2293798597",
+)
 @pytest.mark.parametrize("sel", ["a", "c", "d", ["a", "b"], ["c", "d"]])
 @pytest.mark.parametrize("key", ["a", ["a", "b"]])
 @pytest.mark.parametrize("func", ["cumsum", "cumprod", "cumcount"])
@@ -1775,6 +1779,10 @@ def test_groupby_string_label():
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.skipif(
+    WINDOWS and sys.version_info < (3, 11),
+    reason="https://github.com/dask/dask/pull/11320#issuecomment-2293798597",
+)
 @pytest.mark.parametrize("op", ["cumsum", "cumprod"])
 def test_groupby_dataframe_cum_caching(op):
     """Test caching behavior of cumulative operations on grouped dataframes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # NOTE: These are tested in `continuous_integration/test_imports.sh` If
     # you modify these, make sure to change the corresponding line there.
     "click >= 8.1",
-    "cloudpickle >= 2.0.0",
+    "cloudpickle >= 3.0.0",
     "fsspec >= 2021.09.0",
     "packaging >= 20.0",
     "partd >= 1.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ diagnostics = [
 delayed = []
 complete = [
     "dask[array,dataframe,distributed,diagnostics]",
-    "pyarrow >= 7.0",
+    "pyarrow >= 13.0",
     # Can be removed once minimal pyarrow version is >14.0.1
     # https://lists.apache.org/thread/yhy7tdfjf9hrl9vfrtzo8p2cyjq87v7n
     "pyarrow_hotfix",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ diagnostics = [
 delayed = []
 complete = [
     "dask[array,dataframe,distributed,diagnostics]",
-    "pyarrow >= 13.0",
+    "pyarrow >= 7.0",
     # Can be removed once minimal pyarrow version is >14.0.1
     # https://lists.apache.org/thread/yhy7tdfjf9hrl9vfrtzo8p2cyjq87v7n
     "pyarrow_hotfix",


### PR DESCRIPTION
So, apparently there is some funky stuff happening inside of pickle that can cause tokens that are derived from cloudpickle to drift.

One example I could track down is `__slotnames__` that is being used as a cache, see https://github.com/python/cpython/blob/9f153a2acf949cee1d70915d5158e91fda991bcf/Lib/copyreg.py#L152

However, I also noticed that loading and restoring an object can cause attributes to change. I haven't found out which (this is a little cumbersome (diffing pickletools output ...))

I added some logic to our tests and indeed a lot of stuff broke. Not only in the vicinity of local objects or dataclasses but also around numpy objects which apparently have a similar problem.

I pulled out a big hammer but I think this is now working as intended although it might be quite slow if we actually have to fall back to pickle (since I'm pickling up to three times). Open to suggestions

closes https://github.com/pydata/xarray/issues/9325