### PR TITLE
Fix equality compariso for 2 task ref classes

### DIFF
--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -368,6 +368,11 @@ class TaskRef:
     val: KeyType
     __slots__ = ("key",)
 
+    def __eq__(self, other):
+        if not isinstance(other, TaskRef):
+            return False
+        return self.key == other.key
+
     def __init__(self, key: KeyType):
         self.key = key
 

--- a/dask/tests/test_task_spec.py
+++ b/dask/tests/test_task_spec.py
@@ -901,3 +901,11 @@ def test_subgraph_dont_hold_in_memory_too_long_legacy():
     converted = convert_legacy_graph(dsk)
     assert converted["bar"]()
     assert OnlyTwice.total == 10
+
+
+def test_taskref_equality():
+    first_ref = TaskRef("foo")
+    second_ref = TaskRef("foo")
+    assert first_ref == second_ref
+    third_ref = TaskRef("bar")
+    assert first_ref != third_ref


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

cc @fjetter 