### PR TITLE
add LLM chatbot to Dask docs

### DIFF
--- a/docs/source/_static/custom.js
+++ b/docs/source/_static/custom.js
@@ -13,11 +13,10 @@ document.addEventListener("DOMContentLoaded", function () {
   script.setAttribute("runllm-position-y", "50%");
   script.setAttribute("runllm-assistant-id", "273");
   script.setAttribute("runllm-theme-color", "#FFC11E");
-  script.setAttribute("runllm-slack-community-url", "TODO");
+  script.setAttribute("runllm-slack-community-url", "https://dask.slack.com/");
   script.setAttribute("runllm-per-user-usage-limit", 2);
   script.setAttribute("runllm-usage-limit-effective-days", 30);
-  script.setAttribute("runllm-usage-limit-message", `#Hello!
-You are out of queries.`);
+  script.setAttribute("runllm-usage-limit-message", `Hi! You've hit the limit for anonymous questions, but you can join us on Slack in #DaskBot and ask as many questions as you'd like.`);
   script.setAttribute("runllm-brand-logo", "_images/dask_icon.svg");
 
   script.async = true;

--- a/docs/source/_static/custom.js
+++ b/docs/source/_static/custom.js
@@ -1,0 +1,25 @@
+document.addEventListener("DOMContentLoaded", function () {
+  var script = document.createElement("script");
+  script.type = "module";
+  script.id = "runllm-widget-script"
+
+  script.src = "https://widget.runllm.com";
+
+  script.setAttribute("version", "stable");
+  script.setAttribute("runllm-keyboard-shortcut", "Mod+j"); // cmd-j or ctrl-j to open the widget.
+  script.setAttribute("runllm-name", "DaskBot");
+  script.setAttribute("runllm-position", "BOTTOM_RIGHT"); // put above ethical ads
+  script.setAttribute("runllm-position-x", "20px");
+  script.setAttribute("runllm-position-y", "50%");
+  script.setAttribute("runllm-assistant-id", "273");
+  script.setAttribute("runllm-theme-color", "#FFC11E");
+  script.setAttribute("runllm-slack-community-url", "TODO");
+  script.setAttribute("runllm-per-user-usage-limit", 2);
+  script.setAttribute("runllm-usage-limit-effective-days", 30);
+  script.setAttribute("runllm-usage-limit-message", `#Hello!
+You are out of queries.`);
+  script.setAttribute("runllm-brand-logo", "_images/dask_icon.svg");
+
+  script.async = true;
+  document.head.appendChild(script);
+});

--- a/docs/source/_static/custom.js
+++ b/docs/source/_static/custom.js
@@ -24,4 +24,3 @@ document.addEventListener("DOMContentLoaded", function () {
   script.async = true;
   document.head.appendChild(script);
 });
-

--- a/docs/source/_static/custom.js
+++ b/docs/source/_static/custom.js
@@ -18,7 +18,10 @@ document.addEventListener("DOMContentLoaded", function () {
   script.setAttribute("runllm-usage-limit-effective-days", 30);
   script.setAttribute("runllm-usage-limit-message", `Hi! You've hit the limit for anonymous questions, but you can join us on Slack in #DaskBot and ask as many questions as you'd like.`);
   script.setAttribute("runllm-brand-logo", "_images/dask_icon.svg");
+  script.setAttribute("runllm-floating-button-text", "Ask DaskBot");
+  script.setAttribute("runllm-join-community-text", "Chat with DaskBot in Slack");
 
   script.async = true;
   document.head.appendChild(script);
 });
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -154,6 +154,8 @@ html_theme_options = {"logo_only": True}
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+html_js_files = ["custom.js"]
+
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
 # html_last_updated_fmt = '%b %d, %Y'


### PR DESCRIPTION
This adds a LLM chatbot (using RAG based on Dask docs, StackOverflow Q&A, and a few other Dask-related sources) to the Dask docs. It's something I talked with a few Dask contributors about (@mrocklin , @jrbourbeau , @fjetter, @jacobtomlinson  via Florian) before getting this pull request ready.

We (I and some other folks at Coiled) have played a bit with the questions and answers and think the quality is high enough to try out on real users, but we (@jrbourbeau for now) will plan to monitor the Q&A for quality. 

It's implemented using a product (https://runllm.com/) that Coiled plans to pay for (and continue paying for if this experiment goes well and we keep this in the docs). To avoid paying unlimited amounts for anonymous questions and limit abuse, we're requiring users to join the Dask Slack to send more than 2 queries.

Some considerations going into the choices here:

* Discourse would have been better since the Dask community is much more present there; supporting Discourse is more complicated than Slack, but it's on RunLLM's roadmap. We'd probably want to switch to pushing people there once it's an option. (I've created the Slack channel "DaskBot" for this and set up the integration.)
* I picked the middle/right side of the screen for the button, since dask.docs.org already shows ads in the bottom right.
* We can't currently change the text "Ask AI", but if people feel it's important to switch to something more like "Ask Daskbot", I can let the RunLLM people know we'd really like to make that switch in the future. 

<img width="1728" alt="Screenshot 2024-11-21 at 5 12 20 PM" src="https://github.com/user-attachments/assets/301f6acf-378b-41d0-8afe-84397e2f2721">
<img width="1725" alt="Screenshot 2024-11-21 at 5 12 06 PM" src="https://github.com/user-attachments/assets/d655b4fc-394e-499c-aabb-359f5118cfaf">

