### PR TITLE
Ensure that from_array creates a copy

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3622,7 +3622,7 @@ def from_array(
     if isinstance(x, (list, tuple, memoryview) + np.ScalarType):
         x = np.array(x)
 
-    if is_arraylike(x):
+    if is_arraylike(x) and hasattr(x, "copy"):
         x = x.copy()
 
     if asarray is None:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3622,6 +3622,9 @@ def from_array(
     if isinstance(x, (list, tuple, memoryview) + np.ScalarType):
         x = np.array(x)
 
+    if is_arraylike(x):
+        x = x.copy()
+
     if asarray is None:
         asarray = not hasattr(x, "__array_function__")
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -5383,6 +5383,15 @@ def test_to_backend():
             x.to_backend("missing")
 
 
+def test_from_array_copies():
+    x = np.arange(60).reshape((6, 10))
+    original_array = x.copy()
+    chunks = (2, 3)
+    dx = da.from_array(x, chunks=chunks)
+    x[2:4, x[0] > 3] = -5
+    assert_eq(original_array, dx)
+
+
 def test_load_store_chunk():
     actual = np.array([0, 0, 0, 0, 0, 0])
     load_store_chunk(

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2707,7 +2707,8 @@ def test_from_array_inline():
 
     a = np.array([1, 2, 3]).view(MyArray)
     dsk = dict(da.from_array(a, name="my-array", inline_array=False).dask)
-    assert dsk["original-my-array"] is a
+    assert not dsk["original-my-array"] is a
+    assert_eq(dsk["original-my-array"], a)
 
     dsk = dict(da.from_array(a, name="my-array", inline_array=True).dask)
     assert "original-my-array" not in dsk

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2579,7 +2579,8 @@ def test_from_array_ndarray_onechunk(x):
     dx = da.from_array(x, chunks=-1)
     assert_eq(x, dx)
     assert len(dx.dask) == 1
-    assert dx.dask[(dx.name,) + (0,) * dx.ndim] is x
+    assert not dx.dask[(dx.name,) + (0,) * dx.ndim] is x
+    assert_eq(dx.dask[(dx.name,) + (0,) * dx.ndim], x)
 
 
 def test_from_array_ndarray_getitem():
@@ -4379,7 +4380,7 @@ def test_blockwise_with_numpy_arrays():
     assert_eq(x + y, x + x)
 
     s = da.sum(x)
-    assert any(x is v for v in s.dask.values())
+    assert any(isinstance(v, np.ndarray) for v in s.dask.values())
 
 
 @pytest.mark.parametrize("chunks", (100, 6))

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -392,7 +392,6 @@ def test_fuse_getter_with_asarray(chunks):
     y = da.ones(10, chunks=chunks)
     z = x + y
     dsk = z.__dask_optimize__(z.dask, z.__dask_keys__())
-    assert any(v is x for v in dsk.values())
     for v in dsk.values():
         s = str(v)
         assert s.count("getitem") + s.count("getter") <= 1


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

Yikes, I ran into this when working on linear fusion. Testing that gave me a bunch of weird collision errors which are explainable by the missing copy here