### PR TITLE
Accept ``chunks`` in ``shuffle`` API

### DIFF
--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -10,7 +10,7 @@ from typing import Literal
 import numpy as np
 
 from dask import config
-from dask._task_spec import DataNode, List, Task, TaskRef
+from dask._task_spec import DataNode, GraphNode, List, Task, TaskRef
 from dask.array.chunk import getitem
 from dask.array.core import Array, unknown_chunk_message
 from dask.array.dispatch import concatenate_lookup, take_lookup
@@ -18,7 +18,12 @@ from dask.base import tokenize
 from dask.highlevelgraph import HighLevelGraph
 
 
-def shuffle(x, indexer: list[list[int]], axis: int, chunks: Literal["auto"] = "auto"):
+def shuffle(
+    x: Array,
+    indexer: list[list[int]],
+    axis: int,
+    chunks: Literal["auto"] | tuple[tuple[int, ...], ...] = "auto",
+) -> Array:
     """
     Reorders one dimensions of a Dask Array based on an indexer.
 
@@ -39,12 +44,16 @@ def shuffle(x, indexer: list[list[int]], axis: int, chunks: Literal["auto"] = "a
         each group will end up in exactly one chunk.
     axis: int
         The axis to shuffle along.
-    chunks: "auto"
+    chunks: tuple[tuple[int, ...], ...] | "auto"
         Hint on how to rechunk if single groups are becoming too large. The default is
         to split chunks along the other dimensions evenly to keep the chunksize
         consistent. The rechunking is done in a way that ensures that non all-to-all
         network communication is necessary, chunks are only split and not combined with
         other chunks.
+
+        If chunks are provided explicitly, the dimensions that aren't shuffled are
+        rechunked to the given size. The chunks along the shuffled dimension must match
+        the indexer that is given for the shuffle.
 
     Examples
     --------
@@ -84,7 +93,7 @@ def shuffle(x, indexer: list[list[int]], axis: int, chunks: Literal["auto"] = "a
     token = tokenize(x, indexer, axis)
     out_name = f"shuffle-{token}"
 
-    chunks, layer = _shuffle(x.chunks, indexer, axis, x.name, out_name, token)
+    chunks, layer = _shuffle(x.chunks, indexer, axis, x.name, out_name, token, chunks)
     if len(layer) == 0:
         return Array(x.dask, x.name, x.chunks, meta=x)
 
@@ -141,9 +150,19 @@ def _calculate_new_chunksizes(
 
 
 def _rechunk_other_dimensions(
-    x: Array, longest_group: int, axis: int, chunks: Literal["auto"]
+    x: Array,
+    longest_group: int,
+    axis: int,
+    chunks: Literal["auto"] | tuple[tuple[int, ...], ...] = "auto",
 ) -> Array:
-    assert chunks == "auto", "Only auto is supported for now"
+    if chunks != "auto":
+        assert all(
+            isinstance(c, tuple) for c in chunks
+        ), "chunks must be a tuple of tuples"
+        chunks_list = list(chunks)
+        chunks_list[axis] = x.chunks[axis]
+        return x.rechunk(tuple(chunks_list))
+
     chunksize_tolerance = config.get("array.chunk-size-tolerance")
 
     if longest_group <= max(x.chunks[axis]) * chunksize_tolerance:
@@ -179,7 +198,15 @@ def _validate_indexer(chunks, indexer, axis):
         )
 
 
-def _shuffle(chunks, indexer, axis, in_name, out_name, token):
+def _shuffle(
+    chunks,
+    indexer,
+    axis,
+    in_name,
+    out_name,
+    token,
+    old_chunks: Literal["auto"] | tuple[tuple[int, ...], ...] = "auto",
+):
     _validate_indexer(chunks, indexer, axis)
 
     if len(indexer) == len(chunks[axis]):
@@ -192,24 +219,40 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
         else:
             return chunks, {}
 
-    indexer = copy.deepcopy(indexer)
+    if old_chunks == "auto":
+        indexer = copy.deepcopy(indexer)
 
-    chunksize_tolerance = config.get("array.chunk-size-tolerance")
-    chunk_size_limit = int(sum(chunks[axis]) / len(chunks[axis]) * chunksize_tolerance)
+        chunksize_tolerance = config.get("array.chunk-size-tolerance")
+        chunk_size_limit = int(
+            sum(chunks[axis]) / len(chunks[axis]) * chunksize_tolerance
+        )
 
-    # Figure out how many groups we can put into one chunk
-    current_chunk, new_chunks = [], []
-    for idx in indexer:
-        if len(current_chunk) + len(idx) > chunk_size_limit and len(current_chunk) > 0:
-            new_chunks.append(current_chunk)
-            current_chunk = idx.copy()
-        else:
-            current_chunk.extend(idx)
-            if len(current_chunk) > chunk_size_limit / chunksize_tolerance:
-                new_chunks.append(current_chunk)
-                current_chunk = []
-    if len(current_chunk) > 0:
-        new_chunks.append(current_chunk)
+        # Figure out how many groups we can put into one chunk
+        current_chunk: list[int] = []
+        new_chunks = []
+        for idx in indexer:
+            if (
+                len(current_chunk) + len(idx) > chunk_size_limit
+                and len(current_chunk) > 0
+            ):
+                new_chunks.append(np.array(current_chunk))
+                current_chunk = idx.copy()
+            else:
+                current_chunk.extend(idx)
+                if len(current_chunk) > chunk_size_limit / chunksize_tolerance:
+                    new_chunks.append(np.array(current_chunk))
+                    current_chunk = []
+        if len(current_chunk) > 0:
+            new_chunks.append(np.array(current_chunk))
+    else:
+        assert len(indexer) == len(
+            old_chunks[axis]
+        ), "Indexer and chunks must have the same length"
+        assert all(
+            len(idx) == c for idx, c in zip(indexer, old_chunks[axis])
+        ), "Indexer and chunks must match"
+        new_chunks = list(map(np.array, indexer))
+        chunk_size_limit = max(old_chunks[axis])
 
     chunk_boundaries = np.cumsum(chunks[axis])
 
@@ -218,8 +261,8 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
         product(*(range(len(c)) for i, c in enumerate(chunks) if i != axis))
     )
 
-    intermediates = dict()
-    merges = dict()
+    intermediates: dict[str | tuple[str, int], GraphNode] = dict()
+    merges: dict[str | tuple[str, int], GraphNode] = dict()
     dtype = np.min_scalar_type(max(max(chunks[axis]), chunk_size_limit))
     split_name = f"shuffle-split-{token}"
     slices = [slice(None)] * len(chunks)
@@ -233,7 +276,6 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
     }
 
     for new_chunk_idx, new_chunk_taker in enumerate(new_chunks):
-        new_chunk_taker = np.array(new_chunk_taker)
         sorter = np.argsort(new_chunk_taker).astype(dtype)
         sorter_key = sorter_name + tokenize(sorter)
         # low level fusion can't deal with arrays on first position
@@ -247,7 +289,7 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
         taker_boundary = taker_boundary.tolist()
         taker_boundary.append(len(new_chunk_taker))
 
-        taker_cache = {}
+        taker_cache: dict[int, str] = {}
         for chunk_tuple in chunk_tuples:
             merge_keys = []
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2787,8 +2787,8 @@ class Array(DaskMethodsMixin):
         self,
         indexer: list[list[int]],
         axis: int,
-        chunks: Literal["auto"] = "auto",
-    ):
+        chunks: Literal["auto"] | tuple[tuple[int, ...], ...] = "auto",
+    ) -> Array:
         """Reorders one dimensions of a Dask Array based on an indexer.
 
         Refer to :func:`dask.array.shuffle` for full documentation.


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

cc @dcherian 

Is this what you need? The chunks along the shuffled axis must match the indexer with this, or should we match them together internally?