### PR TITLE
Use TaskSpec in local dask execution

### DIFF
--- a/dask/core.py
+++ b/dask/core.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Collection, Iterable, Mapping
+from collections.abc import Collection, Iterable, Mapping, MutableMapping
 from typing import Any, Literal, TypeVar, cast, overload
 
 from dask._task_spec import DependenciesMapping
@@ -53,28 +53,6 @@ def istask(x):
     return type(x) is tuple and x and callable(x[0])
 
 
-def has_tasks(dsk, x):
-    """Whether ``x`` has anything to compute.
-
-    Returns True if:
-    - ``x`` is a task
-    - ``x`` is a key in ``dsk``
-    - ``x`` is a list that contains any tasks or keys
-    """
-    if istask(x):
-        return True
-    try:
-        if x in dsk:
-            return True
-    except Exception:
-        pass
-    if isinstance(x, list):
-        for i in x:
-            if has_tasks(dsk, i):
-                return True
-    return False
-
-
 def preorder_traversal(task):
     """A generator to preorder-traverse a task."""
 
@@ -94,53 +72,13 @@ def lists_to_tuples(res, keys):
     return res
 
 
-def _execute_task(arg, cache, dsk=None):
-    """Do the actual work of collecting data and executing a function
-
-    Examples
-    --------
-
-    >>> inc = lambda x: x + 1
-    >>> add = lambda x, y: x + y
-    >>> cache = {'x': 1, 'y': 2}
-
-    Compute tasks against a cache
-    >>> _execute_task((add, 'x', 1), cache)  # Compute task in naive manner
-    2
-    >>> _execute_task((add, (inc, 'x'), 1), cache)  # Support nested computation
-    3
-
-    Also grab data from cache
-    >>> _execute_task('x', cache)
-    1
-
-    Support nested lists
-    >>> list(_execute_task(['x', 'y'], cache))
-    [1, 2]
-
-    >>> list(map(list, _execute_task([['x', 'y'], ['y', 'x']], cache)))
-    [[1, 2], [2, 1]]
-
-    >>> _execute_task('foo', cache)  # Passes through on non-keys
-    'foo'
-    """
-    if isinstance(arg, list):
-        return [_execute_task(a, cache) for a in arg]
-    elif istask(arg):
-        func, args = arg[0], arg[1:]
-        # Note: Don't assign the subtask results to a variable. numpy detects
-        # temporaries by their reference count and can execute certain
-        # operations in-place.
-        return func(*(_execute_task(a, cache) for a in args))
-    elif not ishashable(arg):
-        return arg
-    elif arg in cache:
-        return cache[arg]
-    else:
-        return arg
+def _pack_result(result: Mapping, keys: list | Key) -> Any:
+    if isinstance(keys, list):
+        return tuple(_pack_result(result, k) for k in keys)
+    return result[keys]
 
 
-def get(dsk, out, cache=None):
+def get(dsk: Mapping, out: list | Key, cache: MutableMapping | None = None) -> Any:
     """Get value from Dask
 
     Examples
@@ -154,19 +92,16 @@ def get(dsk, out, cache=None):
     >>> get(d, 'y')
     2
     """
-    for k in flatten(out) if isinstance(out, list) else [out]:
+    for k in flatten(out):
         if k not in dsk:
             raise KeyError(f"{k} is not a key in the graph")
     if cache is None:
         cache = {}
-    for key in toposort(dsk):
-        task = dsk[key]
-        result = _execute_task(task, cache)
-        cache[key] = result
-    result = _execute_task(out, cache)
-    if isinstance(out, list):
-        result = lists_to_tuples(result, out)
-    return result
+    from dask._task_spec import convert_legacy_graph, execute_graph
+
+    dsk2 = convert_legacy_graph(dsk, all_keys=set(dsk) | set(cache))
+    result = execute_graph(dsk2, cache, keys=set(flatten([out])))
+    return _pack_result(result, out)
 
 
 def keys_in_tasks(keys: Collection[Key], tasks: Iterable[Any], as_list: bool = False):

--- a/dask/core.py
+++ b/dask/core.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from collections.abc import Collection, Iterable, Mapping, MutableMapping
 from typing import Any, Literal, TypeVar, cast, overload
 
-from dask._task_spec import DependenciesMapping
+from dask._task_spec import DependenciesMapping, convert_legacy_graph, execute_graph
 from dask.typing import Graph, Key, NoDefault, no_default
 
 
@@ -97,7 +97,6 @@ def get(dsk: Mapping, out: list | Key, cache: MutableMapping | None = None) -> A
             raise KeyError(f"{k} is not a key in the graph")
     if cache is None:
         cache = {}
-    from dask._task_spec import convert_legacy_graph, execute_graph
 
     dsk2 = convert_legacy_graph(dsk, all_keys=set(dsk) | set(cache))
     result = execute_graph(dsk2, cache, keys=set(flatten([out])))

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -51,6 +51,7 @@ admin:
       - dask[\\\/](base|core|local|multiprocessing|optimization|threaded|utils)\.py
       - dask[\\\/]array[\\\/]core\.py
       - dask[\\\/]dataframe[\\\/](core|methods)\.py
+      - dask[\\\/]_task_spec\.py
       - distributed[\\\/](client|scheduler|utils|worker)\.py
       - tornado[\\\/]gen\.py
       - pandas[\\\/]core[\\\/]

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -12,7 +12,7 @@ from dask._task_spec import Task
 from dask.diagnostics import CacheProfiler, Profiler, ResourceProfiler
 from dask.diagnostics.profile_visualize import BOKEH_VERSION
 from dask.threaded import get
-from dask.utils import apply, tmpfile
+from dask.utils import tmpfile
 from dask.utils_test import slowadd
 
 try:
@@ -192,38 +192,6 @@ def test_unquote():
     t = [1, 2, 3]
     task_dask = [1, 2, 3]
     assert unquote(task_dask) == t
-
-
-@pytest.mark.skipif("not bokeh")
-def test_pprint_task():
-    from dask.diagnostics.profile_visualize import pprint_task
-
-    keys = {"a", "b", "c", "d", "e"}
-    assert pprint_task((add, "a", 1), keys) == "add(_, *)"
-    assert pprint_task((add, (add, "a", 1)), keys) == "add(add(_, *))"
-    res = "sum([*, _, add(_, *)])"
-    assert pprint_task((sum, [1, "b", (add, "a", 1)]), keys) == res
-    assert pprint_task((sum, (1, 2, 3, 4, 5, 6, 7)), keys) == "sum(*)"
-
-    assert len(pprint_task((sum, list(keys) * 100), keys)) < 100
-    assert pprint_task((sum, list(keys) * 100), keys) == "sum([_, _, _, ...])"
-    assert (
-        pprint_task((sum, [1, 2, (sum, ["a", 4]), 5, 6] * 100), keys)
-        == "sum([*, *, sum([_, *]), ...])"
-    )
-    assert (
-        pprint_task((sum, [1, 2, (sum, ["a", (sum, [1, 2, 3])]), 5, 6]), keys)
-        == "sum([*, *, sum([_, sum(...)]), ...])"
-    )
-
-    # With kwargs
-    def foo(w, x, y=(), z=3):
-        return w + x + sum(y) + z
-
-    task = (apply, foo, (tuple, ["a", "b"]), (dict, [["y", ["a", "b"]], ["z", "c"]]))
-    assert pprint_task(task, keys) == "foo(_, _, y=[_, _], z=_)"
-    task = (apply, foo, (tuple, ["a", "b"]), (dict, [["y", ["a", 1]], ["z", 1]]))
-    assert pprint_task(task, keys) == "foo(_, _, y=[_, *], z=*)"
 
 
 @pytest.mark.skipif("not bokeh")

--- a/dask/diagnostics/tests/test_profiler.py
+++ b/dask/diagnostics/tests/test_profiler.py
@@ -8,6 +8,7 @@ from timeit import default_timer
 
 import pytest
 
+from dask._task_spec import Task
 from dask.diagnostics import CacheProfiler, Profiler, ResourceProfiler
 from dask.diagnostics.profile_visualize import BOKEH_VERSION
 from dask.threaded import get
@@ -40,7 +41,8 @@ def test_profiler():
     keys = [i.key for i in prof_data]
     assert keys == ["c", "d", "e"]
     tasks = [i.task for i in prof_data]
-    assert tasks == [(add, "a", "b"), (mul, "a", "b"), (mul, "c", "d")]
+    assert len(tasks) == 3
+    assert all(isinstance(t, Task) for t in tasks)
     prof.clear()
     assert prof.results == []
 

--- a/dask/local.py
+++ b/dask/local.py
@@ -116,6 +116,7 @@ from functools import partial
 from queue import Empty, Queue
 
 from dask import config
+from dask._task_spec import DataNode, DependenciesMapping, convert_legacy_graph
 from dask.callbacks import local_callbacks, unpack_callbacks
 from dask.core import flatten, get_dependencies, reverse_dict
 from dask.order import order
@@ -165,7 +166,6 @@ def start_state_from_dask(dsk, cache=None, sortkey=None):
         cache = config.get("cache", None)
     if cache is None:
         cache = dict()
-    from dask._task_spec import DataNode, DependenciesMapping, convert_legacy_graph
 
     dsk = convert_legacy_graph(dsk, all_keys=set(dsk) | set(cache))
     data_keys = set()
@@ -425,7 +425,6 @@ def get_async(
     else:
         result_flat = {result}
     results = set(result_flat)
-    from dask._task_spec import convert_legacy_graph
 
     dsk = dict(convert_legacy_graph(dsk))
     with local_callbacks(callbacks) as callbacks:

--- a/dask/local.py
+++ b/dask/local.py
@@ -178,7 +178,7 @@ def start_state_from_dask(dsk, cache=None, sortkey=None):
     dsk2.update(cache)
 
     dependencies = DependenciesMapping(dsk)
-    waiting = {k: v.copy() for k, v in dependencies.items() if k not in data_keys}
+    waiting = {k: set(v) for k, v in dependencies.items() if k not in data_keys}
 
     dependents = reverse_dict(dependencies)
     for a in cache:

--- a/dask/tests/test_callbacks.py
+++ b/dask/tests/test_callbacks.py
@@ -27,7 +27,7 @@ def test_start_state_callback():
     class MyCallback(Callback):
         def _start_state(self, dsk, state):
             flag[0] = True
-            assert dsk["x"] == 1
+            assert dsk["x"]() == 1
             assert len(state["cache"]) == 1
 
     with MyCallback():
@@ -98,8 +98,8 @@ def test_nested_schedulers():
         get_threaded(outer_dsk, "b")
 
     assert not Callback.active
-    assert outer_callback.dsk == outer_dsk
-    assert inner_callback.dsk == inner_dsk
+    assert outer_callback.dsk.keys() == outer_dsk.keys()
+    assert inner_callback.dsk.keys() == inner_dsk.keys()
     assert not Callback.active
 
 

--- a/dask/tests/test_core.py
+++ b/dask/tests/test_core.py
@@ -11,7 +11,6 @@ from dask.core import (
     get_dependencies,
     get_deps,
     getcycle,
-    has_tasks,
     ishashable,
     iskey,
     istask,
@@ -86,23 +85,6 @@ def test_istask():
     assert not istask((1, 2))
     f = namedtuple("f", ["x", "y"])
     assert not istask(f(sum, 2))
-
-
-def test_has_tasks():
-    dsk = {
-        "a": [1, 2, 3],
-        "b": "a",
-        "c": [1, (inc, 1)],
-        "d": [(sum, "a")],
-        "e": ["a", "b"],
-        "f": [["a", "b"], 2, 3],
-    }
-    assert not has_tasks(dsk, dsk["a"])
-    assert has_tasks(dsk, dsk["b"])
-    assert has_tasks(dsk, dsk["c"])
-    assert has_tasks(dsk, dsk["d"])
-    assert has_tasks(dsk, dsk["e"])
-    assert has_tasks(dsk, dsk["f"])
 
 
 def test_preorder_traversal():

--- a/dask/tests/test_task_spec.py
+++ b/dask/tests/test_task_spec.py
@@ -64,22 +64,24 @@ def test_convert_legacy_dsk_skip_new():
 
 def test_repr():
     t = Task("key", func, "a", "b")
-    assert repr(t) == "<Task key func('a', 'b')>"
+    assert repr(t) == "<Task 'key' func('a', 'b')>"
 
     t = Task("nested", func2, t, t.ref())
-    assert repr(t) == "<Task nested func2(<Task key func('a', 'b')>, Alias(key->key))>"
+    assert (
+        repr(t) == "<Task 'nested' func2(<Task 'key' func('a', 'b')>, Alias(key->key))>"
+    )
 
     def long_function_name_longer_even_longer(a, b):
         return a + b
 
     t = Task("long", long_function_name_longer_even_longer, t, t.ref())
-    assert repr(t) == "<Task long long_function_name_longer_even_longer(...)>"
+    assert repr(t) == "<Task 'long' long_function_name_longer_even_longer(...)>"
 
     def use_kwargs(a, kwarg=None):
         return a + kwarg
 
     t = Task("kwarg", use_kwargs, "foo", kwarg="kwarg_value")
-    assert repr(t) == "<Task kwarg use_kwargs('foo', kwarg='kwarg_value')>"
+    assert repr(t) == "<Task 'kwarg' use_kwargs('foo', kwarg='kwarg_value')>"
 
 
 def _assert_dsk_conversion(new_dsk):

--- a/dask/tests/test_task_spec.py
+++ b/dask/tests/test_task_spec.py
@@ -754,7 +754,7 @@ def test_execute_tasks_in_graph():
         t3 := Task("key-3", func, "foo", "bar"),
         Task("key-4", func, t3.ref(), t2.ref()),
     ]
-    res = execute_graph(dsk)
+    res = execute_graph(dsk, keys=["key-4"])
     assert len(res) == 1
     assert res["key-4"] == "foo-bar-a-b=c"
 

--- a/dask/tests/test_task_spec.py
+++ b/dask/tests/test_task_spec.py
@@ -62,6 +62,26 @@ def test_convert_legacy_dsk_skip_new():
     assert converted == dsk
 
 
+def test_repr():
+    t = Task("key", func, "a", "b")
+    assert repr(t) == "<Task key func('a', 'b')>"
+
+    t = Task("nested", func2, t, t.ref())
+    assert repr(t) == "<Task nested func2(<Task key func('a', 'b')>, Alias(key->key))>"
+
+    def long_function_name_longer_even_longer(a, b):
+        return a + b
+
+    t = Task("long", long_function_name_longer_even_longer, t, t.ref())
+    assert repr(t) == "<Task long long_function_name_longer_even_longer(...)>"
+
+    def use_kwargs(a, kwarg=None):
+        return a + kwarg
+
+    t = Task("kwarg", use_kwargs, "foo", kwarg="kwarg_value")
+    assert repr(t) == "<Task kwarg use_kwargs('foo', kwarg='kwarg_value')>"
+
+
 def _assert_dsk_conversion(new_dsk):
     vals = [(k, v.key) for k, v in new_dsk.items()]
     assert all(v[0] == v[1] for v in vals), vals


### PR DESCRIPTION
This effectively causes all dask/dask schedulers to convert to the new task spec and use it as an execution backend.

Todos
- ~Haven't done a sanity perf check but if there is something slow, it is likely because it is still using tuples as tasks (the parsing has some overhead)~ I believe that these kinds of tests are currently premature. I also haven't seen anything significant happening when running distributed tests and expect performance to improve in follow up PRs either way
- the module structure is a little messed up. For now I put in lazy imports but it would be nice if that wasn't necessary everywhere. Might be not as bad as it looks but I haven't spent the time to clean this up properly.
- (Follow up) Migrate the internals to use TaskSpec. A couple of heavy hitters like Blockwise would already go a long way. The more we migrate, the less overhead the converter has.

Note
- I am removing a non-underscored function from `dask.core`. That's _technically_ a breaking change. However, I would like to propose to make everything in dask.core private. It's effectively a second utils package. We might want to kill the entire module since it's really confusing since there is also dask.base which is *much* more meaningful and contains more valuable user facing stuff.

xref https://github.com/dask/dask/issues/9969