### PR TITLE
Improve dask.order performance for large graphs

### DIFF
--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -810,25 +810,34 @@ class DependenciesMapping(MutableMapping):
     def __init__(self, dsk):
         self.dsk = dsk
         self._removed = set()
+        # Set a copy of dsk to avoid dct resizing
+        self._cache = dsk.copy()
+        self._cache.clear()
 
     def __getitem__(self, key):
-        v = self.dsk[key]
-        if not isinstance(v, GraphNode):
-            from dask.core import get_dependencies
-
-            deps = get_dependencies(self.dsk, task=self.dsk[key])
+        if (val := self._cache.get(key)) is not None:
+            return val
         else:
-            deps = self.dsk[key].dependencies
-        if self._removed:
-            # deps is a frozenset but for good measure, let's not use -= since
-            # that _may_ perform an inplace mutation
-            deps = deps - self._removed
-        return deps
+            v = self.dsk[key]
+            try:
+                deps = v.dependencies
+            except AttributeError:
+                from dask.core import get_dependencies
+
+                deps = get_dependencies(self.dsk, task=v)
+
+            if self._removed:
+                # deps is a frozenset but for good measure, let's not use -= since
+                # that _may_ perform an inplace mutation
+                deps = deps - self._removed
+            self._cache[key] = deps
+            return deps
 
     def __iter__(self):
         return iter(self.dsk)
 
     def __delitem__(self, key: Any) -> None:
+        self._cache.clear()
         self._removed.add(key)
 
     def __setitem__(self, key: Any, value: Any) -> None:

--- a/dask/order.py
+++ b/dask/order.py
@@ -562,7 +562,7 @@ def order(
         while next_deps:
             item = max(next_deps, key=sort_key)
             path_append(item)
-            next_deps = dependencies[item]
+            next_deps = dependencies[item].difference(result)
             path_extend(next_deps)
 
         # B. Walk the critical path

--- a/dask/order.py
+++ b/dask/order.py
@@ -670,12 +670,12 @@ def _connecting_to_roots(
                 and (result_first is r_child or r_child.issubset(result_first))
             ):
                 identical_sets = False
-                if not new_set:
+                if new_set is None:
                     new_set = set(result_first)
                 max_dependents[key] = max(max_dependents[child], max_dependents[key])
                 new_set.update(r_child)
 
-        if new_set:
+        if new_set is not None:
             new_set_frozen = frozenset(new_set)
             deduped = dedup_mapping.get(new_set_frozen, None)
             if deduped is None:


### PR DESCRIPTION
This adds a caching layer to the DependenciesMapping class to handle the mutations that happen in dask.order.

This further includes a couple of substantial performance fixes for very large graphs