### PR TITLE
Ensure merge divisions are unaltered by optimize

### DIFF
--- a/dask/dataframe/dask_expr/_merge.py
+++ b/dask/dataframe/dask_expr/_merge.py
@@ -222,16 +222,6 @@ class Merge(Expr):
         return self.right
 
     def _divisions(self):
-        if self.merge_indexed_left and self.merge_indexed_right:
-            divisions = list(
-                unique(merge_sorted(self.left.divisions, self.right.divisions))
-            )
-            if len(divisions) == 1:
-                return (divisions[0], divisions[0])
-            if self.left.npartitions == 1 and self.right.npartitions == 1:
-                return (min(divisions), max(divisions))
-            return divisions
-
         if self._is_single_partition_broadcast:
             use_left = self.right_index or _contains_index_name(
                 self.right._meta, self.right_on
@@ -253,6 +243,16 @@ class Merge(Expr):
                 return self.left.divisions
             else:
                 _npartitions = max(self.left.npartitions, self.right.npartitions)
+
+        elif self.merge_indexed_left and self.merge_indexed_right:
+            divisions = list(
+                unique(merge_sorted(self.left.divisions, self.right.divisions))
+            )
+            if len(divisions) == 1:
+                return (divisions[0], divisions[0])
+            if self.left.npartitions == 1 and self.right.npartitions == 1:
+                return (min(divisions), max(divisions))
+            return divisions
 
         elif self.is_broadcast_join:
             meta_index_names = set(self._meta.index.names)

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -2448,5 +2448,6 @@ def test_ensure_npartitions_properly_set(how, npartitions_left, npartitions_righ
     res = ddf_left.join(ddf_right, how=how)
     assert res.expr._npartitions == res.npartitions
     assert res.npartitions == len(res.divisions) - 1
+    assert res.npartitions == res.optimize().npartitions
     assert len(res) == len(res.compute())
     assert len(res) == sum(res.map_partitions(len).compute())


### PR DESCRIPTION
`_divisons` is pretty much implementing the same decision tree as lower but the order so far was wrong causing the npartitions to change during lowering

follow up to https://github.com/dask/dask/pull/11762