### PR TITLE
Implement ``nanpercentile`` for dask arrays

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -100,7 +100,7 @@ try:
     from dask.array.numpy_compat import moveaxis, rollaxis
     from dask.array.optimization import optimize
     from dask.array.overlap import map_overlap, push
-    from dask.array.percentile import percentile
+    from dask.array.percentile import nanpercentile, percentile
     from dask.array.rechunk import rechunk
     from dask.array.reductions import (
         all,

--- a/dask/array/percentile.py
+++ b/dask/array/percentile.py
@@ -8,6 +8,7 @@ from numbers import Number
 import numpy as np
 from tlz import merge
 
+from build.lib.dask.utils import derived_from
 from dask.array.core import Array
 from dask.base import tokenize
 from dask.highlevelgraph import HighLevelGraph
@@ -317,6 +318,7 @@ def merge_percentiles(finalq, qs, vals, method="lower", Ns=None, raise_on_nan=Tr
     return rv
 
 
+@derived_from(np)
 def nanpercentile(a, q, **kwargs):
     from dask.array.reductions import nanquantile
 

--- a/dask/array/percentile.py
+++ b/dask/array/percentile.py
@@ -107,7 +107,13 @@ def percentile(a, q, method="linear", internal_method="default", **kwargs):
     numpy.percentile : Numpy's equivalent Percentile function
     """
     from dask.array.dispatch import percentile_lookup as _percentile
+    from dask.array.reductions import quantile
     from dask.array.utils import array_safe, meta_from_array
+
+    if a.ndim > 1:
+        q = np.true_divide(q, a.dtype.type(100) if a.dtype.kind == "f" else 100)
+
+        return quantile(a, q, method=method, **kwargs)
 
     allowed_internal_methods = ["default", "dask", "tdigest"]
 
@@ -309,3 +315,11 @@ def merge_percentiles(finalq, qs, vals, method="lower", Ns=None, raise_on_nan=Tr
                 "'higher', 'midpoint', or 'nearest'"
             )
     return rv
+
+
+def nanpercentile(a, q, **kwargs):
+    from dask.array.reductions import nanquantile
+
+    q = np.true_divide(q, a.dtype.type(100) if a.dtype.kind == "f" else 100)
+
+    return nanquantile(a, q, **kwargs)

--- a/dask/array/percentile.py
+++ b/dask/array/percentile.py
@@ -8,10 +8,10 @@ from numbers import Number
 import numpy as np
 from tlz import merge
 
-from build.lib.dask.utils import derived_from
 from dask.array.core import Array
 from dask.base import tokenize
 from dask.highlevelgraph import HighLevelGraph
+from dask.utils import derived_from
 
 
 @wraps(np.percentile)

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -914,7 +914,7 @@ def test_weighted_reduction():
 @pytest.mark.parametrize("q", [0.75, [0.75], [0.75, 0.4]])
 @pytest.mark.parametrize("rechunk", [True, False])
 def test_nanquantile(rechunk, q, axis):
-    shape = 10, 15, 10, 15
+    shape = 7, 10, 7, 10
     arr = np.random.randn(*shape)
     indexer = np.random.randint(0, 10, size=shape)
     arr[indexer >= 8] = np.nan
@@ -924,6 +924,14 @@ def test_nanquantile(rechunk, q, axis):
     assert_eq(
         da.nanquantile(darr, q, axis=axis, keepdims=True),
         np.nanquantile(arr, q, axis=axis, keepdims=True),
+    )
+    assert_eq(
+        da.nanpercentile(darr, q * 100, axis=axis),
+        np.nanpercentile(arr, q * 100, axis=axis),
+    )
+    assert_eq(
+        da.nanpercentile(darr, q * 100, axis=axis, keepdims=True),
+        np.nanpercentile(arr, q * 100, axis=axis, keepdims=True),
     )
 
 
@@ -942,6 +950,11 @@ def test_quantile(rechunk, q, axis):
         da.quantile(darr, q, axis=axis, keepdims=True),
         np.quantile(arr, q, axis=axis, keepdims=True),
     )
+    assert_eq(da.percentile(darr, q, axis=axis), np.percentile(arr, q, axis=axis))
+    assert_eq(
+        da.percentile(darr, q, axis=axis, keepdims=True),
+        np.percentile(arr, q, axis=axis, keepdims=True),
+    )
 
 
 def test_nanquantile_all_nan():
@@ -954,6 +967,7 @@ def test_nanquantile_all_nan():
         assert_eq(
             da.nanquantile(darr, 0.75, axis=-1), np.nanquantile(arr, 0.75, axis=-1)
         )
+        assert_eq(da.percentile(darr, 0.75, axis=-1), np.percentile(arr, 0.75, axis=-1))
 
 
 def test_nanquantile_method():
@@ -965,6 +979,10 @@ def test_nanquantile_method():
     assert_eq(
         da.nanquantile(darr, 0.75, axis=-1, method="weibull"),
         np.nanquantile(arr, 0.75, axis=-1, method="weibull"),
+    )
+    assert_eq(
+        da.nanpercentile(darr, 0.75, axis=-1, method="weibull"),
+        np.nanpercentile(arr, 0.75, axis=-1, method="weibull"),
     )
 
 
@@ -978,3 +996,6 @@ def test_nanquantile_two_dims():
     arr = np.random.randn(10, 10)
     darr = da.from_array(arr, chunks=(2, -1))
     assert_eq(da.nanquantile(darr, 0.75, axis=-1), np.nanquantile(arr, 0.75, axis=-1))
+    assert_eq(
+        da.nanpercentile(darr, 0.75, axis=-1), np.nanpercentile(arr, 0.75, axis=-1)
+    )

--- a/docs/source/array-api.rst
+++ b/docs/source/array-api.rst
@@ -166,6 +166,7 @@ Top level functions
    nanmin
    nanprod
    nanquantile
+   nanpercentile
    nanstd
    nansum
    nanvar

--- a/docs/source/array-numpy-compatibility.rst
+++ b/docs/source/array-numpy-compatibility.rst
@@ -242,7 +242,7 @@ is available via the `Array API Comparison repository <https://github.com/data-a
    :obj:`numpy.nanmean`, :obj:`dask.array.nanmean` [#1]_, dask equivalent
    :obj:`numpy.nanmedian`, :obj:`dask.array.nanmedian` [#16]_, dask equivalent
    :obj:`numpy.nanmin`, :obj:`dask.array.nanmin` [#1]_ [#2]_, dask equivalent
-   :obj:`numpy.nanpercentile`, \-
+   :obj:`numpy.nanpercentile`, :obj:`dask.array.nanpercentile`
    :obj:`numpy.nanprod`, :obj:`dask.array.nanprod` [#1]_ [#2]_, dask equivalent
    :obj:`numpy.nanquantile`, \-
    :obj:`numpy.nanstd`, :obj:`dask.array.nanstd` [#1]_, dask equivalent


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

I saw np.nanpercentile used in xr.groupby(...).reduce(...), which triggers a compute for every group, that's pretty annoying. We should just add support for it now that we have quantile