### PR TITLE
Make tokenization for vindex more efficient

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5680,10 +5680,10 @@ def _vindex_array(x, dict_indexes):
     broadcast_shape = broadcast_indexes[0].shape
 
     lookup = dict(zip(dict_indexes, broadcast_indexes))
-    flat_indexes = [
-        lookup[i].ravel().tolist() if i in lookup else None for i in range(x.ndim)
-    ]
+    flat_indexes = [lookup[i].ravel() if i in lookup else None for i in range(x.ndim)]
     flat_indexes.extend([None] * (x.ndim - len(flat_indexes)))
+
+    token = tokenize(x, flat_indexes)
 
     flat_indexes = [
         list(index) if index is not None else index for index in flat_indexes
@@ -5691,7 +5691,6 @@ def _vindex_array(x, dict_indexes):
     bounds = [list(accumulate(add, (0,) + c)) for c in x.chunks]
     bounds2 = [b for i, b in zip(flat_indexes, bounds) if i is not None]
     axis = _get_axis(flat_indexes)
-    token = tokenize(x, flat_indexes)
     out_name = "vindex-merge-" + token
 
     max_chunk_point_dimensions = reduce(


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

Stumbled upon this, the lists can grow quite large and tokenizing an array is much faster