### PR TITLE
Ensure process_runnables is not too eager in the presence of multiple splits

### DIFF
--- a/dask/order.py
+++ b/dask/order.py
@@ -318,9 +318,10 @@ def order(
                     add_to_result(key)
                     continue
                 path = [key]
-                branches = deque([path])
+                branches = deque([(0, path)])
+
                 while branches:
-                    path = branches.popleft()
+                    nsplits, path = branches.popleft()
                     while True:
                         # Loop invariant. Too expensive to compute at runtime
                         # assert not set(known_runnable_paths).intersection(runnable_hull)
@@ -339,6 +340,7 @@ def order(
                                 runnable_hull.discard(current)
                         elif len(path) == 1 or len(deps_upstream) == 1:
                             if len(deps_downstream) > 1:
+                                nsplits += 1
                                 for d in sorted(deps_downstream, key=sort_key):
                                     # This ensures we're only considering splitters
                                     # that are genuinely splitting and not
@@ -346,7 +348,7 @@ def order(
                                     if len(dependencies[d]) == 1:  # type: ignore
                                         branch = path.copy()
                                         branch.append(d)
-                                        branches.append(branch)
+                                        branches.append((nsplits, branch))
                                 break
                             path.extend(deps_downstream)
                             continue
@@ -366,6 +368,13 @@ def order(
                                         pruned_branches
                                     )
                                 else:
+                                    if nsplits > 1:
+                                        path = []
+                                        for pruned in pruned_branches:
+                                            path.extend(pruned)
+                                        branches.append((nsplits - 1, path))
+                                        break
+
                                     while pruned_branches:
                                         path = pruned_branches.popleft()
                                         for k in path:

--- a/dask/tests/test_order.py
+++ b/dask/tests/test_order.py
@@ -2472,3 +2472,101 @@ def test_do_not_mutate_input():
     assert_topological_sort(dsk, o)
     assert dsk == dsk_copy
     assert dependencies == dependencies_copy
+
+
+def test_stackstac():
+    # see https://github.com/dask/dask/issues/11363
+    # and https://github.com/dask/dask/pull/11367
+    final_keys = [
+        ("transpose-9c80c6b26d7ef5cfec7274ee9e6b091e", 0, 0, 0),
+        ("transpose-9c80c6b26d7ef5cfec7274ee9e6b091e", 0, 1, 0),
+    ]
+    dsk = {
+        ("transpose-9c80c6b26d7ef5cfec7274ee9e6b091e", 0, 0, 0): (
+            f,
+            ("vindex-merge", 0, 0, 0),
+        ),
+        ("transpose-9c80c6b26d7ef5cfec7274ee9e6b091e", 0, 1, 0): (
+            f,
+            ("vindex-merge", 0, 1, 0),
+        ),
+        ("vindex-merge", 0, 0, 0): (
+            f,
+            ("vindex-slice", 0, 0, 0),
+            ("vindex-slice", 1, 0, 0),
+            ("vindex-slice", 2, 0, 0),
+            ("vindex-slice", 3, 0, 0),
+        ),
+        ("vindex-slice", 2, 0, 0): (f, ("getitem-vindex", 2, 0, 0)),
+        ("vindex-merge", 0, 1, 0): (
+            f,
+            ("vindex-slice", 0, 0, 1),
+            ("vindex-slice", 1, 0, 1),
+            ("vindex-slice", 2, 0, 1),
+            ("vindex-slice", 3, 0, 1),
+        ),
+        ("vindex-slice", 2, 0, 1): (f, ("getitem-vindex", 2, 0, 1)),
+        ("vindex-slice", 1, 0, 0): (f, ("getitem-vindex", 1, 0, 0)),
+        ("getitem-vindex", 2, 0, 1): (
+            f,
+            ("shuffle-split", 321),
+            ("shuffle-split", 322),
+        ),
+        ("vindex-slice", 3, 0, 1): (f, ("getitem-vindex", 3, 0, 1)),
+        ("vindex-slice", 0, 0, 1): (f, ("getitem-vindex", 0, 0, 1)),
+        ("getitem-vindex", 3, 0, 1): (
+            f,
+            ("shuffle-split", 299),
+            ("shuffle-split", 300),
+        ),
+        ("getitem-vindex", 2, 0, 0): (f, ("concatenate", 0, 1, 9, 1)),
+        ("vindex-slice", 3, 0, 0): (f, ("getitem-vindex", 3, 0, 0)),
+        ("shuffle-split", 322): (f, ("concatenate", 0, 1, 9, 1)),
+        ("vindex-slice", 0, 0, 0): (f, ("getitem-vindex", 0, 0, 0)),
+        ("getitem-vindex", 0, 0, 1): (
+            f,
+            ("shuffle-split", 341),
+            ("shuffle-split", 342),
+        ),
+        ("vindex-slice", 1, 0, 1): (f, ("getitem-vindex", 1, 0, 1)),
+        ("shuffle-split", 321): (f, ("concatenate-getitem", 321)),
+        ("shuffle-split", 299): (f, ("concatenate-getitem", 299)),
+        ("getitem-vindex", 3, 0, 0): (f, ("concatenate", 0, 1, 8, 1)),
+        ("getitem-vindex", 0, 0, 0): (f, ("concatenate", 0, 1, 10, 0)),
+        ("getitem-vindex", 1, 0, 0): (f, ("concatenate", 0, 1, 9, 0)),
+        ("concatenate-getitem", 299): (f, ("fetch-raster", 0, 0, 8, 1)),
+        ("concatenate", 0, 1, 9, 1): (f, ("getitem-sub", 0, 1, 9, 1)),
+        ("concatenate-getitem", 321): (f, ("fetch-raster", 0, 0, 9, 1)),
+        ("fetch-raster", 0, 0, 8, 1): (f, ("asset_table", 0, 0)),
+        ("concatenate", 0, 1, 8, 1): (f, ("getitem-sub", 0, 1, 8, 1)),
+        ("fetch-raster", 0, 0, 9, 1): (f, ("asset_table", 0, 0)),
+        ("concatenate", 0, 1, 9, 0): (f, ("getitem-sub", 0, 1, 9, 0)),
+        ("shuffle-split", 300): (f, ("concatenate", 0, 1, 8, 1)),
+        ("concatenate", 0, 1, 10, 0): (f, ("getitem-sub", 0, 1, 10, 0)),
+        ("asset_table", 0, 0): (f, ("asset-table-data", 0, 0)),
+        ("shuffle-split", 342): (f, ("concatenate", 0, 1, 10, 0)),
+        ("getitem-vindex", 1, 0, 1): (
+            f,
+            ("shuffle-split", 319),
+            ("shuffle-split", 320),
+        ),
+        ("getitem-sub", 0, 1, 10, 0): (f, ("fetch-raster", 0, 0, 10, 0)),
+        ("getitem-sub", 0, 1, 8, 1): (f, ("fetch-raster", 0, 0, 8, 1)),
+        ("shuffle-split", 341): (f, ("concatenate-getitem", 341)),
+        ("getitem-sub", 0, 1, 9, 1): (f, ("fetch-raster", 0, 0, 9, 1)),
+        ("concatenate-getitem", 341): (f, ("fetch-raster", 0, 0, 10, 0)),
+        ("asset-table-data", 0, 0): (f,),
+        ("getitem-sub", 0, 1, 9, 0): (f, ("fetch-raster", 0, 0, 9, 0)),
+        ("fetch-raster", 0, 0, 10, 0): (f, ("asset_table", 0, 0)),
+        ("shuffle-split", 320): (f, ("concatenate", 0, 1, 9, 0)),
+        ("shuffle-split", 319): (f, ("concatenate-getitem", 319)),
+        ("fetch-raster", 0, 0, 9, 0): (f, ("asset_table", 0, 0)),
+        ("concatenate-getitem", 319): (f, ("fetch-raster", 0, 0, 9, 0)),
+    }
+    o = order(dsk, return_stats=True)
+    _, pressure = diagnostics(dsk)
+    assert max(pressure) <= 9, pressure
+    for k in final_keys:
+        # Ensure that we're not processing the entire graph using
+        # process_runnables (fractional values) but are using the critical path
+        assert o[k].critical_path in {1, 2}


### PR DESCRIPTION
Well, this isn't fixing anything visible yet but it fixes an internal branch of the algorithm that's been acting too eagerly. I'm still working on a test.

This relates to https://github.com/dask/dask/issues/11363

CPath before

![image](https://github.com/user-attachments/assets/d0efa935-3453-41b2-9ae1-58cd8adf045c)


After

![image](https://github.com/user-attachments/assets/bd3846c1-cf13-4e60-94f2-e0d4d46ba6da)

So, the initial version would start executing along the critical path until it hits the first wall. After this, it would try to process runnable tasks as good as possible. Since the root task is shared by all branches, this allows all computation branches to be considered as candidates (this is the essential dilemma of the widely shared dependencies).
Following these candidates effectively causes a depth first search. However, if we do not process them at all, this typically leaves many intermediates in memory we could otherwise release. Therefore, to allow some progress, these runnable paths are allowed to execute if they are reducing to a task, i.e. we're speculatively walking down those branches and if those speculatively executed branches reduce into a task, they are allowed to execute for real. 

What happens here is that those executable branches encounter multiple splits (we're following splits as well since they often allow us to reduce stuff). After the second split we're actually finding an intermediate reducer... This is where the algorithm on main decided to go with it. However, this leaves us still with one more task in memory than if we didn't execute that branch which is a suboptimal decision. Only if all those splits reduce, we should execute the branch.

In the case of this specific example this doesn't change anything but I believe this makes the algorithm more predictable.


<details>
<summary>Simplified graph</summary>

```python
dsk = {
        ("transpose-9c80c6b26d7ef5cfec7274ee9e6b091e", 0, 0, 0): (
            f,
            ("vindex-merge", 0, 0, 0),
        ),
        ("transpose-9c80c6b26d7ef5cfec7274ee9e6b091e", 0, 1, 0): (
            f,
            ("vindex-merge", 0, 1, 0),
        ),
        ("vindex-merge", 0, 0, 0): (
            f,
            ("vindex-slice", 0, 0, 0),
            ("vindex-slice", 1, 0, 0),
            ("vindex-slice", 2, 0, 0),
            ("vindex-slice", 3, 0, 0),
        ),
        ("vindex-slice", 2, 0, 0): (f, ("getitem-vindex", 2, 0, 0)),
        ("vindex-merge", 0, 1, 0): (
            f,
            ("vindex-slice", 0, 0, 1),
            ("vindex-slice", 1, 0, 1),
            ("vindex-slice", 2, 0, 1),
            ("vindex-slice", 3, 0, 1),
        ),
        ("vindex-slice", 2, 0, 1): (f, ("getitem-vindex", 2, 0, 1)),
        ("vindex-slice", 1, 0, 0): (f, ("getitem-vindex", 1, 0, 0)),
        ("getitem-vindex", 2, 0, 1): (
            f,
            ("shuffle-split", 321),
            ("shuffle-split", 322),
        ),
        ("vindex-slice", 3, 0, 1): (f, ("getitem-vindex", 3, 0, 1)),
        ("vindex-slice", 0, 0, 1): (f, ("getitem-vindex", 0, 0, 1)),
        ("getitem-vindex", 3, 0, 1): (
            f,
            ("shuffle-split", 299),
            ("shuffle-split", 300),
        ),
        ("getitem-vindex", 2, 0, 0): (f, ("concatenate", 0, 1, 9, 1)),
        ("vindex-slice", 3, 0, 0): (f, ("getitem-vindex", 3, 0, 0)),
        ("shuffle-split", 322): (f, ("concatenate", 0, 1, 9, 1)),
        ("vindex-slice", 0, 0, 0): (f, ("getitem-vindex", 0, 0, 0)),
        ("getitem-vindex", 0, 0, 1): (
            f,
            ("shuffle-split", 341),
            ("shuffle-split", 342),
        ),
        ("vindex-slice", 1, 0, 1): (f, ("getitem-vindex", 1, 0, 1)),
        ("shuffle-split", 321): (f, ("concatenate-getitem", 321)),
        ("shuffle-split", 299): (f, ("concatenate-getitem", 299)),
        ("getitem-vindex", 3, 0, 0): (f, ("concatenate", 0, 1, 8, 1)),
        ("getitem-vindex", 0, 0, 0): (f, ("concatenate", 0, 1, 10, 0)),
        ("getitem-vindex", 1, 0, 0): (f, ("concatenate", 0, 1, 9, 0)),
        ("concatenate-getitem", 299): (f, ("fetch-raster", 0, 0, 8, 1)),
        ("concatenate", 0, 1, 9, 1): (f, ("getitem-sub", 0, 1, 9, 1)),
        ("concatenate-getitem", 321): (f, ("fetch-raster", 0, 0, 9, 1)),
        ("fetch-raster", 0, 0, 8, 1): (f, ("asset_table", 0, 0)),
        ("concatenate", 0, 1, 8, 1): (f, ("getitem-sub", 0, 1, 8, 1)),
        ("fetch-raster", 0, 0, 9, 1): (f, ("asset_table", 0, 0)),
        ("concatenate", 0, 1, 9, 0): (f, ("getitem-sub", 0, 1, 9, 0)),
        ("shuffle-split", 300): (f, ("concatenate", 0, 1, 8, 1)),
        ("concatenate", 0, 1, 10, 0): (f, ("getitem-sub", 0, 1, 10, 0)),
        ("asset_table", 0, 0): (f, ("asset-table-data", 0, 0)),
        ("shuffle-split", 342): (f, ("concatenate", 0, 1, 10, 0)),
        ("getitem-vindex", 1, 0, 1): (
            f,
            ("shuffle-split", 319),
            ("shuffle-split", 320),
        ),
        ("getitem-sub", 0, 1, 10, 0): (f, ("fetch-raster", 0, 0, 10, 0)),
        ("getitem-sub", 0, 1, 8, 1): (f, ("fetch-raster", 0, 0, 8, 1)),
        ("shuffle-split", 341): (f, ("concatenate-getitem", 341)),
        ("getitem-sub", 0, 1, 9, 1): (f, ("fetch-raster", 0, 0, 9, 1)),
        ("concatenate-getitem", 341): (f, ("fetch-raster", 0, 0, 10, 0)),
        ("asset-table-data", 0, 0): (f,),
        ("getitem-sub", 0, 1, 9, 0): (f, ("fetch-raster", 0, 0, 9, 0)),
        ("fetch-raster", 0, 0, 10, 0): (f, ("asset_table", 0, 0)),
        ("shuffle-split", 320): (f, ("concatenate", 0, 1, 9, 0)),
        ("shuffle-split", 319): (f, ("concatenate-getitem", 319)),
        ("fetch-raster", 0, 0, 9, 0): (f, ("asset_table", 0, 0)),
        ("concatenate-getitem", 319): (f, ("fetch-raster", 0, 0, 9, 0)),
    }
```
</details>