### PR TITLE
Avois overflowing when downcasting shuffle arrays

### DIFF
--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -220,7 +220,7 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
 
     intermediates = dict()
     merges = dict()
-    dtype = np.min_scalar_type(max(chunks[axis]))
+    dtype = np.min_scalar_type(max(max(chunks[axis]), chunk_size_limit))
     split_name = f"shuffle-split-{token}"
     slices = [slice(None)] * len(chunks)
     split_name_suffixes = count()

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -1103,3 +1103,11 @@ def test_all_none_slices_just_mappings():
     # check that we are just mapping the keys
     assert all(isinstance(v, Alias) for k, v in dsk.items() if "getitem" in k[0])
     assert_eq(result, np.ones((6, 10)))
+
+
+def test_minimal_dtype_doesnt_overflow():
+    x = np.arange(1980)
+    dx = dask.array.from_array(x, chunks=[248])
+    ib = np.zeros(1980, dtype=bool)
+    ib[1560:1860] = True
+    assert_eq(dx[ib], x[ib])


### PR DESCRIPTION
- [ ] Closes #11614
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
