### PR TITLE
Do not use asynchronous clients in get_scheduler

### DIFF
--- a/Untitled.ipynb
+++ b/Untitled.ipynb
@@ -1,0 +1,72 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9ea0e290-eee6-43a7-b159-4da6d0e20975",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pickle, time\n",
+    "class A:\n",
+    "    def __reduce__(self):\n",
+    "        time.sleep(0.1)\n",
+    "        return lambda : 1, ()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f5e030f3-d759-4dfb-a0c2-a7c28dbb3338",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = A()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "66f4d23a-ad1b-4295-a8b6-edeace26785e",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "Can't pickle local object 'A.__reduce__.<locals>.<lambda>'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "File \u001b[0;32m<timed eval>:1\u001b[0m\n",
+      "\u001b[0;31mAttributeError\u001b[0m: Can't pickle local object 'A.__reduce__.<locals>.<lambda>'"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "pickle.dumps(a)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/conftest.py
+++ b/conftest.py
@@ -95,3 +95,11 @@ def pytest_assertrepr_compare(op, left, right):
             f" left: {left.key} right: {right.key}",
             " Diff:",
         ] + diff
+
+
+@pytest.fixture(autouse=True, scope="session")
+def allow_distributed_async_clients():
+    import dask
+
+    with dask.config.set({"admin.async-client-fallback": "sync"}):
+        yield

--- a/dask/base.py
+++ b/dask/base.py
@@ -1113,7 +1113,17 @@ def get_scheduler(get=None, scheduler=None, collections=None, cls=None):
                         f"Requested {scheduler} scheduler but no Client active."
                     )
                 assert _get_distributed_client is not None
-                return _get_distributed_client().get
+                client = _get_distributed_client()
+                if client.asynchronous:
+                    warnings.warn(
+                        "Distributed Client detected but Client instance is "
+                        "asynchronous. Falling back to 'sync' scheduler. "
+                        "To use an asynchronous Client, please use "
+                        "``Client.compute`` and ``Client.gather`` "
+                        "instead of the top level ``dask.compute``",
+                        UserWarning,
+                    )
+                    return get_scheduler(scheduler="sync")
             else:
                 raise ValueError(
                     "Expected one of [distributed, %s]"

--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -247,6 +247,11 @@ properties:
   admin:
     type: object
     properties:
+      allow-async-clients:
+        type: boolean
+        description: |
+          If False, raise an exception if dask.compute is attempting to select
+          an asynchronous Client. If True, fall back to a sync scheduler.
 
       traceback:
         type: object

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -44,6 +44,7 @@ optimization:
     delayed: false
 
 admin:
+  async-client-fallback: null
   traceback:
     shorten:
       - concurrent[\\\/]futures[\\\/]


### PR DESCRIPTION
When using an asynchronous version of the distributed Client, the function `dask.compute` and `Collections.compute` methods are not properly working because the `Client.get` is returning a coroutine object instead of the actual result. This typically crashes with the repacking logic in `dask.compute`.

Making this _just work_ is not possible from my understanding of asyncio and I see two options. For ordinary users it is best to raise in this situation. For our testing infrastructure it is still nice if there was a well defined behavior. For example, read_parquet is triggering a quantile computation this way regardless of the client used.