### PR TITLE
Remove flaky optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ complete = [
     "lz4 >= 4.3.2",
 ]
 test = [
-    "flaky",
     "pandas[test]",
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
This reverts https://github.com/dask/dask/pull/11770. The `flaky` mark comes from a different package, pytest-rerunfailures, which is already present.

cc @phofl. Apologies for the unnecessary churn. I need to figure out what happened to my local environment to mess this up.