### PR TITLE
Ensure `broadcast_shapes()` returns integers, not NumPy scalars.

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4795,7 +4795,7 @@ def broadcast_shapes(*shapes):
         if np.isnan(sizes).any():
             dim = np.nan
         else:
-            dim = 0 if 0 in sizes else np.max(sizes)
+            dim = 0 if 0 in sizes else np.max(sizes).item()
         if any(i not in [-1, 0, 1, dim] and not np.isnan(i) for i in sizes):
             raise ValueError(
                 "operands could not be broadcast together with "

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -871,6 +871,8 @@ def test_broadcast_shapes():
     assert (3, 4) == broadcast_shapes((3, 1), (1, 4), (4,))
     assert (5, 6, 7, 3, 4) == broadcast_shapes((3, 1), (), (5, 6, 7, 1, 4))
 
+    assert all(isinstance(i, int) for i in broadcast_shapes((2, 5)))
+
     pytest.raises(ValueError, lambda: broadcast_shapes((3,), (3, 4)))
     pytest.raises(ValueError, lambda: broadcast_shapes((2, 3), (2, 3, 1)))
     pytest.raises(ValueError, lambda: broadcast_shapes((2, 3), (1, np.nan)))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -10,6 +10,7 @@ import pytest
 
 np = pytest.importorskip("numpy")
 
+import itertools
 import math
 import operator
 import os
@@ -871,7 +872,9 @@ def test_broadcast_shapes():
     assert (3, 4) == broadcast_shapes((3, 1), (1, 4), (4,))
     assert (5, 6, 7, 3, 4) == broadcast_shapes((3, 1), (), (5, 6, 7, 1, 4))
 
-    assert all(isinstance(i, int) for i in broadcast_shapes((2, 5)))
+    assert all(
+        isinstance(i, int) for i in itertools.chain(*broadcast_shapes([(1, 2), (3, 1)]))
+    )
 
     pytest.raises(ValueError, lambda: broadcast_shapes((3,), (3, 4)))
     pytest.raises(ValueError, lambda: broadcast_shapes((2, 3), (2, 3, 1)))


### PR DESCRIPTION
- [x] Closes #11433
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

This aligns Dask's behaviour with NumPy's - https://github.com/dask/dask/issues/11433#issuecomment-2416955896

Do let me know if you think this merits any changes to tests.