### PR TITLE
Improve test runtime for test_rot90

### DIFF
--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -239,13 +239,26 @@ def test_flip(funcname, kwargs, shape):
 
 @pytest.mark.parametrize(
     "kwargs",
-    [{}, {"axes": (1, 0)}, {"axes": (2, 3)}, {"axes": (0, 1, 2)}, {"axes": (1, 1)}],
+    [
+        {},
+        {"axes": (1, 0)},
+        {"axes": (2, 3)},
+        {"axes": (0, 1, 2)},
+    ],
 )
-@pytest.mark.parametrize("shape", [tuple(), (4,), (4, 6), (4, 6, 8), (4, 6, 8, 10)])
+@pytest.mark.parametrize(
+    "shape",
+    [
+        tuple(),
+        (4,),
+        (4, 6),
+        (4, 6, 8),
+    ],
+)
 def test_rot90(kwargs, shape):
     axes = kwargs.get("axes", (0, 1))
     np_a = np.random.default_rng().random(shape)
-    da_a = da.from_array(np_a, chunks=1)
+    da_a = da.from_array(np_a, chunks=2)
 
     np_func = np.rot90
     da_func = da.rot90


### PR DESCRIPTION
This test is running for about a minute on CI. It is heavily parametrized, both internally and externally. On top, the default version is not even setting any chunks. Testing on a single chunk feels a bit pointless.

Adding the second chunk plus removing some of the parametrization shrinks the test runtime significantly (14s to 0.5s on my machine, i.e. on CI that'd be 2s which is still something but OK)