### PR TITLE
Added `flaky` to tests extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ complete = [
     "lz4 >= 4.3.2",
 ]
 test = [
+    "flaky",
     "pandas[test]",
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
I believe this is the package that provides the `flaky` mark / fixture we use in a few spots (e.g. https://github.com/dask/dask/blob/f2b8287cbdfd076e3f588b56da33714c619f8ea3/dask/bytes/tests/test_http.py#L194).