### PR TITLE
Remove optimize_slices

### DIFF
--- a/dask/array/optimization.py
+++ b/dask/array/optimization.py
@@ -1,36 +1,21 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from itertools import zip_longest
 from numbers import Integral
-from typing import Any
-
-import numpy as np
 
 from dask import config
 from dask._task_spec import convert_legacy_graph, fuse_linear_task_spec
-from dask.array.chunk import getitem
-from dask.array.core import getter, getter_inline, getter_nofancy
 from dask.blockwise import fuse_roots, optimize_blockwise
 from dask.core import flatten
 from dask.highlevelgraph import HighLevelGraph
-from dask.optimization import SubgraphCallable
 from dask.utils import ensure_dict
-
-# All get* functions the optimizations know about
-GETTERS = (getter, getter_nofancy, getter_inline, getitem)
-# These get* functions aren't ever completely removed from the graph,
-# even if the index should be a no-op by numpy semantics. Some array-like's
-# don't completely follow semantics, making indexing always necessary.
-GETNOREMOVE = (getter, getter_nofancy)
 
 
 def optimize(dsk, keys, **kwargs):
     """Optimize dask for array computation
 
     1.  Cull tasks not necessary to evaluate keys
-    2.  Remove full slicing, e.g. x[:]
-    3.  Inline fast functions like getitem and np.transpose
+    2.  Perform linear fusion
     """
     if not isinstance(keys, (list, set)):
         keys = [keys]
@@ -52,126 +37,6 @@ def optimize(dsk, keys, **kwargs):
 
     dsk = convert_legacy_graph(dsk)
     dsk = fuse_linear_task_spec(dsk, keys=keys)
-
-    return dsk
-
-
-def _is_getter_task(
-    value,
-) -> tuple[Callable, Any, Any, bool, bool | None] | None:
-    """Check if a value in a Dask graph looks like a getter.
-
-    1. Is it a tuple with the first element a known getter.
-    2. Is it a SubgraphCallable with a single element in its
-       dsk which is a known getter.
-
-    If a getter is found, it returns a tuple with (getter, array, index, asarray, lock).
-    Otherwise it returns ``None``.
-
-    TODO: the second check is a hack to allow for slice fusion between tasks produced
-    from blockwise layers and slicing operations. Once slicing operations have
-    HighLevelGraph layers which can talk to Blockwise layers this check *should* be
-    removed, and we should not have to introspect SubgraphCallables.
-    """
-    if type(value) is not tuple:
-        return None
-    first = value[0]
-    get: Callable | None = None
-    if first in GETTERS:
-        get = first
-    # We only accept SubgraphCallables with a single sub-task right now as it's
-    # not clear which task to inspect if there is more than one, or how to resolve
-    # conflicts if they occur.
-    elif isinstance(first, SubgraphCallable) and len(first.dsk) == 1:
-        v = next(iter(first.dsk.values()))
-        if type(v) is tuple and len(v) > 1 and v[0] in GETTERS:
-            get = v[0]
-    if get is None:  # Didn't find a getter
-        return None
-
-    length = len(value)
-    if length == 3:
-        # getter defaults to asarray=True, getitem is semantically False
-        return get, value[1], value[2], get is not getitem, None
-    elif length == 5:
-        return get, *value[1:]
-
-    return None
-
-
-def optimize_slices(dsk):
-    """Optimize slices
-
-    1.  Fuse repeated slices, like x[5:][2:6] -> x[7:11]
-    2.  Remove full slices, like         x[:] -> x
-
-    See also:
-        fuse_slice_dict
-    """
-    fancy_ind_types = (list, np.ndarray)
-    dsk = dsk.copy()
-    for k, v in dsk.items():
-        if a_task := _is_getter_task(v):
-            get, a, a_index, a_asarray, a_lock = a_task
-
-            while b_task := _is_getter_task(a):
-                f2, b, b_index, b_asarray, b_lock = b_task
-
-                if a_lock and a_lock is not b_lock:
-                    break
-                if (type(a_index) is tuple) != (type(b_index) is tuple):
-                    break
-                if type(a_index) is tuple:
-                    indices = b_index + a_index
-                    if len(a_index) != len(b_index) and any(i is None for i in indices):
-                        break
-                    if f2 is getter_nofancy and any(
-                        isinstance(i, fancy_ind_types) for i in indices
-                    ):
-                        break
-                elif f2 is getter_nofancy and (
-                    type(a_index) in fancy_ind_types or type(b_index) in fancy_ind_types
-                ):
-                    break
-                try:
-                    c_index = fuse_slice(b_index, a_index)
-                    # rely on fact that nested gets never decrease in
-                    # strictness e.g. `(getter_nofancy, (getter, ...))` never
-                    # happens
-                    get = getter if f2 is getter_inline else f2
-                except NotImplementedError:
-                    break
-                a, a_index, a_lock = b, c_index, b_lock
-                a_asarray |= b_asarray
-
-            # Skip the get call if not from from_array and nothing to do
-            if get not in GETNOREMOVE and (
-                (
-                    type(a_index) is slice
-                    and not a_index.start
-                    and a_index.stop is None
-                    and a_index.step is None
-                )
-                or (
-                    type(a_index) is tuple
-                    and all(
-                        type(s) is slice
-                        and not s.start
-                        and s.stop is None
-                        and s.step is None
-                        for s in a_index
-                    )
-                )
-            ):
-                dsk[k] = a
-            elif get is getitem or (a_asarray and not a_lock):
-                # default settings are fine, drop the extra parameters Since we
-                # always fallback to inner `get` functions, `get is getitem`
-                # can only occur if all gets are getitem, meaning all
-                # parameters must be getitem defaults.
-                dsk[k] = (get, a, a_index)
-            else:
-                dsk[k] = (get, a, a_index, a_asarray, a_lock)
 
     return dsk
 


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

This can all go away now

``fuse_slices`` should probably go away to or get a lot easier, but this is still used in store