### PR TITLE
Add ``scikit-image`` nightly back to upstream CI

### DIFF
--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -34,6 +34,7 @@ if [[ ${UPSTREAM_DEV} ]]; then
         numpy \
         pandas \
         scipy \
+        scikit-image \
         h5py
 
     # Used when automatically opening an issue when the `upstream` CI build fails


### PR DESCRIPTION
Now that https://github.com/scikit-image/scikit-image/issues/7607 is resolved we can add these nightlies back (xref https://github.com/dask/dask/pull/11516 where they were removed) 