### PR TITLE
Adjust accuracy in test_solve_triangular_vector

### DIFF
--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -640,7 +640,7 @@ def test_solve_triangular_vector(shape, chunk):
     db = da.from_array(b, chunk)
     res = da.linalg.solve_triangular(dAu, db)
     assert_eq(res, scipy.linalg.solve_triangular(Au, b))
-    assert_eq(dAu.dot(res), b.astype(float))
+    assert_eq(dAu.dot(res), b.astype(float), rtol=1e-4)
 
     # lower
     Al = np.tril(A)


### PR DESCRIPTION
I can reproduce if I install the exact environment of CI but didn't find out what dep is causing this. I think that should be fine

closes  https://github.com/dask/dask/issues/11460