### PR TITLE
Update zoom link for dask meeting

### DIFF
--- a/docs/source/support.rst
+++ b/docs/source/support.rst
@@ -17,7 +17,7 @@ Community Meeting
     We've combined the monthly Dask Demo Day and Dask Developer Meeting into a single, monthly Dask community meeting.
 
 Join us for the monthly community meetings on the first Thursday of the month at
-10:00 US Central Time. `Join via Zoom <https://us06web.zoom.us/j/89383035703?pwd=WkRJSzNnRTh4T2R1ZjJuVVdJWlMxQT09>`__.
+10:00 US Central Time. `Join via Zoom <https://dask.org/meeting-room>`__.
 
 Have something you'd like to share? Let us know by dropping a comment on `this GitHub issue <https://github.com/dask/community/issues/307>`__.
 


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

cc @jacobtomlinson @jrbourbeau 

Ok, changing this (hopefully) one last time. I've set up https://dask.org/meeting-room to redirect to the actual zoom so we don't have to keep changing links if/when Zoom ownership changes happen in the future: https://us06web.zoom.us/j/89143118706?pwd=vpJgdF2YY5rwMEL8VxyXN5UHIbSqHe.1

I've also updated https://docs.google.com/document/d/1UqNAP87a56ERH_xkQsS5Q_0PKYybd5Lj2WANy_hRzI0/edit + https://github.com/dask/community/issues/307#issue-1587938315



