### PR TITLE
ENH: relax conditions on boolean index assignment

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1896,8 +1896,6 @@ class Array(DaskMethodsMixin):
         if isinstance(key, Array):
             from dask.array.routines import where
 
-            if isinstance(value, Array) and value.ndim > 1:
-                raise ValueError("boolean index array should have 1 dimension")
             try:
                 y = where(key, value, self)
             except ValueError as e:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3884,6 +3884,22 @@ def test_setitem_2d():
     assert_eq(x, dx)
 
 
+def test_setitem_multid_value():
+    x = np.arange(16).reshape((1, 4, 4))
+    dx = da.from_array(x.copy(), chunks=(1, 2, 2))
+
+    i = np.asarray([[False, False, True, False]])
+    di = da.from_array(i.copy())
+
+    y = np.arange(4).reshape((1, 4))
+    dy = da.from_array(y.copy())
+
+    x[i] = y
+    dx[di] = dy
+
+    assert_eq(x, dx)
+
+
 def test_setitem_extended_API_0d():
     # 0-d array
     x = np.array(9)
@@ -4132,8 +4148,8 @@ def test_setitem_on_read_only_blocks():
 def test_setitem_errs():
     x = da.ones((4, 4), chunks=(2, 2))
 
-    with pytest.raises(ValueError):
-        x[x > 1] = x
+    # with pytest.raises(ValueError):
+    #     x[x > 1] = x
 
     # Shape mismatch
     with pytest.raises(ValueError):


### PR DESCRIPTION
- [x] Closes #11398
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

The condition that `value` be no greater than 1-dimensional here is more strict than NumPy. I've added a test case with an example where NumPy is happy with a 2-d value. Maybe there is a deeper reason for this being the case, but for now, try removing a step of validation.