### PR TITLE
Speed up normalize_pickle by 50 percent

### DIFF
--- a/dask/tests/test_tokenize.py
+++ b/dask/tests/test_tokenize.py
@@ -1440,6 +1440,23 @@ def test_tokenize_pandas_arrow_strings():
     assert any(str(tok) == "string" for tok in flatten(tokens))
 
 
+class APickleable:
+    counter = 0
+
+    def __reduce__(self):
+        APickleable.counter += 1
+        return APickleable, ()
+
+
+def test_normalize_pickle():
+    a = APickleable()
+    tokenize(a)
+    # We're pickling multiple times because pickle is caching things on
+    # instances such that subsequent pickles can yield different results.
+    # For a trivial object like this, this should only happen twice
+    assert APickleable.counter <= 2
+
+
 def test_tokenize_recursive_respects_ensure_deterministic():
     class Foo:
         def __dask_tokenize__(self):

--- a/dask/tokenize.py
+++ b/dask/tokenize.py
@@ -235,8 +235,10 @@ def _normalize_pickle(o: object) -> tuple:
     buffers: list[pickle.PickleBuffer] = []
     pik: int | None = None
     pik2: int
-
+    success = False
     for mod in [pickle, cloudpickle]:
+        if success:
+            break
         for _ in range(3):
             buffers.clear()
             try:
@@ -246,6 +248,7 @@ def _normalize_pickle(o: object) -> tuple:
             except Exception:
                 break
             if pik == pik2:
+                success = True
                 break
             pik = pik2
         else:


### PR DESCRIPTION
This code is pretty nasty as it is. There is also a bug that affects the happy path since `cloudpickle` is *always* called once even if pickle works flawlessly. This change should speed up tokenize of trivial objects by 50%