### PR TITLE
Ensure divisions not diverging from npartitions in Merge

### DIFF
--- a/dask/dataframe/dask_expr/_merge.py
+++ b/dask/dataframe/dask_expr/_merge.py
@@ -205,7 +205,7 @@ class Merge(Expr):
     def _npartitions(self):
         if self.operand("_npartitions") is not None:
             return self.operand("_npartitions")
-        return max(self.left.npartitions, self.right.npartitions)
+        return len(self._divisions()) - 1
 
     @property
     def _bcast_left(self):
@@ -273,8 +273,10 @@ class Merge(Expr):
             else:
                 _npartitions = max(self.left.npartitions, self.right.npartitions)
 
+        elif self.operand("_npartitions") is not None:
+            _npartitions = self.operand("_npartitions")
         else:
-            _npartitions = self._npartitions
+            _npartitions = max(self.left.npartitions, self.right.npartitions)
 
         return (None,) * (_npartitions + 1)
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -2431,3 +2431,18 @@ def test_pairwise_merge_results_in_identical_output_df(
     ddf_pairwise = ddf_pairwise.join(dfs_to_merge, how=how)
 
     assert_eq(ddf_pairwise, ddf_loop)
+
+
+def test_simpler_case():
+    ddf_right = dd.from_pandas(
+        pd.DataFrame(
+            {"A": [5, 6, 7, 8], "B": [4, 3, 2, 1]},
+            index=[0, 1, 2, 3],
+        ),
+        1,
+    )
+    ddf_left = dd.from_pandas(pd.DataFrame(index=[0, 1, 3]), 2)
+    res = ddf_left.join(ddf_right, how="left")
+    assert res.expr._npartitions == res.npartitions
+    assert len(res) == len(res.compute())
+    assert len(res) == sum(res.map_partitions(len).compute())


### PR DESCRIPTION
Stumbled over this while investigating https://github.com/dask/dask/pull/11736

The problems I see on the branch over there are not reproducible on main but it may be related to this. Either way, I think these definitions shouldn't diverge since some optimizations might take the wrong turn