### PR TITLE
Make rechunking in shuffle more intelligent to distribute unevenly if necessary

### DIFF
--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import copy
 import math
+from functools import reduce
 from itertools import count, product
+from operator import mul
 from typing import Literal
 
 import numpy as np
@@ -100,40 +102,50 @@ def _rechunk_other_dimensions(
         # We are staying below our threshold, so don't rechunk
         return x
 
-    # How much the chunksizes on our shuffle axis will increase
-    chunksize_inc_factor = longest_group / max(x.chunks[axis])
+    # How large is the largest chunk in the input
+    maximum_chunk = reduce(mul, map(max, x.chunks))
 
-    new_chunks = []
-    for i in range(len(x.chunks)):
-        if i == axis:
-            new_chunks.append(x.chunks[i])
-            continue
+    changeable_dimensions = set(range(len(x.chunks))) - {axis}
+    new_chunks = list(x.chunks)
+    new_chunks[axis] = (longest_group,)
 
-        new_chunksizes = []
-        # calculate what the max chunk size in this dimension is and split every
-        # chunk that is larger than that. We split the increase factor evenly
-        # between all dimensions that are not shuffled.
-        up_chunksize_limit_for_dim = max(x.chunks[i]) / (
-            chunksize_inc_factor ** (1 / (len(x.chunks) - 1))
-        )
-        for c in x.chunks[i]:
-            if c > chunksize_tolerance * up_chunksize_limit_for_dim:
-                factor = math.ceil(c / up_chunksize_limit_for_dim)
+    while changeable_dimensions:
+        length_changeable_dimensions = len(changeable_dimensions)
+        chunksize_inc_factor = reduce(mul, map(max, new_chunks)) / maximum_chunk  # type: ignore[operator]
+        if chunksize_inc_factor <= 1:
+            break
 
-                # Ensure that we end up at least with chunksize 1
-                factor = min(factor, c)
+        for i in list(changeable_dimensions):
+            new_chunksizes = []
+            # calculate what the max chunk size in this dimension is and split every
+            # chunk that is larger than that. We split the increase factor evenly
+            # between all dimensions that are not shuffled.
+            up_chunksize_limit_for_dim = max(new_chunks[i]) / (
+                chunksize_inc_factor ** (1 / length_changeable_dimensions)
+            )
+            for c in x.chunks[i]:
+                if c > chunksize_tolerance * up_chunksize_limit_for_dim:
+                    factor = math.ceil(c / up_chunksize_limit_for_dim)
 
-                chunksize, remainder = divmod(c, factor)
-                nc = [chunksize] * factor
-                for ii in range(remainder):
-                    # Add remainder parts to the first few chunks
-                    nc[ii] += 1
-                new_chunksizes.extend(nc)
+                    # Ensure that we end up at least with chunksize 1
+                    factor = min(factor, c)
 
-            else:
-                new_chunksizes.append(c)
-        new_chunks.append(tuple(new_chunksizes))
+                    chunksize, remainder = divmod(c, factor)
+                    nc = [chunksize] * factor
+                    for ii in range(remainder):
+                        # Add remainder parts to the first few chunks
+                        nc[ii] += 1
+                    new_chunksizes.extend(nc)
 
+                else:
+                    new_chunksizes.append(c)
+
+            if tuple(new_chunksizes) == new_chunks[i] or max(new_chunksizes) == 1:
+                changeable_dimensions.remove(i)
+
+            new_chunks[i] = tuple(new_chunksizes)
+
+    new_chunks[axis] = x.chunks[axis]
     return x.rechunk(tuple(new_chunks))
 
 

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -109,6 +109,8 @@ def _rechunk_other_dimensions(
     new_chunks = list(x.chunks)
     new_chunks[axis] = (longest_group,)
 
+    # iterate until we distributed the increase in chunksize accross all dimensions
+    # or every non-shuffle dimension is all 1
     while changeable_dimensions:
         length_changeable_dimensions = len(changeable_dimensions)
         chunksize_inc_factor = reduce(mul, map(max, new_chunks)) / maximum_chunk  # type: ignore[operator]

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -112,7 +112,7 @@ def _rechunk_other_dimensions(
     # iterate until we distributed the increase in chunksize accross all dimensions
     # or every non-shuffle dimension is all 1
     while changeable_dimensions:
-        length_changeable_dimensions = len(changeable_dimensions)
+        n_changeable_dimensions = len(changeable_dimensions)
         chunksize_inc_factor = reduce(mul, map(max, new_chunks)) / maximum_chunk  # type: ignore[operator]
         if chunksize_inc_factor <= 1:
             break
@@ -123,7 +123,7 @@ def _rechunk_other_dimensions(
             # chunk that is larger than that. We split the increase factor evenly
             # between all dimensions that are not shuffled.
             up_chunksize_limit_for_dim = max(new_chunks[i]) / (
-                chunksize_inc_factor ** (1 / length_changeable_dimensions)
+                chunksize_inc_factor ** (1 / n_changeable_dimensions)
             )
             for c in x.chunks[i]:
                 if c > chunksize_tolerance * up_chunksize_limit_for_dim:

--- a/dask/array/tests/test_shuffle.py
+++ b/dask/array/tests/test_shuffle.py
@@ -114,5 +114,29 @@ def test_resize_other_dimensions():
 
     arr = da.random.random((250, 50, 5), chunks=((45, 100, 38, 67), 10, 1))
     result = _rechunk_other_dimensions(arr, 40, 1, "auto")
-    assert result.chunks == ((45, 50, 50, 38, 34, 33), (10,) * 5, (1,) * 5)
+    assert result.chunks == (
+        (23, 22, 25, 25, 25, 25, 19, 19, 23, 22, 22),
+        (10,) * 5,
+        (1,) * 5,
+    )
+    assert_eq(arr, result)
+
+    arr = da.random.random((5, 50, 5), chunks=(5, 10, (2, 3)))
+    result = _rechunk_other_dimensions(arr, 100, 1, "auto")
+    assert result.chunks == ((2, 1, 1, 1), (10,) * 5, (1,) * 5)
+    assert_eq(arr, result)
+
+    arr = da.random.random((5, 50, 5), chunks=(5, 10, (2, 3)))
+    result = _rechunk_other_dimensions(arr, 1000, 1, "auto")
+    assert result.chunks == ((1,) * 5, (10,) * 5, (1,) * 5)
+    assert_eq(arr, result)
+
+    arr = da.random.random((5, 50, 5), chunks=(5, 10, (2, 3)))
+    result = _rechunk_other_dimensions(arr, 250, 1, "auto")
+    assert result.chunks == ((1,) * 5, (10,) * 5, (1,) * 5)
+    assert_eq(arr, result)
+
+    arr = da.random.random((2, 1, 2), chunks=(2, 1, 2))
+    result = _rechunk_other_dimensions(arr, 4, 1, "auto")
+    assert result.chunks == ((1, 1), (1,), (1, 1))
     assert_eq(arr, result)


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

cc @hendrikmakait 

I tried computing the factors beforehan, but that was a lot more complicated than this. 