### PR TITLE
Remove dead code from make_blockwise

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -54,9 +54,11 @@ from dask.array.numpy_compat import NUMPY_GE_200
 from dask.array.reshape import _not_implemented_message
 from dask.array.utils import assert_eq, same_keys
 from dask.base import compute_as_if_collection, tokenize
-from dask.blockwise import broadcast_dimensions
-from dask.blockwise import make_blockwise_graph as top
-from dask.blockwise import optimize_blockwise
+from dask.blockwise import (
+    broadcast_dimensions,
+    make_blockwise_graph,
+    optimize_blockwise,
+)
 from dask.delayed import Delayed, delayed
 from dask.highlevelgraph import HighLevelGraph, MaterializedLayer
 from dask.layers import Blockwise
@@ -90,14 +92,14 @@ def test_graph_from_arraylike(inline_array):
 
 
 def test_top():
-    assert top(inc, "z", "ij", "x", "ij", numblocks={"x": (2, 2)}) == {
+    assert make_blockwise_graph(inc, "z", "ij", "x", "ij", numblocks={"x": (2, 2)}) == {
         ("z", 0, 0): (inc, ("x", 0, 0)),
         ("z", 0, 1): (inc, ("x", 0, 1)),
         ("z", 1, 0): (inc, ("x", 1, 0)),
         ("z", 1, 1): (inc, ("x", 1, 1)),
     }
 
-    assert top(
+    assert make_blockwise_graph(
         add, "z", "ij", "x", "ij", "y", "ij", numblocks={"x": (2, 2), "y": (2, 2)}
     ) == {
         ("z", 0, 0): (add, ("x", 0, 0), ("y", 0, 0)),
@@ -106,7 +108,7 @@ def test_top():
         ("z", 1, 1): (add, ("x", 1, 1), ("y", 1, 1)),
     }
 
-    assert top(
+    assert make_blockwise_graph(
         dotmany, "z", "ik", "x", "ij", "y", "jk", numblocks={"x": (2, 2), "y": (2, 2)}
     ) == {
         ("z", 0, 0): (dotmany, [("x", 0, 0), ("x", 0, 1)], [("y", 0, 0), ("y", 1, 0)]),
@@ -115,13 +117,13 @@ def test_top():
         ("z", 1, 1): (dotmany, [("x", 1, 0), ("x", 1, 1)], [("y", 0, 1), ("y", 1, 1)]),
     }
 
-    assert top(identity, "z", "", "x", "ij", numblocks={"x": (2, 2)}) == {
-        ("z",): (identity, [[("x", 0, 0), ("x", 0, 1)], [("x", 1, 0), ("x", 1, 1)]])
-    }
+    assert make_blockwise_graph(
+        identity, "z", "", "x", "ij", numblocks={"x": (2, 2)}
+    ) == {("z",): (identity, [[("x", 0, 0), ("x", 0, 1)], [("x", 1, 0), ("x", 1, 1)]])}
 
 
 def test_top_supports_broadcasting_rules():
-    assert top(
+    assert make_blockwise_graph(
         add, "z", "ij", "x", "ij", "y", "ij", numblocks={"x": (1, 2), "y": (2, 1)}
     ) == {
         ("z", 0, 0): (add, ("x", 0, 0), ("y", 0, 0)),
@@ -132,7 +134,9 @@ def test_top_supports_broadcasting_rules():
 
 
 def test_top_literals():
-    assert top(add, "z", "ij", "x", "ij", 123, None, numblocks={"x": (2, 2)}) == {
+    assert make_blockwise_graph(
+        add, "z", "ij", "x", "ij", 123, None, numblocks={"x": (2, 2)}
+    ) == {
         ("z", 0, 0): (add, ("x", 0, 0), 123),
         ("z", 0, 1): (add, ("x", 0, 1), 123),
         ("z", 1, 0): (add, ("x", 1, 0), 123),
@@ -216,7 +220,7 @@ def test_chunked_dot_product():
     getx = graph_from_arraylike(x, (5, 5), shape=(20, 20), name="x")
     geto = graph_from_arraylike(o, (5, 5), shape=(20, 20), name="o")
 
-    result = top(
+    result = make_blockwise_graph(
         dotmany, "out", "ik", "x", "ij", "o", "jk", numblocks={"x": (4, 4), "o": (4, 4)}
     )
 
@@ -232,7 +236,7 @@ def test_chunked_transpose_plus_one():
     getx = graph_from_arraylike(x, (5, 5), shape=(20, 20), name="x")
 
     f = lambda x: x.T + 1
-    comp = top(f, "out", "ij", "x", "ji", numblocks={"x": (4, 4)})
+    comp = make_blockwise_graph(f, "out", "ij", "x", "ji", numblocks={"x": (4, 4)})
 
     dsk = merge(getx, comp)
     out = dask.get(dsk, [[("out", i, j) for j in range(4)] for i in range(4)])

--- a/dask/tests/test_utils.py
+++ b/dask/tests/test_utils.py
@@ -43,7 +43,6 @@ from dask.utils import (
     random_state_data,
     skip_doctest,
     stringify,
-    stringify_collection_keys,
     takes_multiple_arguments,
     tmpfile,
     typename,
@@ -781,17 +780,6 @@ def test_stringify():
     dsk = stringify(dsk, exclusive=set(dsk) | {("z", 1)})
     assert dsk[("y", 1)][0].dsk["x"] == "('y', 1)"
     assert dsk[("y", 1)][1][0] == "('z', 1)"
-
-
-def test_stringify_collection_keys():
-    obj = "Hello"
-    assert stringify_collection_keys(obj) is obj
-
-    obj = [("a", 0), (b"a", 0), (1, 1)]
-    res = stringify_collection_keys(obj)
-    assert res[0] == str(obj[0])
-    assert res[1] == str(obj[1])
-    assert res[2] == obj[2]
 
 
 @pytest.mark.parametrize(

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -2064,29 +2064,6 @@ def stringify(obj, exclusive: Iterable | None = None):
     return obj
 
 
-def stringify_collection_keys(obj):
-    """Convert all collection keys in ``obj`` to strings.
-
-    This is a specialized version of ``stringify()`` that only converts keys
-    of the form: ``("a string", ...)``
-    """
-
-    typ = type(obj)
-    if typ is tuple and obj:
-        obj0 = obj[0]
-        if type(obj0) is str or type(obj0) is bytes:
-            return stringify(obj)
-        if callable(obj0):
-            return (obj0,) + tuple(stringify_collection_keys(x) for x in obj[1:])
-    if typ is list:
-        return [stringify_collection_keys(v) for v in obj]
-    if typ is dict:
-        return {k: stringify_collection_keys(v) for k, v in obj.items()}
-    if typ is tuple:  # If the tuple itself isn't a key, check its elements
-        return tuple(stringify_collection_keys(v) for v in obj)
-    return obj
-
-
 class cached_property(functools.cached_property):
     """Read only version of functools.cached_property."""
 


### PR DESCRIPTION
From all I can tell, this is dead code. The function `make_blockwise_graph` is used in exactly one place and the kwargs `deserialize`, `return_key_deps` and `func_future_args` are never used. If we remove them, this other code is also dead