### PR TITLE
bug: handle list like objects i.e. `pd.Index` in `_simplify_down`

### DIFF
--- a/dask/dataframe/dask_expr/_expr.py
+++ b/dask/dataframe/dask_expr/_expr.py
@@ -2178,7 +2178,7 @@ class Projection(Elemwise):
             if not isinstance(a, list):
                 # df[scalar][b] -> First selection coerces to Series
                 return
-            elif isinstance(b, list):
+            elif pd.types.is_list_like(b):
                 assert all(bb in a for bb in b)
             else:
                 assert b in a


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Fixes bug when a `pd.Index` is passed to `_simplify_down`