### PR TITLE
Add back LLM chatbot to Dask docs

### DIFF
--- a/docs/source/_static/custom.js
+++ b/docs/source/_static/custom.js
@@ -1,0 +1,26 @@
+document.addEventListener("DOMContentLoaded", function () {
+  var script = document.createElement("script");
+  script.type = "module";
+  script.id = "runllm-widget-script"
+
+  script.src = "https://widget.runllm.com";
+
+  script.setAttribute("version", "stable");
+  script.setAttribute("runllm-keyboard-shortcut", "Mod+j"); // cmd-j or ctrl-j to open the widget.
+  script.setAttribute("runllm-name", "DaskBot");
+  script.setAttribute("runllm-position", "BOTTOM_RIGHT"); // put above ethical ads
+  script.setAttribute("runllm-position-x", "20px");
+  script.setAttribute("runllm-position-y", "50%");
+  script.setAttribute("runllm-assistant-id", "273");
+  script.setAttribute("runllm-theme-color", "#FFC11E");
+  script.setAttribute("runllm-slack-community-url", "https://dask.slack.com/");
+  script.setAttribute("runllm-per-user-usage-limit", 2);
+  script.setAttribute("runllm-usage-limit-effective-days", 30);
+  script.setAttribute("runllm-usage-limit-message", `Hi! You've hit the limit for anonymous questions, but you can join us on Slack in #DaskBot and ask as many questions as you'd like.`);
+  script.setAttribute("runllm-brand-logo", "_images/dask_icon.svg");
+  script.setAttribute("runllm-floating-button-text", "Ask DaskBot");
+  script.setAttribute("runllm-join-community-text", "Chat with DaskBot in Slack");
+
+  script.async = true;
+  document.head.appendChild(script);
+});

--- a/docs/source/_static/custom.js
+++ b/docs/source/_static/custom.js
@@ -19,7 +19,7 @@ document.addEventListener("DOMContentLoaded", function () {
   script.setAttribute("runllm-usage-limit-message", `Hi! You've hit the limit for anonymous questions, but you can join us on Slack in #DaskBot and ask as many questions as you'd like.`);
   script.setAttribute("runllm-brand-logo", "_images/dask_icon.svg");
   script.setAttribute("runllm-floating-button-text", "Ask DaskBot");
-  script.setAttribute("runllm-join-community-text", "Chat with DaskBot in Slack");
+  script.setAttribute("runllm-join-community-text", "Chat with DaskBot in Slack (join the #DaskBot channel)");
 
   script.async = true;
   document.head.appendChild(script);

--- a/docs/source/_static/custom.js
+++ b/docs/source/_static/custom.js
@@ -16,7 +16,7 @@ document.addEventListener("DOMContentLoaded", function () {
   script.setAttribute("runllm-slack-community-url", "https://dask.slack.com/");
   script.setAttribute("runllm-per-user-usage-limit", 2);
   script.setAttribute("runllm-usage-limit-effective-days", 30);
-  script.setAttribute("runllm-usage-limit-message", `Hi! You've hit the limit for anonymous questions, but you can join us on Slack in #DaskBot and ask as many questions as you'd like.`);
+  script.setAttribute("runllm-usage-limit-message", `Hi! You've hit the limit for questions here in the docs, but you can join us on the Dask community Slack and ask as many questions as you'd like in #DaskBot channel. Hope to see you there.`);
   script.setAttribute("runllm-brand-logo", "_images/dask_icon.svg");
   script.setAttribute("runllm-floating-button-text", "Ask DaskBot");
   script.setAttribute("runllm-join-community-text", "Chat with DaskBot in Slack (join the #DaskBot channel)");

--- a/docs/source/_static/custom.js
+++ b/docs/source/_static/custom.js
@@ -14,7 +14,7 @@ document.addEventListener("DOMContentLoaded", function () {
   script.setAttribute("runllm-assistant-id", "273");
   script.setAttribute("runllm-theme-color", "#FFC11E");
   script.setAttribute("runllm-slack-community-url", "https://dask.slack.com/");
-  script.setAttribute("runllm-per-user-usage-limit", 2);
+  script.setAttribute("runllm-per-user-usage-limit", 5);
   script.setAttribute("runllm-usage-limit-effective-days", 30);
   script.setAttribute("runllm-usage-limit-message", `Hi! You've hit the limit for questions here in the docs, but you can join us on the Dask community Slack and ask as many questions as you'd like in #DaskBot channel. Hope to see you there.`);
   script.setAttribute("runllm-brand-logo", "_images/dask_icon.svg");

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -154,6 +154,8 @@ html_theme_options = {"logo_only": True}
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+html_js_files = ["custom.js"]
+
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
 # html_last_updated_fmt = '%b %d, %Y'


### PR DESCRIPTION
Initially added in #11556, reverted in #11577. 

Put back the LLM chatbot. You can try it at https://dask--11594.org.readthedocs.build/en/11594/.

We'd reverted it for two reasons:

1. It was briefly broken (unexpected error) at `https://docs.dask.org/en/latest/`. The RunLLM folks say that's solved on their end now (duplicate config or something, one of them wrong).
2. The user flow from docs => Slack wasn't great. (Seems like users might get confused about what channel to be in, and the fact they have to @ mention the chatbot.)

To address (2) I've done:

- now the chatbot responds without an @ mention (a setting I changed)
- channel is more prominent:

<img width="875" alt="Screenshot 2024-12-11 at 3 47 06 PM" src="https://github.com/user-attachments/assets/aa33d95b-a7ed-4cb4-a85a-30b0e70a80c4" />
