### PR TITLE
Added key_max_length to assert_eq

### DIFF
--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -515,6 +515,7 @@ def assert_eq(
     check_index=True,
     sort_results=True,
     scheduler="sync",
+    key_max_length=100,
     **kwargs,
 ):
     if check_divisions:
@@ -524,8 +525,8 @@ def assert_eq(
             at = type(np.asarray(a.divisions).tolist()[0])  # numpy to python
             bt = type(np.asarray(b.divisions).tolist()[0])  # scalar conversion
             assert at == bt, (at, bt)
-    assert_sane_keynames(a)
-    assert_sane_keynames(b)
+    assert_sane_keynames(a, key_max_length=key_max_length)
+    assert_sane_keynames(b, key_max_length=key_max_length)
     a = _check_dask(
         a, check_names=check_names, check_dtypes=check_dtype, scheduler=scheduler
     )
@@ -607,14 +608,14 @@ def assert_divisions(ddf, scheduler=None):
         assert index(results[-1]).max() <= ddf.divisions[-1]
 
 
-def assert_sane_keynames(ddf):
+def assert_sane_keynames(ddf, key_max_length=100):
     if not hasattr(ddf, "dask"):
         return
     for k in ddf.dask.keys():
         while isinstance(k, tuple):
             k = k[0]
         assert isinstance(k, (str, bytes))
-        assert len(k) < 100
+        assert len(k) <= key_max_length
         assert " " not in k
         assert k.split("-")[0].isidentifier(), k
 


### PR DESCRIPTION
In https://github.com/dask/dask-ml/pull/1008 we have a key with a long, but IMO reasonable, name:

```
'frompandas-getitem-operation-assign-values-from-dask-array-getitem-from-dask-array-b02111402bccb70b6fde7347c3d8368f'
```

that's the result of `enc.inverse_transform(enc.transform(df).values))` where both transform and inverse_transform do some dask.dataframe operations.

If people agree that that name is long but reasonable, then it'd be nice to have the check in assert_eq be configurable.
