### PR TITLE
Ensure that recursively calling tokenize respects ensure_deterministic

### DIFF
--- a/dask/tests/test_task_spec.py
+++ b/dask/tests/test_task_spec.py
@@ -745,3 +745,8 @@ def test_execute_tasks_in_graph():
     res = execute_graph(dsk)
     assert len(res) == 1
     assert res["key-4"] == "foo-bar-a-b=c"
+
+
+def test_deterministic_tokenization_respected():
+    with pytest.raises(RuntimeError, match="deterministic"):
+        tokenize(Task("key", func, object()), ensure_deterministic=True)


### PR DESCRIPTION
In https://github.com/dask/dask/pull/11373 I removed contextvars for the seen set to reduce overhead. The logic I put in place for the `_ENSURE_DETERMINISTIC` variable was erroneous and not safe for recursively calling tokenize. This PR addresses this while maintaining the performance critical global variable for set.