### PR TITLE
Make reshape_blockwise a noop if shape is the same

### DIFF
--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -473,6 +473,9 @@ def reshape_blockwise(
 
     _sanity_checks(x, shape)
 
+    if len(shape) == x.ndim and shape == x.shape:
+        return Array(x.dask, x.name, x.chunks, meta=x)
+
     outname = "reshape-blockwise-" + tokenize(x, shape)
     chunk_tuples = list(product(*(range(len(c)) for i, c in enumerate(x.chunks))))
 
@@ -514,9 +517,6 @@ def reshape_blockwise(
     _, _, mapper_in, one_dimensions = reshape_rechunk(
         x.shape, shape, x.chunks, disallow_dimension_expansion=True
     )
-
-    if len(shape) == x.ndim:
-        return Array(x.dask, x.name, x.chunks, meta=x)
 
     # Convert input chunks to output chunks
     out_shapes = [

--- a/dask/array/tests/test_reshape.py
+++ b/dask/array/tests/test_reshape.py
@@ -411,18 +411,21 @@ def test_reshape_blockwise_raises_for_expansion():
         reshape_blockwise(arr, (3, 2, 9))
 
 
-@pytest.mark.parametrize("shape", [(18, 3), (6, 3, 3)])
-def test_reshape_blockwise_dimension_reduction_and_chunks(shape):
+def test_reshape_blockwise_dimension_reduction_and_chunks():
     x = np.arange(0, 54).reshape(6, 3, 3)
     arr = from_array(x, chunks=(3, 2, (2, 1)))
     with pytest.raises(ValueError, match="Setting chunks is not allowed when"):
-        reshape_blockwise(arr, shape, arr.chunks)
+        reshape_blockwise(arr, (18, 3), arr.chunks)
 
 
 def test_reshape_blockwise_identity():
     x = np.arange(0, 54).reshape(6, 3, 3)
     arr = from_array(x, chunks=(3, 2, (2, 1)))
     result = reshape_blockwise(arr, (6, 3, 3))
+    assert len(arr.dask) == len(result.dask)
+    assert_eq(result, x)
+
+    result = reshape_blockwise(arr, (6, 3, 3), chunks=arr.chunks)
     assert len(arr.dask) == len(result.dask)
     assert_eq(result, x)
 


### PR DESCRIPTION
- [ ] Closes #11540
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
