### PR TITLE
Add cupy support for indexed assignment

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -1338,7 +1338,7 @@ def parse_assignment_indices(indices, shape):
             # Index is an integer
             index = int(index)
 
-        elif isinstance(index, np.ndarray) or is_dask_collection(index):
+        elif is_arraylike(index) or is_dask_collection(index):
             # Index is 1-d array
             n_lists += 1
             if n_lists > 1:


### PR DESCRIPTION
Minor fix to `parse_assignment_indices` in `dask.array`: Generalizes the `np.ndarray` instance check to use `is_arraylike`.

- [x] Closes [#xxxx](https://github.com/dask/dask/issues/11266)
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
