### PR TITLE
Reduce graph size for vindex

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5699,6 +5699,8 @@ def _vindex_array(x, dict_indexes):
         else:
             inblock_idxs.append(a)
 
+    inblock_idxs = np.broadcast_arrays(*inblock_idxs)
+
     chunks = [c for i, c in enumerate(x.chunks) if i not in axes]
     # determine number of points in one single output block.
     # Use the input chunk size to determine this.

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5690,13 +5690,14 @@ def _vindex_array(x, dict_indexes):
         for b, ind in zip(bounds2, dict_indexes.values())
     )
     starts = (b[i] for i, b in zip(block_idxs, bounds2))
-    inblock_idxs = np.broadcast_arrays(
-        *(idx - start for idx, start in zip(dict_indexes.values(), starts))
-    )
-    for i, a in enumerate(inblock_idxs):
+    inblock_idxs = []
+    for idx, start in zip(dict_indexes.values(), starts):
+        a = idx - start
         if len(a) > 0:
             dtype = np.min_scalar_type(np.max(a, axis=None))
-            inblock_idxs[i] = a.astype(dtype)
+            inblock_idxs.append(a.astype(dtype, copy=False))
+        else:
+            inblock_idxs.append(a)
 
     chunks = [c for i, c in enumerate(x.chunks) if i not in axes]
     # determine number of points in one single output block.
@@ -5749,8 +5750,8 @@ def _vindex_array(x, dict_indexes):
         sorted_keys = keys.flat[sortidx]  # flattens
         sorted_inblock_idxs = [_.flat[sortidx] for _ in inblock_idxs]
         sorted_outblock_idx = outblock_idx.flat[sortidx]
-        dtype = np.min_scalar_type(max(sorted_outblock_idx))
-        sorted_outblock_idx = sorted_outblock_idx.astype(dtype)
+        dtype = np.min_scalar_type(max_chunk_point_dimensions)
+        sorted_outblock_idx = sorted_outblock_idx.astype(dtype, copy=False)
         # Determine the start and end of each unique key. We will loop over this
         flag = np.concatenate([[True], sorted_keys[1:] != sorted_keys[:-1], [True]])
         (key_bounds,) = flag.nonzero()

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5693,6 +5693,10 @@ def _vindex_array(x, dict_indexes):
     inblock_idxs = np.broadcast_arrays(
         *(idx - start for idx, start in zip(dict_indexes.values(), starts))
     )
+    for i, a in enumerate(inblock_idxs):
+        if len(a) > 0:
+            dtype = np.min_scalar_type(np.max(a, axis=None))
+            inblock_idxs[i] = a.astype(dtype)
 
     chunks = [c for i, c in enumerate(x.chunks) if i not in axes]
     # determine number of points in one single output block.
@@ -5745,6 +5749,8 @@ def _vindex_array(x, dict_indexes):
         sorted_keys = keys.flat[sortidx]  # flattens
         sorted_inblock_idxs = [_.flat[sortidx] for _ in inblock_idxs]
         sorted_outblock_idx = outblock_idx.flat[sortidx]
+        dtype = np.min_scalar_type(max(sorted_outblock_idx))
+        sorted_outblock_idx = sorted_outblock_idx.astype(dtype)
         # Determine the start and end of each unique key. We will loop over this
         flag = np.concatenate([[True], sorted_keys[1:] != sorted_keys[:-1], [True]])
         (key_bounds,) = flag.nonzero()


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`


cc @dcherian FYI

This cuts graph size from 750 to 250 on your example. it's not perfect but helps