### PR TITLE
Switch to using ``zarr.open_array`` instead of using the ``zarr.Array`` constructor

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3635,9 +3635,9 @@ def from_zarr(
             store = zarr.storage.FSStore(url, **storage_options)
         else:
             store = url
-        z = zarr.Array(store, read_only=True, path=component, **kwargs)
+        z = zarr.open_array(store, read_only=True, path=component, **kwargs)
     else:
-        z = zarr.Array(url, read_only=True, path=component, **kwargs)
+        z = zarr.open_array(url, read_only=True, path=component, **kwargs)
     chunks = chunks if chunks is not None else z.chunks
     if name is None:
         name = "from-zarr-" + tokenize(z, component, storage_options, chunks, **kwargs)


### PR DESCRIPTION
This is a small change to help pave the way for Zarr's v3 release. There are a few more small things to do here but this will really help us start integration testing with Dask + Zarr.

- [x] Toward https://github.com/zarr-developers/zarr-python/issues/1953
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

@jrbourbeau