### PR TITLE
Fix `Task.__repr__()` of unpickled object

### DIFF
--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -653,7 +653,9 @@ class Task(GraphNode):
         )
 
     def __repr__(self) -> str:
-        if not self._repr:
+        # When `Task` is deserialized the constructor will not run and
+        # `self._repr` is thus undefined.
+        if not hasattr(self, "_repr") or not self._repr:
             self.unpack()
             head = funcname(self.func)
             tail = ")"

--- a/dask/tests/test_task_spec.py
+++ b/dask/tests/test_task_spec.py
@@ -84,6 +84,32 @@ def test_repr():
     assert repr(t) == "<Task 'kwarg' use_kwargs('foo', kwarg='kwarg_value')>"
 
 
+def test_unpickled_repr():
+    t = pickle.loads(pickle.dumps(Task("key", func, "a", "b")))
+    assert repr(t) == "<Task 'key' func('a', 'b')>"
+
+    t = pickle.loads(pickle.dumps(Task("nested", func2, t, t.ref())))
+    assert (
+        repr(t) == "<Task 'nested' func2(<Task 'key' func('a', 'b')>, Alias(key->key))>"
+    )
+
+    def long_function_name_longer_even_longer(a, b):
+        return a + b
+
+    t = pickle.loads(
+        pickle.dumps(Task("long", long_function_name_longer_even_longer, t, t.ref()))
+    )
+    assert repr(t) == "<Task 'long' long_function_name_longer_even_longer(...)>"
+
+    def use_kwargs(a, kwarg=None):
+        return a + kwarg
+
+    t = pickle.loads(
+        pickle.dumps(Task("kwarg", use_kwargs, "foo", kwarg="kwarg_value"))
+    )
+    assert repr(t) == "<Task 'kwarg' use_kwargs('foo', kwarg='kwarg_value')>"
+
+
 def _assert_dsk_conversion(new_dsk):
     vals = [(k, v.key) for k, v in new_dsk.items()]
     assert all(v[0] == v[1] for v in vals), vals


### PR DESCRIPTION
https://github.com/dask/dask/pull/11378 added a `Task._repr` object that is defined during `Task.__init__()`. In `Task.__repr__()` the object is tested but it doesn't account for the situation where `Task` may have been deserialized and thus `Task.__init__()` is never called, causing that to fail as the attribute was never defined. One other way to fix this would have been to define a default value when the attribute is defined in the scope of the class, but that unfortunately doesn't work due to the `__slots__ = tuple(__annotations__)` in the class. Another alternative to the `hasattr` check could be to define a `@property` with a different name and make `__repr__()` simply return that, which would handle checks regardless of `__init__()` being called, but I think that's too much bloat for little benefit.

- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
