### PR TITLE
Use internal keyword for trimming in map_overlap to reduce graph size

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -891,28 +891,42 @@ def map_blocks(
     def _getter_item(a, b, **kwargs):
         return getter(a, b, **kwargs).item()
 
+    def _add_blockwise_layer_for_keyword(keyword_arr, prefix):
+        name = prefix + out.name
+        cs = tuple((1,) * len(c) for c in out.chunks)
+
+        dsk = graph_from_arraylike(
+            keyword_arr,
+            cs,
+            keyword_arr.shape,
+            name,
+            getitem=_getter_item,
+            dtype=keyword_arr.dtype,
+            inline_array=True,
+        )
+        return Array(dsk, name, chunks=cs, dtype=keyword_arr.dtype)
+
     if has_keyword(func, "block_id"):
         # put block_id into a Blockwise layer so that we can fuse it
         # with the other blockwise layers
         block_id_arr = np.empty(tuple([len(c) for c in out.chunks]), dtype=np.object_)
         for block_id in product(*(range(len(c)) for c in out.chunks)):
             block_id_arr[block_id] = block_id
-
-        block_id_name = "block-id-" + out.name
-        cs = tuple((1,) * len(c) for c in out.chunks)
-
-        dsk = graph_from_arraylike(
-            block_id_arr,
-            cs,
-            block_id_arr.shape,
-            block_id_name,
-            getitem=_getter_item,
-            dtype=block_id_arr.dtype,
-            inline_array=True,
-        )
-        block_id_array = Array(dsk, block_id_name, chunks=cs, dtype=np.object_)
+        block_id_array = _add_blockwise_layer_for_keyword(block_id_arr, "block-id-")
         extra_argpairs.append((block_id_array, out_ind))
         extra_names.append("block_id")
+
+    if has_keyword(func, "_overlap_trim_info"):
+        # Internal for map overlap to reduce size of graph
+        num_chunks = out.numblocks
+        block_id_arr = np.empty(tuple([len(c) for c in out.chunks]), dtype=np.object_)
+        for block_id in product(*(range(len(c)) for c in out.chunks)):
+            block_id_arr[block_id] = (block_id, num_chunks)
+        block_id_array = _add_blockwise_layer_for_keyword(
+            block_id_arr, "_overlap_trim_info-id-"
+        )
+        extra_argpairs.append((block_id_array, out_ind))
+        extra_names.append("_overlap_trim_info")
 
     # If func has block_info as an argument, construct an array of block info
     # objects and prepare to inject it.

--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -134,13 +134,15 @@ def trim_internal(x, axes, boundary=None):
     )
 
 
-def _trim(x, axes, boundary, block_info):
+def _trim(x, axes, boundary, _overlap_trim_info):
     """Similar to dask.array.chunk.trim but requires one to specify the
     boundary condition.
 
     ``axes``, and ``boundary`` are assumed to have been coerced.
 
     """
+    chunk_location = _overlap_trim_info[0]
+    num_chunks = _overlap_trim_info[1]
     axes = [axes.get(i, 0) for i in range(x.ndim)]
     axes_front = (ax[0] if isinstance(ax, tuple) else ax for ax in axes)
     axes_back = (
@@ -154,9 +156,7 @@ def _trim(x, axes, boundary, block_info):
 
     trim_front = (
         0 if (chunk_location == 0 and boundary.get(i, "none") == "none") else ax
-        for i, (chunk_location, ax) in enumerate(
-            zip(block_info[0]["chunk-location"], axes_front)
-        )
+        for i, (chunk_location, ax) in enumerate(zip(chunk_location, axes_front))
     )
     trim_back = (
         (
@@ -165,7 +165,7 @@ def _trim(x, axes, boundary, block_info):
             else ax
         )
         for i, (chunks, chunk_location, ax) in enumerate(
-            zip(block_info[0]["num-chunks"], block_info[0]["chunk-location"], axes_back)
+            zip(num_chunks, chunk_location, axes_back)
         )
     )
     ind = tuple(slice(front, back) for front, back in zip(trim_front, trim_back))


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

I've accidentally bumped into this. With 100k chunks, this reduces the trimming graph size from 30MiB to 2MiB. The default block info just adds a lot of stuff that we don't need