### PR TITLE
Extract Dask Array from xarray DataArray in from_array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -27,6 +27,10 @@ from packaging.version import Version
 from tlz import accumulate, concat, first, partition
 from toolz import frequencies
 
+from dask._compatibility import import_optional_dependency
+
+xr = import_optional_dependency("xarray", errors="ignore")
+
 from dask import compute, config, core
 from dask._task_spec import List, Task, TaskRef
 from dask.array import chunk
@@ -3613,6 +3617,11 @@ def from_array(
         raise ValueError(
             "Array is already a dask array. Use 'asarray' or 'rechunk' instead."
         )
+
+    if xr is not None and isinstance(x, xr.DataArray) and x.chunks is not None:
+        if isinstance(x.data, Array):
+            return x.data
+
     elif is_dask_collection(x):
         warnings.warn(
             "Passing an object to dask.array.from_array which is already a "


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

I ran into this yesterday and the pattern is super weird. This creates tons of worker clients and really kills the scheduler, Just extracting the array beforehand is a better solution for this
