### PR TITLE
Convert `Bag` graphs to TaskSpec graphs during optimization

### DIFF
--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -915,3 +915,22 @@ def fuse_linear_task_spec(dsk, keys):
                 # Having the same prefixes can result in the same key, i.e. getitem-hash -> getitem-hash
                 result[top_key] = Alias(top_key, target=renamed_key)
     return result
+
+
+def cull(
+    dsk: dict[KeyType, GraphNode], keys: Iterable[KeyType]
+) -> dict[KeyType, GraphNode]:
+    work = set(keys)
+    seen: set[KeyType] = set()
+    dsk2 = {}
+    wpop = work.pop
+    wupdate = work.update
+    sadd = seen.add
+    while work:
+        k = wpop()
+        if k in seen or k not in dsk:
+            continue
+        sadd(k)
+        dsk2[k] = v = dsk[k]
+        wupdate(v.dependencies)
+    return dsk2

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -112,7 +112,7 @@ def lazify_task(task, start=True):
         if task.func is _execute_subgraph:
             subgraph = task.args[0]
             outkey = task.args[1]
-            # If there is a reify at the start of this we don't want to act
+            # If there is a reify at the output of the subgraph we don't want to act
             final_task = lazify_task(subgraph[outkey], True)
             subgraph = {
                 k: lazify_task(v, False) for k, v in subgraph.items() if k != outkey

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -38,7 +38,15 @@ from tlz import (
 )
 
 from dask import config
-from dask._task_spec import GraphNode, List, Task
+from dask._task_spec import (
+    GraphNode,
+    List,
+    Task,
+    _execute_subgraph,
+    convert_legacy_graph,
+    cull,
+    fuse_linear_task_spec,
+)
 from dask.bag import chunk
 from dask.bag.avro import to_avro
 from dask.base import (
@@ -50,17 +58,15 @@ from dask.base import (
 )
 from dask.blockwise import blockwise
 from dask.context import globalmethod
-from dask.core import flatten, get_dependencies, istask, quote, reverse_dict
+from dask.core import flatten, istask, quote
 from dask.delayed import Delayed, unpack_collections
 from dask.highlevelgraph import HighLevelGraph
-from dask.optimization import cull, fuse, inline
 from dask.sizeof import sizeof
 from dask.typing import Graph, NestedKeys, no_default
 from dask.utils import (
     apply,
     digit,
     ensure_bytes,
-    ensure_dict,
     ensure_unicode,
     funcname,
     get_default_shuffle_method,
@@ -103,6 +109,23 @@ def lazify_task(task, start=True):
         if not start and task.func in (list, reify) and isinstance(task.args[0], Task):
             assert len(task.args) == 1
             task = task.args[0]
+        if task.func is _execute_subgraph:
+            subgraph = task.args[0]
+            outkey = task.args[1]
+            # If there is a reify at the start of this we don't want to act
+            final_task = lazify_task(subgraph[outkey], True)
+            subgraph = {
+                k: lazify_task(v, False) for k, v in subgraph.items() if k != outkey
+            }
+            subgraph[outkey] = final_task
+            return Task(
+                task.key,
+                _execute_subgraph,
+                subgraph,
+                outkey,
+                *task.args[2:],
+                **task.kwargs,
+            )
         return Task(
             task.key,
             task.func,
@@ -133,47 +156,14 @@ def lazify(dsk):
     return valmap(lazify_task, dsk)
 
 
-def inline_singleton_lists(dsk, keys, dependencies=None):
-    """Inline lists that are only used once.
-
-    >>> d = {'b': (list, 'a'),
-    ...      'c': (sum, 'b', 1)}
-    >>> inline_singleton_lists(d, 'c')
-    {'c': (<built-in function sum>, (<class 'list'>, 'a'), 1)}
-
-    Pairs nicely with lazify afterwards.
-    """
-    if dependencies is None:
-        dependencies = {k: get_dependencies(dsk, task=v) for k, v in dsk.items()}
-    dependents = reverse_dict(dependencies)
-
-    inline_keys = {
-        k
-        for k, v in dsk.items()
-        if istask(v)
-        and not isinstance(v, GraphNode)
-        and v
-        and v[0] is list
-        and len(dependents[k]) == 1
-    }
-    inline_keys.difference_update(flatten(keys))
-    dsk = inline(dsk, inline_keys, inline_constants=False)
-    for k in inline_keys:
-        del dsk[k]
-    return dsk
-
-
-def optimize(dsk, keys, fuse_keys=None, rename_fused_keys=None, **kwargs):
+def optimize(dsk, keys, fuse_keys=None, **kwargs):
     """Optimize a dask from a dask Bag."""
-    dsk = ensure_dict(dsk)
-    dsk2, dependencies = cull(dsk, keys)
-    kwargs = {}
-    if rename_fused_keys is not None:
-        kwargs["rename_keys"] = rename_fused_keys
-    dsk3, dependencies = fuse(dsk2, keys + (fuse_keys or []), dependencies, **kwargs)
-    dsk4 = inline_singleton_lists(dsk3, keys, dependencies)
-    dsk5 = lazify(dsk4)
-    return dsk5
+    dsk = convert_legacy_graph(dsk)
+    keys = list(flatten(keys))
+    dsk2 = cull(dsk, keys)
+    dsk3 = fuse_linear_task_spec(dsk2, keys + (fuse_keys or []))
+    dsk4 = lazify(dsk3)
+    return dsk4
 
 
 def _to_textfiles_chunk(data, lazy_file, last_endline):

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -19,7 +19,7 @@ from tlz import groupby, identity, join, merge, pluck, unique, valmap
 
 import dask
 import dask.bag as db
-from dask._task_spec import Task
+from dask._task_spec import List, Task
 from dask.bag.core import (
     Bag,
     collect,
@@ -588,6 +588,31 @@ def test_lazify_task():
     )
     expected = Task(None, reify, Task(None, map, inc, Task(None, filter, iseven, "y")))
     assert lazify_task(task) == expected
+
+    task = Task(
+        None,
+        sum,
+        List(
+            Task(
+                None,
+                reify,
+                Task(None, map, inc, Task(None, reify, Task(None, filter, iseven, 1))),
+            ),
+            Task(
+                None,
+                reify,
+                Task(None, map, inc, Task(None, reify, Task(None, filter, iseven, 2))),
+            ),
+        ),
+    )
+    assert lazify_task(task) == Task(
+        None,
+        sum,
+        List(
+            Task(None, map, inc, Task(None, filter, iseven, 1)),
+            Task(None, map, inc, Task(None, filter, iseven, 2)),
+        ),
+    )
 
 
 def test_lazify_task_legacy():

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -1189,8 +1189,13 @@ def test_to_delayed_optimize_graph(tmpdir, monkeypatch):
     [d2] = b2.to_delayed(optimize_graph=False)
     assert dict(d2.dask) == dict(b2.dask)
     assert d2.__dask_layers__() == b2.__dask_layers__()
-    assert d.compute() == d2.compute()
-    assert calls == 1 + 3
+    calls = 0
+    result = d.compute()
+    assert calls == 1
+    calls = 0
+    result2 = d2.compute()
+    assert calls == 3
+    assert result == result2
 
     x = b2.sum()
     d = x.to_delayed()

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -371,7 +371,7 @@ def test_compute_no_opt():
     # Otherwise, the lengths below would be 4 and 0.
     assert len([k for k in keys if "mul" in k[0]]) == 8
     assert len([k for k in keys if "add" in k[0]]) == 4
-    assert len([k for k in keys if "add-mul" in k[0]]) == 4  # See? Renamed
+    assert len([k for k in keys if "add-from_sequence-mul" in k[0]]) == 4
 
 
 @pytest.mark.skipif("not da")


### PR DESCRIPTION
This optimization seems to be important. There are some interesting shananigans going on inside of the bag implementation with iterators so not lazifying  this can break fusion it seems.

I stumbled over this in https://github.com/dask/dask/pull/11568 because it looks like I'll have to touch bag optimizers to get this over the finishing line, similar to what we did with arrays.

~This is a minimal step in that direction~

Edit: I had to follow through and add the conversion layer to the optimization step as well. I killed off one of the optimizations (inlining lists). Many of these types of tasks will vanish when moving to https://github.com/dask/dask/pull/11568 so I didn't bother with the migration. If this becomes an issue, we'll have to look at how those tasks look like afterwards since it's not entirely clear to me at the moment.

From what I can tell, the most important test is `test_map_releases_element_references_as_soon_as_possible` which tests that tasks are indeed properly pipelined and intermediate memory is released as required. This is also what tripped me in https://github.com/dask/dask/pull/11568