### PR TITLE
Avoid producing chunks of size 0 when using `dask.array.rechunk` with `chunks='auto'`

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3329,7 +3329,8 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
                             new_chunk += c
                         else:
                             # We reach the boundary so start a new chunk
-                            dimension_result.append(new_chunk)
+                            if new_chunk > 0:
+                                dimension_result.append(new_chunk)
                             new_chunk = c
                     if new_chunk > 0:
                         dimension_result.append(new_chunk)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3077,6 +3077,15 @@ def test_align_chunks_to_previous_chunks():
     assert all(c % 512 == 0 for c in chunks[1][:-1])
     assert all(c % 512 == 0 for c in chunks[2][:-1])
 
+    chunks = normalize_chunks(
+        "auto",
+        shape=(48, 720, 1440),
+        previous_chunks=((36, 12), (720,), (1440,)),
+        limit=134217728,
+        dtype=np.float32,
+    )
+    assert chunks == ((36, 12), (720,), (1440,))
+
 
 def test_raise_on_no_chunks():
     x = da.ones(6, chunks=3)


### PR DESCRIPTION
- [x] Closes #11618
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`