### PR TITLE
Preserve chunksizes in vindex

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5568,7 +5568,7 @@ def _vindex_array(x, dict_indexes):
         + ((remainder,) if remainder > 0 else ())
         if points
         else (0,),
-    )  # WTF???
+    )
     chunks = tuple(chunks)
 
     if points:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -11,6 +11,7 @@ import traceback
 import uuid
 import warnings
 from bisect import bisect
+from collections import defaultdict
 from collections.abc import Collection, Iterable, Iterator, Mapping, Sequence
 from functools import partial, reduce, wraps
 from itertools import product, zip_longest
@@ -5540,20 +5541,38 @@ def _vindex_array(x, dict_indexes):
     token = tokenize(x, flat_indexes)
     out_name = "vindex-merge-" + token
 
+    max_chunk_point_dimensions = reduce(
+        mul, map(max, [c for i, c in zip(flat_indexes, x.chunks) if i is not None])
+    )
+
     points = list()
     for i, idx in enumerate(zip(*[i for i in flat_indexes if i is not None])):
         block_idx = [bisect(b, ind) - 1 for b, ind in zip(bounds2, idx)]
         inblock_idx = [
             ind - bounds2[k][j] for k, (ind, j) in enumerate(zip(idx, block_idx))
         ]
-        points.append((i, tuple(block_idx), tuple(inblock_idx)))
+        points.append(
+            (
+                divmod(i, max_chunk_point_dimensions)[1],
+                tuple(block_idx),
+                tuple(inblock_idx),
+                (i // max_chunk_point_dimensions,) + tuple(block_idx),
+            )
+        )
 
     chunks = [c for i, c in zip(flat_indexes, x.chunks) if i is None]
-    chunks.insert(0, (len(points),) if points else (0,))
+    n_chunks, remainder = divmod(len(points), max_chunk_point_dimensions)
+    chunks.insert(
+        0,
+        (max_chunk_point_dimensions,) * n_chunks
+        + ((remainder,) if remainder > 0 else ())
+        if points
+        else (0,),
+    )  # WTF???
     chunks = tuple(chunks)
 
     if points:
-        per_block = groupby(1, points)
+        per_block = groupby(3, points)
         per_block = {k: v for k, v in per_block.items() if v}
 
         other_blocks = list(
@@ -5571,23 +5590,28 @@ def _vindex_array(x, dict_indexes):
         vindex_merge_name = "vindex-merge-" + token
         dsk = {}
         for okey in other_blocks:
+            merge_inputs = defaultdict(list)
+            merge_indexer = defaultdict(list)
             for i, key in enumerate(per_block):
                 dsk[keyname(name, i, okey)] = (
                     _vindex_transpose,
                     (
                         _vindex_slice,
-                        (x.name,) + interleave_none(okey, key),
+                        (x.name,) + interleave_none(okey, tuple(list(key)[1:])),
                         interleave_none(
                             full_slices, list(zip(*pluck(2, per_block[key])))
                         ),
                     ),
                     axis,
                 )
-            dsk[keyname(vindex_merge_name, 0, okey)] = (
-                _vindex_merge,
-                [list(pluck(0, per_block[key])) for key in per_block],
-                [keyname(name, i, okey) for i in range(len(per_block))],
-            )
+                merge_inputs[key[0]].append(keyname(name, i, okey))
+                merge_indexer[key[0]].append(list(pluck(0, per_block[key])))
+            for i in sorted(merge_inputs.keys()):
+                dsk[keyname(vindex_merge_name, i, okey)] = (
+                    _vindex_merge,
+                    merge_indexer[i],
+                    merge_inputs[i],
+                )
 
         result_1d = Array(
             HighLevelGraph.from_collections(out_name, dsk, dependencies=[x]),

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3088,6 +3088,21 @@ def test_vindex_nd():
     assert_eq(result, x.T)
 
 
+@pytest.mark.parametrize("size", [0, 1])
+def test_vindex_preserve_chunksize(size):
+    np_arr = np.random.rand(10_000 * 40).reshape(100, 100, 40)
+    arr = da.from_array(np_arr, chunks=(50, 50, 20))
+    indices_2d = np.random.choice(np.arange(100), size=(10000 + size, 2))
+    idx1 = indices_2d[:, 0]
+    idx2 = indices_2d[:, 0]
+    result = arr.vindex[idx1, idx2, slice(None)]
+    assert result.chunks == (
+        (2500, 2500, 2500, 2500) + ((1,) if size else ()),
+        (20, 20),
+    )
+    assert_eq(result, np_arr[idx1, idx2, :])
+
+
 def test_vindex_negative():
     x = np.arange(10)
     d = da.from_array(x, chunks=(5, 5))


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

This is mind boggling, it just squashed the whole indexer into a single chunk, no matter how large / small the chunks along these dimensions were previously.

cc @dcherian this seems to be a common path in xarray with sel / isel if I am not missing something

Before:
 
<img width="456" alt="Screenshot 2024-08-19 at 20 23 51" src="https://github.com/user-attachments/assets/d706a685-e158-411a-a8f5-3bb15e36949c">

After:

<img width="456" alt="Screenshot 2024-08-19 at 20 27 20" src="https://github.com/user-attachments/assets/7be74119-7bc1-4454-a977-b564ad5f341c">


```
arr = xr.DataArray(np.random.rand(10_000 * 100).reshape(100, 100, 100), dims=['a', "b", "c"]).chunk(a=5, b=5, c=50)
indices_2d = xr.Variable(('x', 'y'), np.random.choice(np.arange(100), size=(50000, 2)))
arr.isel(a=indices_2d[:, 0], b=indices_2d[:, 0])
```