### PR TITLE
Ensure subgraphs release intermediate results

### DIFF
--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -199,7 +199,7 @@ def _execute_subgraph(inner_dsk, outkey, inkeys, external_deps):
         final[k] = DataNode(None, v)
     for k, v in external_deps.items():
         final[k] = DataNode(None, v)
-    res = execute_graph(final)
+    res = execute_graph(final, keys=[outkey])
     return res[outkey]
 
 


### PR DESCRIPTION
This includes the memory release fix of https://github.com/dask/dask/pull/11509 but for parsed subgraph callables