### PR TITLE
Drop legacy timeseries implementation

### DIFF
--- a/dask/dataframe/dask_expr/tests/test_datasets.py
+++ b/dask/dataframe/dask_expr/tests/test_datasets.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-import pickle
-import sys
-
 import pytest
 
 from dask.dataframe._compat import PYARROW_GE_1500
@@ -117,20 +114,6 @@ def test_timeseries_deterministic_head(seed):
     assert_eq(df.head(), df.head())
     assert_eq(df["x"].head(), df.head()["x"])
     assert_eq(df.head()["x"], df["x"].partitions[0].compute().head())
-
-
-@pytest.mark.parametrize("seed", [42, None])
-def test_timeseries_gaph_size(seed):
-    from dask.datasets import timeseries as dd_timeseries
-
-    # Check that our graph size is reasonable
-    df = timeseries(seed=seed)
-    ddf = dd_timeseries(seed=seed)
-    graph_size = sys.getsizeof(pickle.dumps(df.dask))
-    graph_size_dd = sys.getsizeof(pickle.dumps(dict(ddf.dask)))
-    # Make sure we are close to the dask.dataframe graph size
-    threshold = 1.10
-    assert graph_size < threshold * graph_size_dd
 
 
 def test_dataset_head():

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -25,7 +25,7 @@ def test_make_timeseries():
     assert df.divisions[-1] == pd.Timestamp("2014-07-31")
     tm.assert_index_equal(df.columns, pd.Index(["A", "B", "C"]))
     assert df["A"].head().dtype == float
-    assert np.issubdtype(df["B"].head(), np.intp)
+    assert np.issubdtype(df["B"].head(), np.integer)
     assert df["C"].head().dtype == get_string_dtype()
     assert df.index.name == "timestamp"
     assert df.head().index.name == df.index.name

--- a/dask/dataframe/io/tests/test_demo.py
+++ b/dask/dataframe/io/tests/test_demo.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -24,7 +25,7 @@ def test_make_timeseries():
     assert df.divisions[-1] == pd.Timestamp("2014-07-31")
     tm.assert_index_equal(df.columns, pd.Index(["A", "B", "C"]))
     assert df["A"].head().dtype == float
-    assert df["B"].head().dtype == int
+    assert np.issubdtype(df["B"].head(), np.intp)
     assert df["C"].head().dtype == get_string_dtype()
     assert df.index.name == "timestamp"
     assert df.head().index.name == df.index.name

--- a/dask/datasets.py
+++ b/dask/datasets.py
@@ -55,12 +55,12 @@ def timeseries(
     ...     id_lam=1000  # control number of items in id column
     ... )
     """
-    from dask.dataframe.io.demo import make_timeseries
+    from dask.dataframe.dask_expr.datasets import timeseries
 
     if dtypes is None:
         dtypes = {"name": str, "id": int, "x": float, "y": float}
 
-    return make_timeseries(
+    return timeseries(
         start=start,
         end=end,
         freq=freq,


### PR DESCRIPTION
I believe this is no longer required.

There is a lot of indirection happening here but I decided to not clean this up right now. I don't think it's harmful and this way we do not break any consumers