### PR TITLE
Switch from mambaforge to miniforge in CI

### DIFF
--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
           mamba-version: "1.5.10"
@@ -51,7 +50,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
           miniforge-version: latest
-          # use-mamba: true
+          use-mamba: true
           mamba-version: "1.5.10"
           channel-priority: strict
           python-version: "3.10"

--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
           mamba-version: "1.5.10"

--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -21,6 +21,7 @@ jobs:
           miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
+          mamba-version: "1.5.10"
           channel-priority: strict
           environment-file: continuous_integration/environment-3.12.yaml
           activate-environment: test-environment
@@ -52,6 +53,7 @@ jobs:
           miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
+          mamba-version: "1.5.10"
           channel-priority: strict
           python-version: "3.10"
           activate-environment: test-environment

--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -51,7 +51,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
           miniforge-version: latest
-          use-mamba: true
+          # use-mamba: true
           mamba-version: "1.5.10"
           channel-priority: strict
           python-version: "3.10"

--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           miniforge-version: latest
           use-mamba: true
-          mamba-version: "1.5.10"
           channel-priority: strict
           environment-file: continuous_integration/environment-3.12.yaml
           activate-environment: test-environment
@@ -51,7 +50,6 @@ jobs:
         with:
           miniforge-version: latest
           use-mamba: true
-          mamba-version: "1.5.10"
           channel-priority: strict
           python-version: "3.10"
           activate-environment: test-environment

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -36,7 +36,6 @@ jobs:
         with:
           miniforge-version: latest
           use-mamba: true
-          mamba-version: "1.5.10"
           python-version: 3.9
           channel-priority: strict
       - name: Install dependencies

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           use-mamba: true
+          mamba-version: "1.5.10"
           python-version: 3.9
           channel-priority: strict
       - name: Install dependencies

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
-          miniforge-variant: Mambaforge
+          miniforge-version: latest
           use-mamba: true
           mamba-version: "1.5.10"
           python-version: 3.9

--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -28,7 +28,6 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           condarc-file: continuous_integration/condarc
           use-mamba: true

--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -32,6 +32,7 @@ jobs:
           miniforge-version: latest
           condarc-file: continuous_integration/condarc
           use-mamba: true
+          mamba-version: "1.5.10"
           # Note: this file is in the dask/distributed repo
           environment-file: continuous_integration/scripts/test-report-environment.yml
           activate-environment: dask

--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -31,7 +31,6 @@ jobs:
           miniforge-version: latest
           condarc-file: continuous_integration/condarc
           use-mamba: true
-          mamba-version: "1.5.10"
           # Note: this file is in the dask/distributed repo
           environment-file: continuous_integration/scripts/test-report-environment.yml
           activate-environment: dask

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,6 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
           mamba-version: "1.5.10"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,6 @@ jobs:
         with:
           miniforge-version: latest
           use-mamba: true
-          mamba-version: "1.5.10"
           channel-priority: strict
           environment-file: continuous_integration/environment-${{ matrix.environment }}.yaml
           activate-environment: test-environment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,7 @@ jobs:
           miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
+          mamba-version: "1.5.10"
           channel-priority: strict
           environment-file: continuous_integration/environment-${{ matrix.environment }}.yaml
           activate-environment: test-environment

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -55,6 +55,7 @@ jobs:
           miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
+          mamba-version: "1.5.10"
           channel-priority: strict
           environment-file: continuous_integration/environment-3.12.yaml
           activate-environment: test-environment

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -54,7 +54,6 @@ jobs:
         with:
           miniforge-version: latest
           use-mamba: true
-          mamba-version: "1.5.10"
           channel-priority: strict
           environment-file: continuous_integration/environment-3.12.yaml
           activate-environment: test-environment

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
           mamba-version: "1.5.10"


### PR DESCRIPTION
We're seeing CI jobs fail during setup with 

```
Warning: ERROR: executing pre_install.sh failed
```

Here's a similar upstream issue https://github.com/conda-incubator/setup-miniconda/issues/366 where they suggest pinning to `mamba<2` (`mamba=2` just came out). 

cc @jhamman 