### PR TITLE
Ensure numba tokenization does not use slow pickle path

### DIFF
--- a/dask/tests/test_tokenize.py
+++ b/dask/tests/test_tokenize.py
@@ -1369,6 +1369,12 @@ all_numba_funcs = [
 def test_tokenize_numba(func):
     assert func(1, 2) == 3
     check_tokenize(func)
+    for func in all_numba_funcs:
+        tokens = normalize_token(func)
+
+        # Ensure that we attempt to tokenize it instead of dumping it into pickle
+        assert isinstance(tokens, tuple)
+        assert isinstance(tokens[1], tuple)
 
 
 @pytest.mark.skipif("not numba")

--- a/dask/tokenize.py
+++ b/dask/tokenize.py
@@ -342,6 +342,15 @@ def register_pandas():
         return offset.freqstr
 
 
+@normalize_token.register_lazy("numba")
+def register_numba():
+    import numba
+
+    @normalize_token.register(numba.core.serialize.ReduceMixin)
+    def normalize_numba_ufunc(obj):
+        return normalize_token((obj._reduce_class(), obj._reduce_states()))
+
+
 @normalize_token.register_lazy("pyarrow")
 def register_pyarrow():
     import pyarrow as pa


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/11416

The example provided in the issue

```python
%%time
for i in range(3):
    a = da.ones((10000, 1000, 10), chunks=(1000, 1000, 10), dtype=np.int8)
    res = da.map_blocks(inc, a, dtype=np.int8).compute()
```

now runs on my machine in ~150ms instead of 2.6s

Isolating this to the tokenization of the function

```python
%timeit tokenize(inc)

# main - 345 ms ± 9.06 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

# PR - 447 μs ± 4.36 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

```

so tokenization is about three orders of magnitude faster