### PR TITLE
Ensure `normalize_token` is threadsafe

### DIFF
--- a/dask/tokenize.py
+++ b/dask/tokenize.py
@@ -112,6 +112,12 @@ normalize_token.register(
 )
 
 
+def normalize_token_safe(x):
+    """A thread safe version of normalize_token"""
+    with tokenize_lock:
+        return normalize_token(x)
+
+
 @normalize_token.register((types.MappingProxyType, dict))
 def normalize_dict(d):
     if id(d) in _SEEN:


### PR DESCRIPTION
Initially I assumed we're only accessing these functions through proper `tokenize` which is protected with this recursive lock already. However, we're also using `normalize_token` individually in the distributed scheduler.

If the scheduler is running in the same process as the client (which is typically the case for LocalCluster) this can cause race conditions which can manifest in wrong tokens or even in KeyErrors when normalizing a nested sequence.

I wasn't able to reproduce the KeyError with the test but it is sensitive to a wrong result

This was introduced in https://github.com/dask/dask/pull/11373