### PR TITLE
`arange`: support kwargs

### DIFF
--- a/dask/array/creation.py
+++ b/dask/array/creation.py
@@ -382,7 +382,9 @@ def linspace(
 
 
 @array_creation_dispatch.register_inplace("numpy")
-def arange(*args, chunks="auto", like=None, dtype=None, **kwargs):
+def arange(
+    start=None, /, stop=None, step=1, *, chunks="auto", like=None, dtype=None, **kwargs
+):
     """
     Return evenly spaced values from `start` to `stop` with step size `step`.
 
@@ -395,13 +397,15 @@ def arange(*args, chunks="auto", like=None, dtype=None, **kwargs):
 
     Parameters
     ----------
-    start : int, optional
-        The starting value of the sequence. The default is 0.
-    stop : int
-        The end of the interval, this value is excluded from the interval.
-    step : int, optional
-        The spacing between the values. The default is 1 when not specified.
-        The last value of the sequence.
+    start : int | float, optional
+        If ``stop`` is specified, the start of interval (inclusive); otherwise, the end
+        of the interval (exclusive). Default: 0 when ``stop`` is specified.
+    stop : int | float
+        The end of the interval (exclusive).
+    step : int | float, optional
+        The distance between two adjacent elements ``(out[i+1] - out[i])``.
+        Must not be 0; may be negative, this results in an empty array if stop >= start.
+        Default: 1.
     chunks :  int
         The number of samples on each block. Note that the last block will have
         fewer samples if ``len(array) % chunks != 0``.
@@ -420,22 +424,12 @@ def arange(*args, chunks="auto", like=None, dtype=None, **kwargs):
     --------
     dask.array.linspace
     """
-    if len(args) == 1:
+    if start is None and stop is None:
+        raise TypeError("arange() requires stop to be specified.")
+    elif start is None:
         start = 0
-        stop = args[0]
-        step = 1
-    elif len(args) == 2:
-        start = args[0]
-        stop = args[1]
-        step = 1
-    elif len(args) == 3:
-        start, stop, step = args
-    else:
-        raise TypeError(
-            """
-        arange takes 3 positional arguments: arange([start], stop, [step])
-        """
-        )
+    elif stop is None:
+        start, stop = 0, start
 
     num = int(max(np.ceil((stop - start) / step), 0))
 

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -227,6 +227,26 @@ def test_arange():
     nparr = np.arange(0, -1, 0.5)
     assert_eq(darr, nparr)
 
+    # stop and/or step as kwargs
+    darr = da.arange(stop=10)
+    nparr = np.arange(stop=10)
+    assert_eq(darr, nparr)
+
+    darr = da.arange(10, step=2)
+    nparr = np.arange(10, step=2)
+    assert_eq(darr, nparr)
+
+    darr = da.arange(stop=10, step=2)
+    nparr = np.arange(stop=10, step=2)
+    assert_eq(darr, nparr)
+
+    darr = da.arange(3, stop=10, step=2)
+    nparr = np.arange(3, stop=10, step=2)
+    assert_eq(darr, nparr)
+
+    with pytest.raises(TypeError, match="requires stop"):
+        da.arange()
+
     # Unexpected or missing kwargs
     with pytest.raises(TypeError, match="whatsthis"):
         da.arange(10, chunks=-1, whatsthis=1)


### PR DESCRIPTION
Change `arange` to accept `stop` and `step` as kwargs, in accordance to both numpy and the [Array API standard](https://data-apis.org/array-api/latest/API_specification/generated/array_api.arange.html#arange).