### PR TITLE
Add __all__ to `dask.bag`

### DIFF
--- a/dask/bag/__init__.py
+++ b/dask/bag/__init__.py
@@ -1,5 +1,23 @@
 from __future__ import annotations
 
+__all__ = [
+    "Bag",
+    "Item",
+    "map",
+    "range",
+    "zip",
+    "concat",
+    "from_delayed",
+    "from_sequence",
+    "from_url",
+    "map_partitions",
+    "to_textfiles",
+    "read_avro",
+    "read_text",
+    "assert_eq",
+    "compute",
+]
+
 try:
     from dask.bag.avro import read_avro
     from dask.bag.core import Bag, Item


### PR DESCRIPTION
- [x] Closes #8853
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

I think this one is small enough that we don’t need a test like #11780.

@phofl implied in https://github.com/dask/dask/pull/11779#issuecomment-2681477506 that he considers #8853 closed when the following all have an `__all__`:

- dask.array was done in #11779
- dask.dataframe was done in #11664
- dask.bag is this one
- dask.delayed’s `__all__` has existed for a long time

since this is the last one, I added marked this as “closes #8853” 