### PR TITLE
Fix processing of variables' case in config collection from environment

### DIFF
--- a/dask/config.py
+++ b/dask/config.py
@@ -270,7 +270,7 @@ def collect_env(env: Mapping[str, str] | None = None) -> dict:
 
     for name, value in env.items():
         if name.startswith("DASK_"):
-            varname = name[5:].lower().replace("__", ".")
+            varname = name[5:].swapcase().replace("__", ".")
             d[varname] = interpret_value(value)
 
     result: dict = {}


### PR DESCRIPTION
**Description:**
When populating dask's configuration, the environment variables are currently always set to "lowercase". However, `nanny` spawning configuration includes some environment variables that need to be upper case (e.g. `OMP_NUM_THREADS`, etc). This means that they will appear in lowercase in dask's configuration, and thus they will be set in lowercase as well. This renders them ineffective.

The current PR addresses this problem by replacing the `lowercase` call with a `swapcase`, which allows setting the variables as:
```bash
export DASK_DISTRIBUTED__NANNY__PRE_SPAWN_ENVIRON__omp_num_threads=2
```
The following code:
```Python
dask.config.get("distributed.nanny.pre-spawn-environ")
```
will now produce:
```Python
{"OMP_NUM_THREADS": 2, "MKL_NUM_THREADS": 1, "OPENBLAS_NUM_THREADS": 1}
```

**Note:**
It would have been better to not mess with case at all in the first place, and use lowercase variables in for lowercase configurations. However, this change would break the existing usage of dask. The current PR is backward compatible.