### PR TITLE
Test `dask.dataframe.__all__`

### DIFF
--- a/dask/dataframe/__init__.py
+++ b/dask/dataframe/__init__.py
@@ -98,6 +98,7 @@ __all__ = [
     "merge",
     "merge_asof",
     "pivot_table",
+    "demo",
     "read_csv",
     "read_fwf",
     "read_hdf",

--- a/dask/dataframe/tests/test_api.py
+++ b/dask/dataframe/tests/test_api.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from types import ModuleType
+
+import pytest
+
+pytest.importorskip("pandas")
+
+DA_EXPORTED_SUBMODULES = {"backends", "dispatch", "demo"}
+
+
+def test_api():
+    """Tests that `dask.array.__all__` is correct"""
+    import dask.dataframe as ddf
+
+    member_dict = vars(ddf)
+    members = set(member_dict)
+    # unexported submodules
+    members -= {"tests", "dask"}
+    members -= {
+        m
+        for m, mod in member_dict.items()
+        if m not in DA_EXPORTED_SUBMODULES
+        if isinstance(mod, ModuleType)
+        and mod.__package__
+        and mod.__package__.startswith("dask.dataframe")
+    }
+    # imported utility modules
+    members -= {"annotations"}
+    # private utilities and `__dunder__` members
+    members -= {m for m in members if m.startswith("_")}
+
+    assert set(ddf.__all__) == members


### PR DESCRIPTION
- [ ] Related to #8853
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

This also adds an export for `dask.dataframe.demo`, which was missing from `__all__` and caught by the test.

As requested in https://github.com/dask/dask/pull/11780#pullrequestreview-2640643172 by @phofl