### PR TITLE
Full support for task spec in dask.order

### DIFF
--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -76,6 +76,7 @@ should contain the dependencies of the task.
 """
 import itertools
 import sys
+from collections import defaultdict
 from collections.abc import Callable, Container, Iterable, Mapping, MutableMapping
 from contextlib import contextmanager
 from functools import partial

--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -810,12 +810,8 @@ class Task(GraphNode):
 
 
 class DependenciesMapping(Mapping):
-    def __init__(self, dsk, include_external=True):
+    def __init__(self, dsk):
         self.dsk = dsk
-        self.include_external = include_external
-        if not self.include_external:
-            self._cache = {}
-            self._dsk_set = set(dsk)
 
     def __getitem__(self, key):
         v = self.dsk[key]
@@ -825,26 +821,10 @@ class DependenciesMapping(Mapping):
             deps = get_dependencies(self.dsk, task=self.dsk[key])
         else:
             deps = self.dsk[key].dependencies
-        if not self.include_external:
-            if len(self.dsk) != len(self._dsk_set):
-                self._dsk_set = set(self.dsk)
-                self._cache.clear()
-            try:
-                return self._cache[key]
-            except KeyError:
-                self._cache[key] = deps = deps.intersection(self._dsk_set)
-                return deps
-
         return deps
 
     def __iter__(self):
         return iter(self.dsk)
-
-    def copy(self):
-        return DependenciesMapping(self.dsk)
-
-    def __delitem__(self, key):
-        self.removed_keys.add(key)
 
     def __len__(self) -> int:
         return len(self.dsk)

--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -821,7 +821,9 @@ class DependenciesMapping(Mapping):
         if not isinstance(v, GraphNode):
             from dask.core import get_dependencies
 
-            return get_dependencies(self.dsk, task=self.dsk[key])
+            deps = get_dependencies(self.dsk, task=self.dsk[key])
+        else:
+            deps = self.dsk[key].dependencies
         if not self.include_external:
             if len(self.dsk) != len(self._dsk_set):
                 self._dsk_set = set(self.dsk)
@@ -829,12 +831,10 @@ class DependenciesMapping(Mapping):
             try:
                 return self._cache[key]
             except KeyError:
-                self._cache[key] = rv = self.dsk[key].dependencies.intersection(
-                    self._dsk_set
-                )
-                return rv
+                self._cache[key] = deps = deps.intersection(self._dsk_set)
+                return deps
 
-        return self.dsk[key].dependencies
+        return deps
 
     def __iter__(self):
         return iter(self.dsk)

--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -82,8 +82,6 @@ from contextlib import contextmanager
 from functools import partial
 from typing import Any, TypeVar, cast, overload
 
-from dask.base import tokenize
-from dask.core import reverse_dict
 from dask.sizeof import sizeof
 from dask.typing import Key as KeyType
 from dask.utils import is_namedtuple_instance
@@ -526,6 +524,8 @@ class DataNode(GraphNode):
         return f"DataNode({self.key}, type={self.typ}, {self.value})"
 
     def __dask_tokenize__(self):
+        from dask.base import tokenize
+
         return (type(self).__name__, tokenize(self.value))
 
     def __reduce__(self) -> str | tuple[Any, ...]:
@@ -837,14 +837,6 @@ class DependenciesMapping(MutableMapping):
 
     def __len__(self) -> int:
         return len(self.dsk)
-
-
-def get_deps(dsk):
-    # FIXME: I think we don't need this function
-    assert all(isinstance(v, GraphNode) for v in dsk.values())
-    dependencies = DependenciesMapping(dsk)
-    dependents = reverse_dict(dependencies)
-    return dependencies, dependents
 
 
 class _DevNullMapping(MutableMapping):

--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -809,9 +809,10 @@ class Task(GraphNode):
         return self._is_coro
 
 
-class DependenciesMapping(Mapping):
+class DependenciesMapping(MutableMapping):
     def __init__(self, dsk):
         self.dsk = dsk
+        self._removed = set()
 
     def __getitem__(self, key):
         v = self.dsk[key]
@@ -821,10 +822,18 @@ class DependenciesMapping(Mapping):
             deps = get_dependencies(self.dsk, task=self.dsk[key])
         else:
             deps = self.dsk[key].dependencies
+        if self._removed:
+            deps -= self._removed
         return deps
 
     def __iter__(self):
         return iter(self.dsk)
+
+    def __delitem__(self, key: Any) -> None:
+        self._removed.add(key)
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        raise NotImplementedError
 
     def __len__(self) -> int:
         return len(self.dsk)

--- a/dask/core.py
+++ b/dask/core.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from collections.abc import Collection, Iterable, Mapping
 from typing import Any, Literal, TypeVar, cast, overload
 
+from dask._task_spec import DependenciesMapping
 from dask.typing import Graph, Key, NoDefault, no_default
 
 
@@ -418,7 +419,6 @@ def subs(task, key, val):
 
 
 def _toposort(dsk, keys=None, returncycle=False, dependencies=None):
-    from dask._task_spec import DependenciesMapping
 
     # Stack-based depth-first search traversal.  This is based on Tarjan's
     # method for topological sorting (see wikipedia for pseudocode)
@@ -441,6 +441,7 @@ def _toposort(dsk, keys=None, returncycle=False, dependencies=None):
     seen = set()
 
     if dependencies is None:
+
         dependencies = DependenciesMapping(dsk)
 
     for key in keys:

--- a/dask/core.py
+++ b/dask/core.py
@@ -418,6 +418,8 @@ def subs(task, key, val):
 
 
 def _toposort(dsk, keys=None, returncycle=False, dependencies=None):
+    from dask._task_spec import DependenciesMapping
+
     # Stack-based depth-first search traversal.  This is based on Tarjan's
     # method for topological sorting (see wikipedia for pseudocode)
     if keys is None:
@@ -439,7 +441,7 @@ def _toposort(dsk, keys=None, returncycle=False, dependencies=None):
     seen = set()
 
     if dependencies is None:
-        dependencies = {k: get_dependencies(dsk, k) for k in dsk}
+        dependencies = DependenciesMapping(dsk)
 
     for key in keys:
         if key in completed:

--- a/dask/order.py
+++ b/dask/order.py
@@ -50,6 +50,7 @@ from collections import defaultdict, deque, namedtuple
 from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from typing import Any, Literal, NamedTuple, overload
 
+from dask._task_spec import DataNode, DependenciesMapping
 from dask.core import get_deps, getcycle, istask, reverse_dict
 from dask.typing import Key
 
@@ -104,7 +105,6 @@ def order(
         return {}
 
     dsk = dict(dsk)
-    from dask._task_spec import DataNode, DependenciesMapping
 
     dependencies = DependenciesMapping(dsk)
     dependents = reverse_dict(dependencies)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -15,7 +15,7 @@ from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping, Set
 from contextlib import contextmanager, nullcontext, suppress
 from datetime import datetime, timedelta
 from errno import ENOENT
-from functools import lru_cache, wraps
+from functools import wraps
 from importlib import import_module
 from numbers import Integral, Number
 from operator import add
@@ -26,7 +26,6 @@ from weakref import WeakValueDictionary
 import tlz as toolz
 
 from dask import config
-from dask.core import get_deps
 from dask.typing import no_default
 
 K = TypeVar("K")
@@ -1159,20 +1158,6 @@ def insert(tup, loc, val):
     L = list(tup)
     L[loc] = val
     return tuple(L)
-
-
-def dependency_depth(dsk):
-    deps, _ = get_deps(dsk)
-
-    @lru_cache(maxsize=None)
-    def max_depth_by_deps(key):
-        if not deps[key]:
-            return 1
-
-        d = 1 + max(max_depth_by_deps(dep_key) for dep_key in deps[key])
-        return d
-
-    return max(max_depth_by_deps(dep_key) for dep_key in deps.keys())
 
 
 def memory_repr(num):


### PR DESCRIPTION
This builds on https://github.com/dask/distributed/pull/8797

The relevant commit is https://github.com/dask/dask/commit/b2ee43efaf6f0f847cf4e9ec27fe222c7b10ff5e

It allows dask.order to fully benefit from the task_spec implementation and removes the need to recompute the dependencies of a given graph. This dependency computation is one of the driving runtime cost (particularly since it's been done multiple times).

It also removes a quite bad code path where we previously triggered a deepcopy which was very expensive (for very large graphs)


Sibling PR that enables this in distributed https://github.com/dask/distributed/pull/8842

This PR _should_ work without the distributed change but not the other way round