### PR TITLE
Avoid casting arrow dtypes to numpy object for tokenize

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -1313,6 +1313,10 @@ def register_pandas():
         data = list(mgr.arrays) + [df.columns, df.index]
         return list(map(normalize_token, data))
 
+    @normalize_token.register(pd.arrays.ArrowExtensionArray)
+    def normalize_extension_array(arr):
+        return normalize_token(arr._pa_array)
+
     @normalize_token.register(pd.api.extensions.ExtensionArray)
     def normalize_extension_array(arr):
         import numpy as np


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

```
ser = pd.Series(["a", "b"], dtype="string[pyarrow]")
dser = dd.from_pandas(ser, npartitions=2)
dser.__dask_tokenize__()
```

This casts to object at the moment..