### PR TITLE
Updated docs on local file system

### DIFF
--- a/docs/source/how-to/connect-to-remote-data.rst
+++ b/docs/source/how-to/connect-to-remote-data.rst
@@ -105,10 +105,26 @@ We assume here that each worker has access to the same file system - either
 the workers are co-located on the same machine, or a network file system
 is mounted and referenced at the same path location for every worker node.
 
-Locations specified relative to the current working directory will, in
-general, be respected (as they would be with the built-in python ``open``),
-but this may fail in the case that the client and worker processes do not
-necessarily have the same working directory.
+Dask's data IO methods will typically normalize relative paths to absolute paths
+so that data can be read by a worker even if it has a different working
+directory than your client. But other functions, including ones you've written,
+might not normalize the paths. If the current working directory of your Client
+differs from the working directory of the Worker, you might run issues where a
+file can't be found since the relative path will be incorrect.
+
+In general, things will be simplest if your Client and Workers (and perhaps
+Scheduler) all share the same working directory. You can check this with a
+snippet like:
+
+.. code-block:: python
+
+   >>> import os
+   >>> from dask.distributed import Client, LocalCluster
+   >>> client = Client(LocalCluster())
+   >>> client.run(os.getcwd)  # doctest: +SKIP
+   {'tcp://127.0.0.1:64597': '/home/coder',
+    'tcp://127.0.0.1:64598': '/home/coder'}
+
 
 Hadoop File System
 ------------------


### PR DESCRIPTION
Small clarification / update to the docs on local filesystem. Main changes are to

1. Note that dask / fsspec typically (always? not sure) normalizes relative paths to absolute before executing on the worker
2. Recommend having the same cwd on the Client and Workers

- [x] Closes https://github.com/dask/dask/issues/11676
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
