### PR TITLE
Remove empty tasks from map_overlap

### DIFF
--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -831,7 +831,7 @@ def test_sliding_window_errors(window_shape, axis):
 
 
 def test_overlap_not_adding_empty_tasks():
-    arr = da.zeros((20, 10), chunks=(5, 5))
+    arr = da.zeros((30, 5), chunks=(10, 5))
 
     def dummy(x):
         return x
@@ -848,6 +848,7 @@ def test_overlap_not_adding_empty_tasks():
         )
 
     assert not any(check(v) for v in dsk.values())
+    result.compute()
 
 
 def test_map_overlap_new_axis():

--- a/dask/array/tests/test_overlap.py
+++ b/dask/array/tests/test_overlap.py
@@ -830,6 +830,26 @@ def test_sliding_window_errors(window_shape, axis):
         sliding_window_view(arr, window_shape, axis)
 
 
+def test_overlap_not_adding_empty_tasks():
+    arr = da.zeros((20, 10), chunks=(5, 5))
+
+    def dummy(x):
+        return x
+
+    result = arr.map_overlap(dummy, depth={0: (0, 1)})
+    dsk = dict(result.dask)
+
+    def check(v):
+        return (
+            isinstance(v, tuple)
+            and len(v) >= 3
+            and isinstance(v[2], tuple)
+            and v[2] == (slice(0, 0, None), slice(None))
+        )
+
+    assert not any(check(v) for v in dsk.values())
+
+
 def test_map_overlap_new_axis():
     arr = da.arange(6, chunks=2)
     assert arr.shape == (6,)

--- a/dask/layers.py
+++ b/dask/layers.py
@@ -237,21 +237,28 @@ def _expand_keys_around_center(k, dims, name=None, axes=None):
      [('y', 0.9, 3.1), ('y', 0.9,   4)]]
     """
 
-    def inds(i, ind):
+    def convert_depth(depth):
+        if not isinstance(depth, tuple):
+            depth = (depth, depth)
+        return depth
+
+    def inds(i, ind, depth):
+        depth = convert_depth(depth)
         rv = []
-        if ind - 0.9 > 0:
+        if ind - 0.9 > 0 and depth[0] != 0:
             rv.append(ind - 0.9)
         rv.append(ind)
-        if ind + 0.9 < dims[i] - 1:
+        if ind + 0.9 < dims[i] - 1 and depth[1] != 0:
             rv.append(ind + 0.9)
         return rv
 
     shape = []
     for i, ind in enumerate(k[1:]):
+        depth = convert_depth(axes.get(i, 0))
         num = 1
-        if ind > 0:
+        if ind > 0 and depth[0] != 0:
             num += 1
-        if ind < dims[i] - 1:
+        if ind < dims[i] - 1 and depth[1] != 0:
             num += 1
         shape.append(num)
 
@@ -262,7 +269,7 @@ def _expand_keys_around_center(k, dims, name=None, axes=None):
             return depth != 0
 
     args = [
-        inds(i, ind) if _valid_depth(axes.get(i, 0)) else [ind]
+        inds(i, ind, axes.get(i, 0)) if _valid_depth(axes.get(i, 0)) else [ind]
         for i, ind in enumerate(k[1:])
     ]
     if name is not None:

--- a/dask/layers.py
+++ b/dask/layers.py
@@ -196,6 +196,8 @@ class ArrayOverlapLayer(Layer):
         overlap_blocks = {}
         for k in interior_keys:
             frac_slice = fractional_slice((name,) + k, axes)
+            if frac_slice is False:
+                continue
             if (name,) + k != frac_slice:
                 interior_slices[(getitem_name,) + k] = frac_slice
             else:
@@ -315,7 +317,7 @@ def fractional_slice(task, axes):
         elif t > r and left_depth:
             index.append(slice(-left_depth, None))
         else:
-            index.append(slice(0, 0))
+            return False
     index = tuple(index)
 
     if all(ind == slice(None, None, None) for ind in index):


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

Removing tasks that aren't really necessary. This is a cases that xarray.rolling and ffill triggers for example. The result in a non trivial reduction of the graph, especially since these tasks can't be fused normally. 