### PR TITLE
Avoid exponentially increasing taskgraph in overlap

### DIFF
--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -844,7 +844,7 @@ def test_map_overlap_new_axis():
     assert_eq(expected, actual, check_shape=False, check_chunks=False)
 
 
-def test_overlap_now_blowing_up_graph():
+def test_overlap_not_blowing_up_graph():
     xr = pytest.importorskip("xarray")
 
     arr = xr.DataArray(

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import pytest
 
+from dask.base import collections_to_dsk
+
 pytest.importorskip("numpy")
 
 import numpy as np
@@ -840,3 +842,15 @@ def test_map_overlap_new_axis():
     # Shape and chunks aren't known until array is computed,
     # so don't expclitly check shape or chunks in assert_eq
     assert_eq(expected, actual, check_shape=False, check_chunks=False)
+
+
+def test_overlap_now_blowing_up_graph():
+    xr = pytest.importorskip("xarray")
+
+    arr = xr.DataArray(
+        da.random.random((2, 10, 5, 121), chunks=(1, 2, 1, 121)),
+        dims=["x", "y", "z", "year"],
+    )
+    result = arr.rolling(dim={"year": 11}, center=True).construct("window_dim")
+    dc = collections_to_dsk([result.data])
+    assert len(dc) < 1000  # previously 3000

--- a/dask/layers.py
+++ b/dask/layers.py
@@ -253,13 +253,20 @@ def _expand_keys_around_center(k, dims, name=None, axes=None):
             num += 1
         shape.append(num)
 
+    def _valid_depth(depth):
+        if isinstance(depth, tuple):
+            return any(x != 0 for x in depth)
+        else:
+            return depth != 0
+
     args = [
-        inds(i, ind) if any((axes.get(i, 0),)) else [ind] for i, ind in enumerate(k[1:])
+        inds(i, ind) if _valid_depth(axes.get(i, 0)) else [ind]
+        for i, ind in enumerate(k[1:])
     ]
     if name is not None:
         args = [[name]] + args
     seq = list(product(*args))
-    shape2 = [d if any((axes.get(i, 0),)) else 1 for i, d in enumerate(shape)]
+    shape2 = [d if _valid_depth(axes.get(i, 0)) else 1 for i, d in enumerate(shape)]
     result = reshapelist(shape2, seq)
     return result
 


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

Reduces task graph size in overlap from 

``O(nr_chunks * (3**nr_dimensions_with_more_than_one_chunk))``

to

``O(nr_chunks * (3**nr_overlapping_dimensions))``