### PR TITLE
array: Never share buffers after compute()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ coverage.xml
 hdfs-initialized-indicator
 .ipynb_checkpoints
 .vscode/
+.env
 .history
 env.yaml

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -25,7 +25,7 @@ dependencies:
   - moto<5
   # Optional dependencies
   - mimesis
-  - numpy
+  - numpy=2.0
   - pandas=2
   - numba
   - flask

--- a/continuous_integration/environment-3.12.yaml
+++ b/continuous_integration/environment-3.12.yaml
@@ -24,7 +24,7 @@ dependencies:
   - moto<5
   # Optional dependencies
   - mimesis
-  - numpy >=2  # only tested here
+  - numpy>=2
   - pandas
   - numba
   - flask

--- a/continuous_integration/environment-3.13.yaml
+++ b/continuous_integration/environment-3.13.yaml
@@ -23,7 +23,7 @@ dependencies:
   - moto<5
   # Optional dependencies
   - mimesis
-  - numpy >=2  # only tested here
+  - numpy>=2.2  # only tested here
   - pandas
   #- numba  # not available for py 13
   - flask

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1726,7 +1726,13 @@ class Array(DaskMethodsMixin):
 
     __array_priority__ = 11  # higher than numpy.ndarray and numpy.matrix
 
-    def __array__(self, dtype=None, copy=None):
+    def __array__(self, dtype=None, copy=None, **kwargs):
+        if kwargs:
+            warnings.warn(
+                f"Extra keyword arguments {kwargs} are ignored and won't be "
+                "accepted in the future",
+                FutureWarning,
+            )
         if copy is False:
             raise ValueError("Can't acquire a memory view of a Dask array")
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1734,7 +1734,11 @@ class Array(DaskMethodsMixin):
                 FutureWarning,
             )
         if copy is False:
-            raise ValueError("Can't acquire a memory view of a Dask array")
+            warnings.warn(
+                "Can't acquire a memory view of a Dask array. "
+                "This will raise in the future.",
+                FutureWarning,
+            )
 
         x = self.compute()
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1307,12 +1307,6 @@ def finalize(results):
     try:
         return results.copy()  # numpy, sparse, scipy.sparse (any version)
     except AttributeError:
-        pass
-    try:
-        # Future-proof: Array API-compliant backends
-        xp = results.__array_namespace__()
-        return xp.asarray(results, copy=True)
-    except (AttributeError, TypeError):
         # Not an Array API object
         return results
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1299,7 +1299,22 @@ def finalize(results):
             return concatenate3(results)
         else:
             results2 = results2[0]
-    return unpack_singleton(results)
+
+    results = unpack_singleton(results)
+    # Single chunk. There is a risk that the result holds a buffer stored in the
+    # graph or on a process-local Worker. Deep copy to make sure that nothing can
+    # accidentally write back to it.
+    try:
+        return results.copy()  # numpy, sparse, scipy.sparse (any version)
+    except AttributeError:
+        pass
+    try:
+        # Future-proof: Array API-compliant backends
+        xp = results.__array_namespace__()
+        return xp.asarray(results, copy=True)
+    except (AttributeError, TypeError):
+        # Not an Array API object
+        return results
 
 
 CHUNKS_NONE_ERROR_MESSAGE = """
@@ -1713,13 +1728,19 @@ class Array(DaskMethodsMixin):
 
     __array_priority__ = 11  # higher than numpy.ndarray and numpy.matrix
 
-    def __array__(self, dtype=None, **kwargs):
+    def __array__(self, dtype=None, copy=None):
+        if copy is False:
+            raise ValueError("Can't acquire a memory view of a Dask array")
+
         x = self.compute()
-        if dtype and x.dtype != dtype:
-            x = x.astype(dtype)
-        if not isinstance(x, np.ndarray):
-            x = np.array(x)
-        return x
+
+        # Apply requested dtype and convert non-numpy backends to numpy.
+        # If copy is True, numpy is going to perform its own deep copy
+        # after this method returns.
+        # If copy is None, finalize() ensures that the returned object
+        # does not share memory with an object stored in the graph or on a
+        # process-local Worker.
+        return np.asarray(x, dtype=dtype)
 
     def __array_function__(self, func, types, args, kwargs):
         import dask.array as module

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -467,8 +467,9 @@ def test_numpy_asarray_copy_false(asarray, chunks):
     """Test that np.*array(x, copy=False) is forbidden"""
     x = da.asarray(np.arange(10), chunks=chunks)
     # Loudly crash if numpy demands for a view of dask's memory
-    with pytest.raises(ValueError, match="Can't acquire a memory view of a Dask array"):
-        asarray(x, copy=False)
+    with pytest.warns(FutureWarning, match="Can't acquire a memory view"):
+        y = asarray(x, copy=False)
+    assert_eq(y, np.arange(10))
 
 
 @pytest.mark.parametrize(

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -516,6 +516,12 @@ def test_numpy_asarray_copy_default(asarray, chunks):
     assert x[0].compute() == 0
 
 
+def test_array_interface_deprecated_kwargs():
+    x = da.ones(10)
+    with pytest.warns(FutureWarning, match="ignored"):
+        x.__array__(something="foo")
+
+
 @pytest.mark.parametrize("chunks", [5, 10])
 def test_compute_copy(chunks):
     """Test that compute() never returns an object that shares

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -52,7 +52,7 @@ from dask.array.core import (
     stack,
     store,
 )
-from dask.array.numpy_compat import NUMPY_GE_200
+from dask.array.numpy_compat import NUMPY_GE_200, NUMPY_GE_210
 from dask.array.reshape import _not_implemented_message
 from dask.array.utils import assert_eq, same_keys
 from dask.base import compute_as_if_collection, tokenize
@@ -408,6 +408,129 @@ def test_Array_computation():
     assert_eq(np.array(a), np.eye(3))
     assert isinstance(a.compute(), np.ndarray)
     assert float(a[0, 0]) == 1
+
+
+@pytest.mark.parametrize("asarray", [np.asarray, np.asanyarray, np.array])
+def test_numpy_asarray_dtype(asarray):
+    """Test dtype= parameter of np.*array()"""
+    x = da.arange(10, dtype="i2")
+    nx = asarray(x, dtype="i4")
+    assert nx.dtype == np.int32
+
+
+@pytest.mark.parametrize(
+    "asarray",
+    [
+        np.array,
+        pytest.param(
+            np.asarray,
+            marks=pytest.mark.skipif(not NUMPY_GE_200, reason="no copy kwarg"),
+        ),
+        pytest.param(
+            np.asanyarray,
+            marks=pytest.mark.skipif(not NUMPY_GE_210, reason="no copy kwarg"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("chunks", [5, 10])
+def test_numpy_asarray_copy_true(asarray, chunks):
+    """Test np.*array(x, copy=True)"""
+    x = da.asarray(np.arange(10), chunks=chunks)
+
+    nx = asarray(x, copy=True)
+    nx[0] = 42
+    # Did not write back to the buffer held in the Dask graph
+    assert x[0].compute() == 0
+
+
+@pytest.mark.parametrize(
+    "asarray",
+    [
+        pytest.param(
+            np.array,
+            marks=pytest.mark.skipif(
+                not NUMPY_GE_200, reason="copy kwarg not forwarded to dask"
+            ),
+        ),
+        pytest.param(
+            np.asarray,
+            marks=pytest.mark.skipif(not NUMPY_GE_200, reason="no copy kwarg"),
+        ),
+        pytest.param(
+            np.asanyarray,
+            marks=pytest.mark.skipif(not NUMPY_GE_210, reason="no copy kwarg"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("chunks", [5, 10])
+def test_numpy_asarray_copy_false(asarray, chunks):
+    """Test that np.*array(x, copy=False) is forbidden"""
+    x = da.asarray(np.arange(10), chunks=chunks)
+    # Loudly crash if numpy demands for a view of dask's memory
+    with pytest.raises(ValueError, match="Can't acquire a memory view of a Dask array"):
+        asarray(x, copy=False)
+
+
+@pytest.mark.parametrize(
+    "asarray",
+    [
+        pytest.param(
+            np.array,
+            marks=pytest.mark.skipif(not NUMPY_GE_200, reason="copy=None invalid"),
+        ),
+        pytest.param(
+            np.asarray,
+            marks=pytest.mark.skipif(not NUMPY_GE_200, reason="no copy kwarg"),
+        ),
+        pytest.param(
+            np.asanyarray,
+            marks=pytest.mark.skipif(not NUMPY_GE_210, reason="no copy kwarg"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("chunks", [5, 10])
+def test_numpy_asarray_copy_none(asarray, chunks):
+    """Test np.*array(x, copy=None)"""
+    x = da.asarray(np.arange(10), chunks=chunks)
+
+    nx = asarray(x, copy=None)
+    nx[0] = 42
+    # Did not write back to the buffer held in the Dask graph
+    assert x[0].compute() == 0
+
+
+@pytest.mark.parametrize("asarray", [np.asarray, np.asanyarray, np.array])
+@pytest.mark.parametrize("chunks", [5, 10])
+def test_numpy_asarray_copy_default(asarray, chunks):
+    """Test that np.*array() never returns an object that shares
+    a buffer with the dask graph or a process-local Worker
+    """
+    x = da.asarray(np.arange(10), chunks=chunks)
+
+    # array() defaults to copy=True.
+    # asarray() and asanyarray() default to copy=None.
+    # For Dask, it doesn't make a difference.
+    nx = asarray(x)
+    nx[0] = 42
+    # Did not write back to the buffer held in the Dask graph
+    assert x[0].compute() == 0
+
+
+@pytest.mark.parametrize("chunks", [5, 10])
+def test_compute_copy(chunks):
+    """Test that compute() never returns an object that shares
+    a buffer with the dask graph or a process-local Worker
+    """
+    x = da.asarray(np.arange(10), chunks=chunks)
+
+    nx = x.compute()
+    nx[0] = 42
+    # Did not write back to the buffer held in the Dask graph
+    assert x[0].compute() == 0
+
+    (nx,) = dask.compute(x)
+    nx[0] = 42
+    assert x[0].compute() == 0
 
 
 def test_Array_numpy_gufunc_call__array_ufunc__01():


### PR DESCRIPTION
- ~Fail loudly~ issue DeprecationWarning when a user attempts `np.asarray(x, copy=False)`, in accordance with the Array API standard. This came up during the work to introduce dask support for scipy through Array API compliance.
- Ensure that `x.compute()` never returns a buffer that is shared with the dask graph or a process-local `Worker.data`, so that users can't write back to it
- Ensure test coverage for both numpy 2.0 and 2.2

FYI @lithomas1 @lucascolley 