### PR TITLE
Fastpath for `meta=dask.Array`

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1378,7 +1378,7 @@ class Array(DaskMethodsMixin):
             dask = HighLevelGraph.from_collections(name, dask, dependencies=())
         self.dask = dask
         self._name = str(name)
-        meta = meta_from_array(meta, dtype=dtype)
+        _meta = meta_from_array(meta, dtype=dtype)
 
         if (
             isinstance(chunks, str)
@@ -1386,7 +1386,7 @@ class Array(DaskMethodsMixin):
             and chunks
             and any(isinstance(c, str) for c in chunks)
         ):
-            dt = meta.dtype
+            dt = _meta.dtype
         else:
             dt = None
         self._chunks = normalize_chunks(chunks, shape, dtype=dt)

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -44,6 +44,11 @@ def meta_from_array(x, ndim=None, dtype=None):
     # implement a _meta attribute that are incompatible with Dask Array._meta
     if hasattr(x, "_meta") and is_dask_collection(x) and is_arraylike(x):
         x = x._meta
+        if ndim is None and dtype is None:
+            # no modifications!
+            return x
+        if ndim is None and dtype is not None:
+            return x.astype(dtype, copy=False)
 
     if dtype is None and x is None:
         raise ValueError("You must specify the meta or dtype of the array")


### PR DESCRIPTION
When passing a dask array and no modifications are needed (e.g. dtype or ndim), then use that's array's meta directly. If only `dtype` is set, then use `astype` on that meta.

 xref https://github.com/xarray-contrib/flox/issues/396

cc @phofl 
