### PR TITLE
asarray ignores dtype for array inputs

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4728,7 +4728,9 @@ def asarray(
             return a.map_blocks(np.asarray, like=like_meta, dtype=dtype, order=order)
         else:
             a = np.asarray(a, like=like_meta, dtype=dtype, order=order)
-    return from_array(a, getitem=getter_inline, **kwargs)
+
+    a = from_array(a, getitem=getter_inline, **kwargs)
+    return _as_dtype(a, dtype)
 
 
 def asanyarray(a, dtype=None, order=None, *, like=None, inline_array=False):
@@ -4800,13 +4802,15 @@ def asanyarray(a, dtype=None, order=None, *, like=None, inline_array=False):
             return a.map_blocks(np.asanyarray, like=like_meta, dtype=dtype, order=order)
         else:
             a = np.asanyarray(a, like=like_meta, dtype=dtype, order=order)
-    return from_array(
+
+    a = from_array(
         a,
         chunks=a.shape,
         getitem=getter_inline,
         asarray=False,
         inline_array=inline_array,
     )
+    return _as_dtype(a, dtype)
 
 
 def is_scalar_for_elemwise(arg):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2826,10 +2826,24 @@ def test_asarray_array_dtype(asarray):
     x = asarray([1, 2])
     assert_eq(asarray(x, dtype=da.float32), np.asarray(x, dtype=np.float32))
 
+    # dask->dask
     x = asarray(x, dtype=da.float64)
     assert x.dtype == da.float64
     x = asarray(x, dtype=da.int32)
     assert x.dtype == da.int32
+    x = asarray(x)
+    assert x.dtype == da.int32
+    # Test explicit null dtype. astype(None) converts to float!
+    x = asarray(x, dtype=None)
+    assert x.dtype == da.int32
+
+    # non-dask->dask
+    x = asarray(np.asarray([1, 2], dtype=np.int8))
+    assert x.dtype == da.int8
+    x = asarray(np.asarray([1, 2], dtype=np.int8), dtype=None)
+    assert x.dtype == da.int8
+    x = asarray(np.asarray([1, 2], dtype=np.int8), dtype=da.float64)
+    assert x.dtype == da.float64
 
 
 @pytest.mark.parametrize("asarray", [da.asarray, da.asanyarray])


### PR DESCRIPTION
Fix bug where `da.asarray(x, dtype=...)` would not change the dtype when x is a non-dask array-like