### PR TITLE
Let vindex accept a Dask Array indexer under certain conditions

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2037,10 +2037,19 @@ class Array(DaskMethodsMixin):
                 "Use normal slicing instead when only using slices. Got: {}".format(key)
             )
         elif any(is_dask_collection(k) for k in key):
-            raise IndexError(
-                "vindex does not support indexing with dask objects. Call compute "
-                "on the indexer first to get an evalurated array. Got: {}".format(key)
-            )
+            if math.prod(self.numblocks) == 1 and len(key) == 1 and self.ndim == 1:
+                idxr = key[0]
+                # we can broadcast in this case
+                return idxr.map_blocks(
+                    _numpy_vindex, self, dtype=self.dtype, chunks=idxr.chunks
+                )
+            else:
+                raise IndexError(
+                    "vindex does not support indexing with dask objects. Call compute "
+                    "on the indexer first to get an evalurated array. Got: {}".format(
+                        key
+                    )
+                )
         return _vindex(self, *key)
 
     @property
@@ -6073,6 +6082,10 @@ class BlockView:
         Return a flattened list of all the blocks in the array in C order.
         """
         return [self[idx] for idx in np.ndindex(self.shape)]
+
+
+def _numpy_vindex(indexer, arr):
+    return arr[indexer]
 
 
 from dask.array.blockwise import blockwise

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -1111,3 +1111,12 @@ def test_minimal_dtype_doesnt_overflow():
     ib = np.zeros(1980, dtype=bool)
     ib[1560:1860] = True
     assert_eq(dx[ib], x[ib])
+
+
+def test_vindex_with_dask_array():
+    arr = np.array([0.2, 0.4, 0.6])
+    darr = da.from_array(arr, chunks=-1)
+
+    indexer = np.random.randint(0, 3, 8).reshape(4, 2).astype(int)
+    dindexer = da.from_array(indexer, chunks=(2, 2))
+    assert_eq(darr.vindex[dindexer], arr[indexer])

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -1120,3 +1120,14 @@ def test_vindex_with_dask_array():
     indexer = np.random.randint(0, 3, 8).reshape(4, 2).astype(int)
     dindexer = da.from_array(indexer, chunks=(2, 2))
     assert_eq(darr.vindex[dindexer], arr[indexer])
+
+    msg = "vindex does not support indexing"
+
+    with pytest.raises(IndexError, match=msg):
+        darr.rechunk((1, 1)).vindex[dindexer]
+
+    with pytest.raises(IndexError, match=msg):
+        darr.reshape((3, 1)).vindex[dindexer]
+
+    with pytest.raises(IndexError, match=msg):
+        darr.vindex[(dindexer, None)]


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

xarray is hitting this for idxmin/idxmax.

cc @dcherian is it sufficient if we make vindex work?