### PR TITLE
Disable legacy dataframe tests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,13 +84,6 @@ jobs:
         if: ${{ matrix.extra == 'pandas-nightly' }}
         run: python -m pip install --pre --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple pandas -U
 
-      - name: Disable query planning for 3.10 builds
-        if: ${{ matrix.environment == '3.10' }}
-        run: |
-          export DASK_DATAFRAME__QUERY_PLANNING="False"
-          echo "DASK_DATAFRAME__QUERY_PLANNING: $DASK_DATAFRAME__QUERY_PLANNING"
-          echo "DASK_DATAFRAME__QUERY_PLANNING=$DASK_DATAFRAME__QUERY_PLANNING" >> $GITHUB_ENV
-
       - name: Disable auto pyarrow strings for 3.10 builds
         if: ${{ matrix.environment == '3.10' }}
         run: |

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -15,7 +15,7 @@ dataframe:
     metadata-task-size-local: 512  # Number of files per local metadata-processing task
     metadata-task-size-remote: 1  # Number of files per remote metadata-processing task
     minimum-partition-size: 75000000
-  convert-string: null  # Whether to convert string-like data to pyarrow strings
+  convert-string: false  # Whether to convert string-like data to pyarrow strings
   query-planning: null  # Whether to use dask-expr
 
 array:

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -15,7 +15,7 @@ dataframe:
     metadata-task-size-local: 512  # Number of files per local metadata-processing task
     metadata-task-size-remote: 1  # Number of files per remote metadata-processing task
     minimum-partition-size: 75000000
-  convert-string: false  # Whether to convert string-like data to pyarrow strings
+  convert-string: null  # Whether to convert string-like data to pyarrow strings
   query-planning: null  # Whether to use dask-expr
 
 array:

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -690,10 +690,6 @@ def test_read_hdf(data, compare):
             pd.read_hdf(fn, "/data", start=1, stop=3),
         )
 
-        assert sorted(dd.read_hdf(fn, "/data", mode="r").dask) == sorted(
-            dd.read_hdf(fn, "/data", mode="r").dask
-        )
-
     with tmpfile("h5") as fn:
         sorted_data = data.sort_index()
         sorted_data.to_hdf(fn, key="/data", format="table")

--- a/dask/dataframe/io/tests/test_orc.py
+++ b/dask/dataframe/io/tests/test_orc.py
@@ -11,7 +11,7 @@ import pytest
 
 import dask.dataframe as dd
 from dask.dataframe.optimize import optimize_dataframe_getitem
-from dask.dataframe.utils import assert_eq
+from dask.dataframe.utils import assert_eq, pyarrow_strings_enabled
 
 pytest.importorskip("pyarrow.orc")
 pa = pytest.importorskip("pyarrow")
@@ -145,10 +145,10 @@ def test_orc_aggregate_files_offset(orc_files):
 @pytest.mark.network
 def test_orc_names(orc_files, tmp_path):
     df = dd.read_orc(orc_files)
-    if dd._dask_expr_enabled():
+    if dd._dask_expr_enabled() and pyarrow_strings_enabled():
         assert df.expr.frame._name.startswith("_read_orc")
     else:
-        assert df._name.startswith("read-orc")
+        assert df.expr._name.startswith("_read_orc")
     out = df.to_orc(tmp_path, compute=False)
     assert out._name.startswith("to-orc")
 

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -532,10 +532,7 @@ def test_blockwise_array_creation(c, io, fuse):
 @pytest.mark.parametrize(
     "io",
     [
-        "parquet-pyarrow",
-        pytest.param(
-            "parquet-fastparquet", marks=pytest.mark.skip_with_pyarrow_strings
-        ),
+        "parquet",
         "csv",
         # See https://github.com/dask/dask/issues/9793
         pytest.param("hdf", marks=pytest.mark.flaky(reruns=5)),
@@ -556,15 +553,10 @@ def test_blockwise_dataframe_io(c, tmpdir, io, fuse, from_futures):
     else:
         ddf0 = dd.from_pandas(df, npartitions=3)
 
-    if io == "parquet-pyarrow":
+    if io == "parquet":
         pytest.importorskip("pyarrow")
         ddf0.to_parquet(str(tmpdir))
         ddf = dd.read_parquet(str(tmpdir))
-    elif io == "parquet-fastparquet":
-        pytest.importorskip("fastparquet")
-        with pytest.warns(FutureWarning):
-            ddf0.to_parquet(str(tmpdir), engine="fastparquet")
-            ddf = dd.read_parquet(str(tmpdir), engine="fastparquet")
     elif io == "csv":
         ddf0.to_csv(str(tmpdir), index=False)
         ddf = dd.read_csv(os.path.join(str(tmpdir), "*"))
@@ -578,14 +570,6 @@ def test_blockwise_dataframe_io(c, tmpdir, io, fuse, from_futures):
 
     df = df[["x"]] + 10
     ddf = ddf[["x"]] + 10
-    if not dd._dask_expr_enabled():
-        with dask.config.set({"optimization.fuse.active": fuse}):
-            ddf.compute()
-            dsk = dask.dataframe.optimize(ddf.dask, ddf.__dask_keys__())
-            # dsk should not be a dict unless fuse is explicitly True
-            assert isinstance(dsk, dict) == bool(fuse)
-
-            dd.assert_eq(ddf, df, check_index=False)
 
 
 def test_blockwise_fusion_after_compute(c):


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

Starting with ripping out the legacy implementation, this is a good first step