### PR TITLE
Improve error message for incorrect columns order in meta information

### DIFF
--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -466,8 +466,8 @@ def test_check_matching_columns_raises_appropriate_errors():
     with pytest.raises(
         ValueError,
         match="Order of columns does not match."
-        "\nActual:   {'b': 'object', 'a': 'object', 'c': 'object'}"
-        "\nExpected: {'a': 'object', 'b': 'object', 'c': 'object'}",
+        "\nActual:   \\['a', 'b', 'c'\\]"
+        "\nExpected: \\['b', 'a', 'c'\\]",
     ):
         assert check_matching_columns(meta, df)
 

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -463,7 +463,12 @@ def test_check_matching_columns_raises_appropriate_errors():
     df = pd.DataFrame(columns=["a", "b", "c"])
 
     meta = pd.DataFrame(columns=["b", "a", "c"])
-    with pytest.raises(ValueError, match="Order of columns does not match"):
+    with pytest.raises(
+        ValueError,
+        match="Order of columns does not match."
+        "\nActual:   {'b': 'object', 'a': 'object', 'c': 'object'}"
+        "\nExpected: {'a': 'object', 'b': 'object', 'c': 'object'}",
+    ):
         assert check_matching_columns(meta, df)
 
     meta = pd.DataFrame(columns=["a", "b", "c", "d"])

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -434,7 +434,11 @@ def check_matching_columns(meta, actual):
         if extra or missing:
             extra_info = f"  Extra:   {extra}\n  Missing: {missing}"
         else:
-            extra_info = "Order of columns does not match"
+            extra_info = (
+                f"Order of columns does not match."
+                f"\nActual:   { { c: str(t) for c, t in meta.dtypes.items() } }"
+                f"\nExpected: { { c: str(t) for c, t in actual.dtypes.items() } }"
+            )
         raise ValueError(
             "The columns in the computed data do not match"
             " the columns in the provided metadata\n"

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -436,12 +436,12 @@ def check_matching_columns(meta, actual):
         else:
             extra_info = (
                 f"Order of columns does not match."
-                f"\nActual:   { { c: str(t) for c, t in meta.dtypes.items() } }"
-                f"\nExpected: { { c: str(t) for c, t in actual.dtypes.items() } }"
+                f"\nActual:   {actual.columns.tolist()}"
+                f"\nExpected: {meta.columns.tolist()}"
             )
         raise ValueError(
             "The columns in the computed data do not match"
-            " the columns in the provided metadata\n"
+            " the columns in the provided metadata.\n"
             f"{extra_info}"
         )
 


### PR DESCRIPTION
- [x] Closes #11390
- [x] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
