### PR TITLE
Cast indexer to minimal dtype in shuffle

### DIFF
--- a/dask/array/tests/test_shuffle.py
+++ b/dask/array/tests/test_shuffle.py
@@ -140,3 +140,15 @@ def test_resize_other_dimensions():
     result = _rechunk_other_dimensions(arr, 4, 1, "auto")
     assert result.chunks == ((1, 1), (1,), (1, 1))
     assert_eq(arr, result)
+
+
+def test_dtype_taker(arr, darr):
+    indexer = [[1, 5, 6], [0, 3], [4, 2, 7]]
+    result = darr.shuffle(indexer, axis=1)
+    expected = arr[:, [1, 5, 6, 0, 3, 4, 2, 7]]
+    assert_eq(result, expected)
+    assert all(
+        v[1].dtype == np.uint8
+        for k, v in dict(result.dask).items()
+        if "array-taker" in k
+    )


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

from 55MiB to 21MiB:

```

arr = da.ones((3_000_000, 16, 16), chunks=(10_000, 16, 16))
arr = arr.persist()

indexer = np.arange(3_000_000)
np.random.shuffle(indexer)

result = arr[indexer, :, :]
result.persist()
```