### PR TITLE
Fix auto-rechunking in einsum

### DIFF
--- a/dask/array/einsumfuncs.py
+++ b/dask/array/einsumfuncs.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
+import math
 from functools import reduce
-from operator import mul
 
 import numpy as np
 
 from dask.array._shuffle import _calculate_new_chunksizes
 from dask.array.core import asarray, blockwise, einsum_lookup
-from dask.utils import derived_from
+from dask.utils import cached_max, derived_from
 
 einsum_symbols = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 einsum_symbols_set = set(einsum_symbols)
@@ -236,18 +236,20 @@ def einsum(*operands, dtype=None, optimize=False, split_every=None, **kwargs):
 
     if len(inputs) > 1 and len(outputs) > 0:
         # Calculate the increase in chunk size compared to the largest input chunk
-        max_chunk_sizes, max_chunk_size_input = [], 1
+        max_chunk_sizes, max_chunk_size_input = {}, 1
         for op, input in zip(ops, inputs):
             max_chunk_size_input = max(
-                reduce(mul, map(max, op.chunks)), max_chunk_size_input
+                math.prod(map(cached_max, op.chunks)), max_chunk_size_input
             )
-            max_chunk_sizes.extend(
-                max(op.chunks[i])
-                for i, inp in enumerate(input)
-                if inp not in contract_inds
+            max_chunk_sizes.update(
+                {
+                    inp: max(cached_max(op.chunks[i]), max_chunk_sizes.get(inp, 1))
+                    for i, inp in enumerate(input)
+                    if inp not in contract_inds
+                }
             )
 
-        max_chunk_size_output = reduce(mul, max_chunk_sizes)
+        max_chunk_size_output = math.prod(max_chunk_sizes.values())
         factor = max_chunk_size_output / (
             max_chunk_size_input * config.get("array.chunk-size-tolerance")
         )
@@ -262,7 +264,7 @@ def einsum(*operands, dtype=None, optimize=False, split_every=None, **kwargs):
                 op.chunks,
                 list(op.chunks),
                 changeable_dimensions,
-                reduce(mul, map(max, op.chunks)) / f,
+                math.prod(map(cached_max, op.chunks)) / f,
             )
             new_ops.append(op.rechunk(result))
         ops = new_ops

--- a/dask/array/einsumfuncs.py
+++ b/dask/array/einsumfuncs.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import math
-from functools import reduce
 
 import numpy as np
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -2503,6 +2503,15 @@ def test_einsum_chunksizes():
     assert result.chunks == ((1,) * 4,) * 4
     assert_eq(np.einsum("aij,amn->ijmn", np_arr1, np_arr2), result)
 
+    # regression test for GH11627
+    z = da.ones(
+        shape=(40000, 2, 10, 2, 10), dtype=np.float64, chunksize=(40000, 1, 5, 2, 10)
+    )
+    x = da.ones(shape=(2, 10, 10), dtype=np.float64, chunksize=(2, 10, 10))
+    y = da.ones(shape=(2, 10, 10), dtype=np.float64, chunksize=(2, 10, 10))
+    res = da.einsum("abcde,bfc,dfe->acef", z, x, y)
+    assert res.numblocks == 1
+
 
 @pytest.mark.parametrize(
     "optimize_opts", [(True, False), ("greedy", False), ("optimal", False)]

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -2510,7 +2510,7 @@ def test_einsum_chunksizes():
     x = da.ones(shape=(2, 10, 10), dtype=np.float64, chunksize=(2, 10, 10))
     y = da.ones(shape=(2, 10, 10), dtype=np.float64, chunksize=(2, 10, 10))
     res = da.einsum("abcde,bfc,dfe->acef", z, x, y)
-    assert res.numblocks == 1
+    assert res.numblocks == (1, 1, 1, 1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is a quick fix

Perhaps we should call `unify_chunks` before doing this calculation and set `align_arrays=False` in the `blockwise` call.

- [x] Closes #11627
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
