### PR TITLE
Make sure that block_id and block_info don't create extra tasks

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -1646,8 +1646,7 @@ def test_map_blocks_optimize_blockwise(func):
     optimized = optimize_blockwise(dsk)
 
     # Everything should be fused into a single layer.
-    # If the lambda includes block_info, there will be two layers.
-    assert len(optimized.layers) == len(dsk.layers) - 6
+    assert len(optimized.layers) == 1
 
 
 def test_repr():

--- a/dask/array/tests/test_map_blocks.py
+++ b/dask/array/tests/test_map_blocks.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import dask.array as da
+from dask.base import collections_to_dsk
+
+
+def test_map_blocks_block_id_fusion():
+    arr = da.ones((20, 10), chunks=(2, 5))
+
+    def dummy(x, block_id=None, block_info=None):
+        return x
+
+    result = arr.map_blocks(dummy).astype("f8")
+    dsk = collections_to_dsk([result])
+    assert len(dsk) == 20


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`


Putting the arguments into a blockwise layer will ensure that blockwise fusion kicks in. Currently, this creates one extra task per chunk, which is not great and generally interrupts blockwise fusion of different layers. map_overlap is using the block_info keyword internally, so this has immediate benefit, not only in 3rd party code