### PR TITLE
Fix example Actors

### DIFF
--- a/docs/source/futures.rst
+++ b/docs/source/futures.rst
@@ -786,10 +786,12 @@ worker:
            return self.n
 
    from dask.distributed import Client
-   client = Client()
 
-   future = client.submit(Counter, actor=True)
-   counter = future.result()
+   if __name__ == '__main__':
+       client = Client()
+
+       future = client.submit(Counter, actor=True)
+       counter = future.result()
 
    >>> counter
    <Actor: Counter, key=Counter-afa1cdfb6b4761e616fa2cfab42398c8>


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

before this change, it was failing with:
```
/tmp/venv/lib/python3.12/site-packages/distributed/node.py:187: UserWarning: Port 8787 is already in use.
Perhaps you already have a cluster running?
Hosting the HTTP server on port 44661 instead
...
2024-12-25 10:41:45,278 - distributed.nanny - ERROR - Failed to start process
Traceback (most recent call last):
  File "/tmp/venv/lib/python3.12/site-packages/distributed/nanny.py", line 452, in instantiate
    result = await self.process.start()
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/venv/lib/python3.12/site-packages/distributed/nanny.py", line 750, in start
    await self.process.start()
  File "/tmp/venv/lib/python3.12/site-packages/distributed/process.py", line 55, in _call_and_set_future
    res = func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/venv/lib/python3.12/site-packages/distributed/process.py", line 215, in _start
    process.start()
  File "/home/isidro/.pyenv/versions/3.12-dev/lib/python3.12/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
                  ^^^^^^^^^^^^^^^^^
  File "/home/isidro/.pyenv/versions/3.12-dev/lib/python3.12/multiprocessing/context.py", line 289, in _Popen
    return Popen(process_obj)
           ^^^^^^^^^^^^^^^^^^
  File "/home/isidro/.pyenv/versions/3.12-dev/lib/python3.12/multiprocessing/popen_spawn_posix.py", line 32, in __init__
    super().__init__(process_obj)
  File "/home/isidro/.pyenv/versions/3.12-dev/lib/python3.12/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/home/isidro/.pyenv/versions/3.12-dev/lib/python3.12/multiprocessing/popen_spawn_posix.py", line 42, in _launch
    prep_data = spawn.get_preparation_data(process_obj._name)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/isidro/.pyenv/versions/3.12-dev/lib/python3.12/multiprocessing/spawn.py", line 164, in get_preparation_data
    _check_not_importing_main()
  File "/home/isidro/.pyenv/versions/3.12-dev/lib/python3.12/multiprocessing/spawn.py", line 140, in _check_not_importing_main
    raise RuntimeError('''
RuntimeError:
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.

        To fix this issue, refer to the "Safe importing of main module"
        section in https://docs.python.org/3/library/multiprocessing.html

```
