### PR TITLE
Skip legacy test because of flaky warning

### DIFF
--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2645,6 +2645,9 @@ def test_groupby_shift_lazy_input():
         )
 
 
+@pytest.mark.skipif(
+    not DASK_EXPR_ENABLED, reason="flaky with a weird deprecation warning"
+)
 @pytest.mark.filterwarnings("ignore:`meta` is not specified")
 def test_groupby_shift_within_partition_sorting():
     # Result is non-deterministic. We run the assertion a few times to keep


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

I've seen this fail occasionally on the 3.10 builds. There is not much use in keeping this around after we deprecated the legacy option anyway