### PR TITLE
Fix sorted_divisions_locations with duplicates

### DIFF
--- a/dask/dataframe/io/io.py
+++ b/dask/dataframe/io/io.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import bisect
 from threading import Lock
 from typing import TYPE_CHECKING
 
@@ -278,24 +279,17 @@ def sorted_division_locations(seq, npartitions=None, chunksize=None):
     if (npartitions is None) == (chunksize is None):
         raise ValueError("Exactly one of npartitions and chunksize must be specified.")
 
-    # Find unique-offset array (if duplicates exist).
-    # Note that np.unique(seq) should work in all cases
-    # for newer versions of numpy/pandas
-    seq_unique = seq.unique() if hasattr(seq, "unique") else np.unique(seq)
-    duplicates = len(seq_unique) < len(seq)
-    enforce_exact = False
-
     # Convert from an ndarray to a plain list so that
     # any divisions we extract from seq are plain Python scalars.
     seq = tolist(seq)
+    # we use bisect later, so we need sorted.
+    # TODO: check if `set` preserves order, if so drop `sorted`.
+    seq_unique = sorted(set(seq))
+    duplicates = len(seq_unique) < len(seq)
+    enforce_exact = False
 
     if duplicates:
-        offsets = (
-            # Avoid numpy conversion (necessary for dask-cudf)
-            seq.searchsorted(seq_unique, side="left")
-            if hasattr(seq, "searchsorted")
-            else np.array(seq).searchsorted(seq_unique, side="left")
-        )
+        offsets = [bisect.bisect_left(seq, x) for x in seq_unique]
         enforce_exact = npartitions and len(offsets) >= npartitions
     else:
         offsets = seq_unique = None
@@ -332,7 +326,8 @@ def sorted_division_locations(seq, npartitions=None, chunksize=None):
         if duplicates:
             # Note: cupy requires casts to `int` below
             if ind is None:
-                ind = int((seq_unique == seq[i]).nonzero()[0][0])
+                # ind = int((seq_unique == seq[i]).nonzero()[0][0])
+                ind = bisect.bisect_left(seq_unique, seq[i])
             if enforce_exact:
                 # Avoid "over-stepping" too many unique
                 # values when npartitions is approximately


### PR DESCRIPTION
This PR is a follow up to https://github.com/dask/dask/pull/11767, which missed a code path when there are duplicates. This caused issues in cudf when we tried to convert from a cupy to numpy array.

The changes here propose to do more stuff in Python land (using lists, sets, and `bisect`) instead of array land (using ndarrays, `np.unique`, and `np.searchsorted`). cc @rjzamora if you have any intuition on whether this will be a problem.

I could see it going either way, so here's a benchmark for various sizes of arrays, cardinality, and number of partitions:

<details>

```python
import statistics
import time
import numpy as np
import cupy as cp
import pandas as pd

from dask.dataframe.io.io import sorted_division_locations


def bench(f, *args):
    times = []
    for i in range(3):
        t0 = time.perf_counter()
        f(*args)
        t1 = time.perf_counter()
        times.append(t1 - t0)
    return statistics.median(times)


def time_small_low(xp):
    seq = xp.array([0, 0, 1, 2])
    seq.sort()
    return bench(sorted_division_locations, seq, 2)


def time_large_low_few(xp):
    seq = xp.random.RandomState(seed=0).randint(0, 10, size=1_000_000)
    seq.sort()
    return bench(sorted_division_locations, seq, 5)


def time_large_low_many(xp):
    seq = xp.random.RandomState(seed=0).randint(0, 100, size=1_000_000)
    seq.sort()
    assert len(np.unique(seq)) < len(seq)
    return bench(sorted_division_locations, seq, 100)


def time_large_high_few(xp):
    seq = xp.random.RandomState(seed=0).randint(0, 10_000, size=1_000_000)
    seq.sort()
    assert len(np.unique(seq)) < len(seq)
    return bench(sorted_division_locations, seq, 10)


def time_large_high_many(xp):
    seq = xp.random.RandomState(seed=0).randint(0, 10_000, size=1_000_000)
    seq.sort()
    assert len(np.unique(seq)) < len(seq)
    return bench(sorted_division_locations, seq, 1_000)


if __name__ == "__main__":
    import collections
    import sys
    name = sys.argv[1]
    d = collections.defaultdict(lambda: collections.defaultdict(dict))
    benchmarks = [
        time_small_low,
        time_large_low_few,
        time_large_low_many,
        time_large_high_few,
        time_large_high_many,
    ]
    times = [
        (benchmark.__name__, xp.__name__, benchmark(xp))
        for benchmark in benchmarks
        for xp in [np, cp]
    ]
    for (benchmark, package, t) in times:
        d[package][benchmark] = t
    df = pd.DataFrame(d)

    print(df)
    df.to_parquet(f"{name}.parquet")
```

</details>


On `main` (with a small patch to fix things, but keeps stuff in array land) here are the timings:

```
                         numpy      cupy
time_small_low        0.000037  0.001629
time_large_low_few    0.013078  0.018292
time_large_low_many   0.016665  0.067639
time_large_high_few   0.050510  0.048642
time_large_high_many  0.056525  0.555232
```

and here's this branch

```
                         numpy      cupy
time_small_low        0.000014  0.000053
time_large_low_few    0.016435  0.020920
time_large_low_many   0.015006  0.017443
time_large_high_few   0.063536  0.058884
time_large_high_many  0.059283  0.069043
```

and here's the difference (this PR - main, so negative numbers here are speedups)

```
                         numpy      cupy
time_small_low       -0.000023 -0.001575
time_large_low_few    0.003358  0.002628
time_large_low_many  -0.001659 -0.050196
time_large_high_few   0.013026  0.010242
time_large_high_many  0.002757 -0.486189
```

And again, the assumption is that all this fits in memory and this is cached, so it probably doesn't matter either way.