### PR TITLE
Fixed mypy config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ platform = "linux"
 # platform = win32
 # platform = darwin
 plugins = ["numpy.typing.mypy_plugin"]
-allow_untyped_decorators = false
+disallow_untyped_decorators = true
 ignore_missing_imports = true
 no_implicit_optional = true
 show_error_codes = true
@@ -176,7 +176,7 @@ exclude = "dask/dataframe/dask_expr/"
 module = [
     "dask.order",
 ]
-allow_untyped_defs = false
+disallow_untyped_defs = true
 
 [tool.codespell]
 ignore-words-list = "coo,nd,medias"


### PR DESCRIPTION
I noticed that the pyproject.toml had a couple invalid mypy configuration settings. I've updated the two to use the correct name, and flipped the setting so that the intent should be the same (e.g. `allow_untyped_defs=false` should be `disallow_untyped_defs=true`).

https://mypy.readthedocs.io/en/stable/config_file.html has the valid settings.

Pre-commit is passing, and I think mypy runs in pre-commit, so it seems like things were compatible with these settings anyway.

(distributed might need a similar PR. I'll get to that later)