### PR TITLE
Simplify `_execute_subgraph`

### DIFF
--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -195,12 +195,10 @@ class _MultiContainer(Container):
 SubgraphType = None
 
 
-def _execute_subgraph(inner_dsk, outkey, inkeys, external_deps):
+def _execute_subgraph(inner_dsk, outkey, inkeys):
     final = {}
     final.update(inner_dsk)
     for k, v in inkeys.items():
-        final[k] = DataNode(None, v)
-    for k, v in external_deps.items():
         final[k] = DataNode(None, v)
     res = execute_graph(final, keys=[outkey])
     return res[outkey]
@@ -474,7 +472,6 @@ class GraphNode:
             {t.key: t for t in tasks},
             outkey,
             (Dict({k: Alias(k) for k in external_deps}) if external_deps else {}),
-            {},
             _data_producer=any(t.data_producer for t in tasks),
         )
 

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -112,8 +112,7 @@ def lazify_task(task, start=True):
             assert len(task.args) == 1
             task = task.args[0]
         if task.func is _execute_subgraph:
-            subgraph = task.args[0]
-            outkey = task.args[1]
+            subgraph, outkey, inkeys = task.args
             # If there is a reify at the output of the subgraph we don't want to act
             final_task = lazify_task(subgraph[outkey], True)
             subgraph = {
@@ -125,8 +124,8 @@ def lazify_task(task, start=True):
                 _execute_subgraph,
                 subgraph,
                 outkey,
-                *task.args[2:],
-                **task.kwargs,
+                inkeys,
+                _data_producer=task.data_producer,
             )
         return Task(
             task.key,


### PR DESCRIPTION
Minor simplification removing a factually dead param.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
