### PR TITLE
Add ``crick`` back to Python 3.11+ CI builds

### DIFF
--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -49,9 +49,7 @@ dependencies:
   - httpretty
   - aiohttp
   - s3fs>=2021.9.0
-  # Need a new `crick` release with support for `numpy=1.24+`
-  # https://github.com/dask/crick/issues/25
-  # - crick
+  - crick
   - cytoolz
   - distributed
   - ipython

--- a/continuous_integration/environment-3.12.yaml
+++ b/continuous_integration/environment-3.12.yaml
@@ -49,9 +49,7 @@ dependencies:
   - httpretty
   - aiohttp
   - s3fs>=2021.9.0
-  # Need a new `crick` release with support for `numpy=1.24+`
-  # https://github.com/dask/crick/issues/25
-  # - crick
+  - crick
   - cytoolz
   - distributed
   - ipython


### PR DESCRIPTION
`numpy=1.24+` has been added, so we can include `crick` in these CI builds again 