### PR TITLE
Expose downstream utilities for dask.dataframe

### DIFF
--- a/dask/dataframe/api.py
+++ b/dask/dataframe/api.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from dask.dataframe.core import get_parallel_type  # noqa: F401
 from dask.dataframe.dask_expr import FrameBase, elemwise, new_collection  # noqa: F401
 from dask.dataframe.dask_expr._expr import are_co_aligned, emulate  # noqa: F401
 from dask.dataframe.dask_expr._groupby import GroupBy, SeriesGroupBy  # noqa: F401
 from dask.dataframe.dask_expr._reductions import ApplyConcatApply  # noqa: F401
 from dask.dataframe.dask_expr._rolling import Rolling  # noqa: F401
+from dask.dataframe.extensions import make_array_nonempty, make_scalar  # noqa: F401
+from dask.dataframe.utils import meta_nonempty  # noqa: F401

--- a/dask/dataframe/api.py
+++ b/dask/dataframe/api.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
 
+from dask.dataframe.dask_expr import FrameBase, elemwise, new_collection  # noqa: F401
+from dask.dataframe.dask_expr._expr import _emulate, are_co_aligned  # noqa: F401
 from dask.dataframe.dask_expr._groupby import GroupBy, SeriesGroupBy  # noqa: F401
+from dask.dataframe.dask_expr._reductions import ApplyConcatApply  # noqa: F401
 from dask.dataframe.dask_expr._rolling import Rolling  # noqa: F401

--- a/dask/dataframe/api.py
+++ b/dask/dataframe/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dask.dataframe.dask_expr import FrameBase, elemwise, new_collection  # noqa: F401
-from dask.dataframe.dask_expr._expr import _emulate, are_co_aligned  # noqa: F401
+from dask.dataframe.dask_expr._expr import are_co_aligned, emulate  # noqa: F401
 from dask.dataframe.dask_expr._groupby import GroupBy, SeriesGroupBy  # noqa: F401
 from dask.dataframe.dask_expr._reductions import ApplyConcatApply  # noqa: F401
 from dask.dataframe.dask_expr._rolling import Rolling  # noqa: F401

--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -3101,7 +3101,7 @@ class DataFrame(FrameBase):
                 "installed."
             )
         if meta is None:
-            meta = expr._emulate(M.map, self, func, na_action=na_action, udf=True)
+            meta = expr.emulate(M.map, self, func, na_action=na_action, udf=True)
             warnings.warn(meta_warning(meta))
         return new_collection(expr.Map(self, arg=func, na_action=na_action, meta=meta))
 
@@ -3233,7 +3233,7 @@ class DataFrame(FrameBase):
             )
             raise NotImplementedError(msg)
         if meta is no_default:
-            meta = expr._emulate(
+            meta = expr.emulate(
                 M.apply, self, function, args=args, udf=True, axis=axis, **kwargs
             )
             warnings.warn(meta_warning(meta))
@@ -4200,7 +4200,7 @@ class Series(FrameBase):
                     expr.MapAlign(self, arg, op=None, na_action=na_action, meta=meta)
                 )
         if meta is None:
-            meta = expr._emulate(M.map, self, arg, na_action=na_action, udf=True)
+            meta = expr.emulate(M.map, self, arg, na_action=na_action, udf=True)
             warnings.warn(meta_warning(meta))
         return new_collection(expr.Map(self, arg=arg, na_action=na_action, meta=meta))
 
@@ -4384,7 +4384,7 @@ class Series(FrameBase):
         """
         self._validate_axis(axis)
         if meta is no_default:
-            meta = expr._emulate(M.apply, self, function, args=args, udf=True, **kwargs)
+            meta = expr.emulate(M.apply, self, function, args=args, udf=True, **kwargs)
             warnings.warn(meta_warning(meta))
         return new_collection(self.expr.apply(function, *args, meta=meta, **kwargs))
 
@@ -4727,7 +4727,7 @@ class Index(Series):
                     expr.MapIndexAlign(self, arg, na_action, meta, is_monotonic)
                 )
         if meta is None:
-            meta = expr._emulate(M.map, self, arg, na_action=na_action, udf=True)
+            meta = expr.emulate(M.map, self, arg, na_action=na_action, udf=True)
             warnings.warn(meta_warning(meta))
         return new_collection(
             expr.Map(

--- a/dask/dataframe/dask_expr/_expr.py
+++ b/dask/dataframe/dask_expr/_expr.py
@@ -4033,7 +4033,7 @@ def _extract_meta(x, nonempty=False):
         return x
 
 
-def _emulate(func, *args, udf=False, **kwargs):
+def emulate(func, *args, udf=False, **kwargs):
     """
     Apply a function using args / kwargs. If arguments contain dd.DataFrame /
     dd.Series, using internal cache (``_meta``) for calculation
@@ -4053,7 +4053,7 @@ def _get_meta_map_partitions(args, dfs, func, kwargs, meta, parent_meta):
         # Use non-normalized kwargs here, as we want the real values (not
         # delayed values)
         a = [meta_nonempty(arg._meta) if isinstance(arg, Expr) else arg for arg in args]
-        meta = _emulate(func, *a, udf=True, **kwargs)
+        meta = emulate(func, *a, udf=True, **kwargs)
         meta_is_emulated = True
     else:
         meta = make_meta(meta, index=meta_index, parent_meta=parent_meta)


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`


cc @TomAugspurger @jorisvandenbossche @MarcoGorelli

This should cover the usage in dask-geopandas and narwhals as far as I can tell in addition to the toplevel public API