### PR TITLE
Temporarily disable gpuCI update CI job

### DIFF
--- a/.github/workflows/update-gpuci.yml
+++ b/.github/workflows/update-gpuci.yml
@@ -1,8 +1,10 @@
 name: Check for gpuCI updates
 
 on:
-  schedule:
-    - cron: "0 0 * * *" # Daily “At 00:00” UTC
+  # Disabling scheduled runs until gpuCI is back online.
+  # See https://github.com/dask/community/issues/404
+  # schedule:
+  #   - cron: "0 0 * * *" # Daily “At 00:00” UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This is just to avoid getting PRs like https://github.com/dask/dask/pull/11533 until things are back online

xref https://github.com/dask/community/issues/404

cc @dask/gpu 