### PR TITLE
Revert "Test ordering on distributed scheduler (#11310)"

### DIFF
--- a/dask/order.py
+++ b/dask/order.py
@@ -137,7 +137,7 @@ def order(
     # way that is simpler to handle
     all_tasks = False
     n_removed_leaves = 0
-    requires_data_task = defaultdict(list)
+    requires_data_task = defaultdict(set)
     while not all_tasks:
         all_tasks = True
         for leaf in list(leaf_nodes):
@@ -174,7 +174,7 @@ def order(
                     dependencies = copy.deepcopy(dependencies)
                 root_nodes.remove(root)
                 for dep in dependents[root]:
-                    requires_data_task[dep].append(root)
+                    requires_data_task[dep].add(root)
                     dependencies[dep].remove(root)
                     if not dependencies[dep]:
                         root_nodes.add(dep)
@@ -254,7 +254,12 @@ def order(
                 processed_roots.add(item)
 
             i += 1
-            for dep in sorted(dependents.get(item, ()), key=sort_key):
+            # Note: This is a `set` and therefore this introduces a certain
+            # randomness. However, this randomness should not have any impact on
+            # the final result since the `process_runnable` should produce
+            # equivalent results regardless of the order in which runnable is
+            # populated (not identical but equivalent)
+            for dep in dependents.get(item, ()):
                 num_needed[dep] -= 1
                 reachable_hull.add(dep)
                 if not num_needed[dep]:
@@ -546,15 +551,14 @@ def order(
 
         # A. Build the critical path
         target = get_target(longest_path=longest_path)
+        next_deps = dependencies[target]
         path_append(target)
 
-        if deps_target := dependencies[target]:
-            next_deps = [max(deps_target, key=sort_key)]
-            while next_deps:
-                item = next_deps[-1]
-                path_append(item)
-                next_deps = sorted(dependencies[item], key=sort_key)
-                path_extend(next_deps)
+        while next_deps:
+            item = max(next_deps, key=sort_key)
+            path_append(item)
+            next_deps = dependencies[item]
+            path_extend(next_deps)
 
         # B. Walk the critical path
 

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import inspect
 
 import pytest
@@ -9,18 +8,8 @@ import dask
 from dask import delayed
 from dask.base import collections_to_dsk, key_split, visualize_dsk
 from dask.core import get_deps
-from dask.order import _connecting_to_roots, diagnostics, ndependencies
+from dask.order import _connecting_to_roots, diagnostics, ndependencies, order
 from dask.utils_test import add, inc
-
-try:
-    import distributed  # noqa: F401
-
-    HAS_DISTRIBUTED = True
-except ImportError:
-    HAS_DISTRIBUTED = False
-
-
-GRAPHS_FOR_DISTRIBUTED = []
 
 
 @pytest.fixture(
@@ -35,16 +24,6 @@ def abcde(request):
 
 def f(*args):
     pass
-
-
-def order(dsk, *args, **kwargs):
-    from dask.order import order as _order
-
-    GRAPHS_FOR_DISTRIBUTED.append((inspect.stack()[1][3], dsk))
-
-    assert _order(dsk, *args, **kwargs) == _order(dsk, *args, **kwargs)
-
-    return _order(dsk, *args, **kwargs)
 
 
 def visualize(dsk, suffix="", **kwargs):
@@ -732,24 +711,18 @@ def test_many_branches_use_ndependencies(abcde):
 
 
 def test_order_cycle():
-    # Note: We're overriding `order` in this module to run some additional tests
-    # and to queue up the graphs for the distributed scheduler test below. We
-    # don't want to run these broken graphs on the scheduler since the test
-    # below is not robust to broken graphs
-    from dask.order import order as _order
-
     with pytest.raises(RuntimeError, match="Cycle detected"):
         dask.get({"a": (f, "a")}, "a")  # we encounter this in `get`
     with pytest.raises(RuntimeError, match="Cycle detected"):
-        _order({"a": (f, "a")})  # trivial self-loop
+        order({"a": (f, "a")})  # trivial self-loop
     with pytest.raises(RuntimeError, match="Cycle detected"):
-        _order({("a", 0): (f, ("a", 0))})  # non-string
+        order({("a", 0): (f, ("a", 0))})  # non-string
     with pytest.raises(RuntimeError, match="Cycle detected"):
-        _order({"a": (f, "b"), "b": (f, "c"), "c": (f, "a")})  # non-trivial loop
+        order({"a": (f, "b"), "b": (f, "c"), "c": (f, "a")})  # non-trivial loop
     with pytest.raises(RuntimeError, match="Cycle detected"):
-        _order({"a": (f, "b"), "b": (f, "c"), "c": (f, "a", "d"), "d": 1})
+        order({"a": (f, "b"), "b": (f, "c"), "c": (f, "a", "d"), "d": 1})
     with pytest.raises(RuntimeError, match="Cycle detected"):
-        _order({"a": (f, "b"), "b": (f, "c"), "c": (f, "a", "d"), "d": (f, "b")})
+        order({"a": (f, "b"), "b": (f, "c"), "c": (f, "a", "d"), "d": (f, "b")})
 
 
 def test_order_empty():
@@ -1990,7 +1963,7 @@ def test_gh_3055_explicit(abcde):
         (c, 0, 0): (f, (b, 0), (a, 2), (a, 1)),
         (d, 0, 0): (f, (c, 0, 1), (c, 0, 0)),
         (d, 0, 1): (f, (c, 0, 1), (c, 0, 0)),
-        ("f", 1, 1): (f, (d, 0, 1)),
+        (f, 1, 1): (f, (d, 0, 1)),
         (c, 1, 0): (f, (b, 1, 0), (b, 1, 2)),
         (c, 0, 2): (f, (b, 0, 0), (b, 0, 1)),
         (e, 0): (f, (c, 1, 0), (c, 0, 2)),
@@ -2499,37 +2472,3 @@ def test_do_not_mutate_input():
     assert_topological_sort(dsk, o)
     assert dsk == dsk_copy
     assert dependencies == dependencies_copy
-
-
-if HAS_DISTRIBUTED:
-    from dask.tests.test_distributed import gen_cluster
-
-    @pytest.mark.slow
-    @gen_cluster(client=True, nthreads=[])
-    async def test_order_on_distributed_cluster(c, s):
-        # Note: For the GRAPHS_FOR_DISTRIBUTED to be populated, the above tests
-        # have to run first
-        for testname, dsk in GRAPHS_FOR_DISTRIBUTED:
-            if not dsk:
-                continue
-
-            while s.tasks:
-                await asyncio.sleep(0.01)
-            _, dependents = get_deps(dsk)
-            output_keys = [k for k, v in dependents.items() if not v]
-            futs = c.get(dsk, output_keys, sync=False)  # noqa: F841
-            while not s.tasks:
-                await asyncio.sleep(0.01)
-            actual = {ts.key: ts.priority for ts in s.tasks.values()}
-            actual_keys = sorted(actual, key=actual.__getitem__)
-
-            expected = dask.order.order(dsk)
-            expected_keys = sorted(expected, key=expected.__getitem__)
-            try:
-                assert actual_keys == expected_keys, (
-                    testname,
-                    actual_keys,
-                    expected_keys,
-                )
-            finally:
-                del futs


### PR DESCRIPTION
This reverts commit b597ebc2177e37fff0930cf67ec86565192d00d7.

There appear to be still lingering problems with determinism. I encountered some failures in https://github.com/dask/dask/pull/11320

I suggest to revert until this is fixed. That PR comes with a performance penalty to make that test happy. if the test is not even working as intended I don't want us to take that hit...
