### PR TITLE
Task Spec: Ensure arrays are allowed as arguments

### DIFF
--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -576,7 +576,7 @@ def _get_dependencies(obj: object) -> set | frozenset:
         if not obj:
             return _no_deps
         return set().union(*map(_get_dependencies, obj.values()))
-    elif isinstance(obj, Iterable) and not isinstance(obj, str):
+    elif isinstance(obj, (list, tuple, frozenset, set)):
         if not obj:
             return _no_deps
         return set().union(*map(_get_dependencies, obj))
@@ -608,7 +608,7 @@ class Task(GraphNode):
         self.kwargs = parse_input(kwargs)
         dependencies: set = set()
         dependencies.update(_get_dependencies(self.args))
-        dependencies.update(_get_dependencies(self.kwargs.values()))
+        dependencies.update(_get_dependencies(tuple(self.kwargs.values())))
         if dependencies:
             self.dependencies = dependencies
         else:


### PR DESCRIPTION
This is a follow up to https://github.com/dask/dask/pull/11429

It's not a good idea to allow all iterables in here and since this is a private function it's better to just call it differently.