### PR TITLE
Cache tokens on expressions and restore after pickle roundtrip

### DIFF
--- a/dask/array/_array_expr/_blockwise.py
+++ b/dask/array/_array_expr/_blockwise.py
@@ -116,6 +116,15 @@ class Blockwise(ArrayExpr):
     def dtype(self):
         return self.operand("dtype")
 
+    @property
+    def deterministic_token(self):
+        if not self._determ_token:
+            # TODO: Is there an actual need to overwrite this?
+            self._determ_token = _tokenize_deterministic(
+                self.func, self.out_ind, self.dtype, *self.args, **self.kwargs
+            )
+        return self._determ_token
+
     @cached_property
     def _name(self):
         if "name" in self._parameters and self.operand("name"):
@@ -123,9 +132,7 @@ class Blockwise(ArrayExpr):
         else:
             return (
                 f"{self.token or funcname(self.func).strip('_')}-"
-                + _tokenize_deterministic(
-                    self.func, self.out_ind, self.dtype, *self.args, **self.kwargs
-                )
+                + self.deterministic_token
             )
 
     def _layer(self):

--- a/dask/array/_array_expr/_io.py
+++ b/dask/array/_array_expr/_io.py
@@ -15,7 +15,6 @@ from dask.array.core import (
     slices_from_chunks,
 )
 from dask.array.utils import meta_from_array
-from dask.tokenize import _tokenize_deterministic
 from dask.utils import SerializableLock
 
 
@@ -36,9 +35,7 @@ class FromGraph(IO):
 
     @functools.cached_property
     def _name(self):
-        return (
-            self.operand("name_prefix") + "-" + _tokenize_deterministic(*self.operands)
-        )
+        return self.operand("name_prefix") + "-" + self.deterministic_token
 
     def _layer(self):
         dsk = dict(self.operand("layer"))

--- a/dask/array/_array_expr/_reductions.py
+++ b/dask/array/_array_expr/_reductions.py
@@ -276,14 +276,21 @@ class PartialReduce(ArrayExpr):
         "reduced_meta": None,
     }
 
+    @property
+    def deterministic_token(self):
+        if not self._determ_token:
+            # TODO: Is there an actual need to overwrite this?
+            self._determ_token = _tokenize_deterministic(
+                self.func, self.array, self.split_every, self.keepdims, self.dtype
+            )
+        return self._determ_token
+
     @cached_property
     def _name(self):
         return (
             (self.operand("name") or funcname(self.func))
             + "-"
-            + _tokenize_deterministic(
-                self.func, self.array, self.split_every, self.keepdims, self.dtype
-            )
+            + self.deterministic_token
         )
 
     @cached_property

--- a/dask/dataframe/dask_expr/_expr.py
+++ b/dask/dataframe/dask_expr/_expr.py
@@ -48,7 +48,7 @@ from dask.dataframe.utils import (
     raise_on_meta_error,
     valid_divisions,
 )
-from dask.tokenize import _tokenize_deterministic, normalize_token
+from dask.tokenize import normalize_token
 from dask.typing import Key, no_default
 from dask.utils import (
     M,
@@ -607,7 +607,7 @@ class Blockwise(Expr):
             head = funcname(self.operation)
         else:
             head = funcname(type(self)).lower()
-        return head + "-" + _tokenize_deterministic(*self.operands)
+        return head + "-" + self.deterministic_token
 
     def _blockwise_arg(self, arg, i):
         """Return a Blockwise-task argument"""
@@ -685,7 +685,7 @@ class MapPartitions(Blockwise):
             head = self.token
         else:
             head = funcname(self.func).lower()
-        return head + "-" + _tokenize_deterministic(*self.operands)
+        return head + "-" + self.deterministic_token
 
     def _broadcast_dep(self, dep: Expr):
         # Always broadcast single-partition dependencies in MapPartitions
@@ -3101,7 +3101,7 @@ class DelayedsExpr(Expr):
 
     @functools.cached_property
     def _name(self):
-        return "delayed-container-" + _tokenize_deterministic(*self.operands)
+        return "delayed-container-" + self.deterministic_token
 
     def _layer(self) -> dict:
         dask = {}
@@ -3782,7 +3782,7 @@ class Fused(Blockwise):
 
     @functools.cached_property
     def _name(self):
-        return f"{str(self)}-{_tokenize_deterministic(*self.operands)}"
+        return f"{str(self)}-{self.deterministic_token}"
 
     def _divisions(self):
         return self.exprs[0]._divisions()

--- a/dask/dataframe/dask_expr/_reductions.py
+++ b/dask/dataframe/dask_expr/_reductions.py
@@ -40,7 +40,6 @@ from dask.dataframe.dask_expr._expr import (
 )
 from dask.dataframe.dispatch import make_meta, meta_nonempty
 from dask.dataframe.utils import is_scalar
-from dask.tokenize import _tokenize_deterministic
 from dask.typing import no_default
 from dask.utils import M, apply, funcname
 
@@ -326,7 +325,7 @@ class TreeReduce(Expr):
             name = funcname(self.combine.__self__).lower() + "-tree"
         else:
             name = funcname(self.combine)
-        return name + "-" + _tokenize_deterministic(*self.operands)
+        return name + "-" + self.deterministic_token
 
     def __dask_postcompute__(self):
         return toolz.first, ()
@@ -858,7 +857,7 @@ class CustomReduction(Reduction):
     @functools.cached_property
     def _name(self):
         name = self.operand("token") or funcname(type(self)).lower()
-        return name + "-" + _tokenize_deterministic(*self.operands)
+        return name + "-" + self.deterministic_token
 
     @classmethod
     def chunk(cls, df, **kwargs):

--- a/dask/dataframe/dask_expr/diagnostics/_analyze.py
+++ b/dask/dataframe/dask_expr/diagnostics/_analyze.py
@@ -14,7 +14,6 @@ from dask.dataframe.dask_expr.diagnostics._explain import (
 from dask.dataframe.dask_expr.io.io import FusedIO
 from dask.dataframe.utils import is_scalar
 from dask.sizeof import sizeof
-from dask.tokenize import _tokenize_deterministic
 from dask.utils import format_bytes, import_required
 
 if TYPE_CHECKING:
@@ -201,4 +200,4 @@ class Analyze(Blockwise):
 
     @functools.cached_property
     def _name(self):
-        return "analyze-" + _tokenize_deterministic(*self.operands)
+        return "analyze-" + self.deterministic_token

--- a/dask/dataframe/dask_expr/io/_delayed.py
+++ b/dask/dataframe/dask_expr/io/_delayed.py
@@ -16,7 +16,6 @@ from dask.dataframe.dask_expr.io import BlockwiseIO
 from dask.dataframe.dispatch import make_meta
 from dask.dataframe.utils import check_meta, pyarrow_strings_enabled
 from dask.delayed import Delayed, delayed
-from dask.tokenize import _tokenize_deterministic
 from dask.typing import Key
 
 if TYPE_CHECKING:
@@ -44,7 +43,7 @@ class FromDelayed(PartitionsFiltered, BlockwiseIO):
     def _name(self):
         if self.prefix is None:
             return super()._name
-        return self.prefix + "-" + _tokenize_deterministic(*self.operands)
+        return self.prefix + "-" + self.deterministic_token
 
     @functools.cached_property
     def _meta(self):

--- a/dask/dataframe/dask_expr/io/io.py
+++ b/dask/dataframe/dask_expr/io/io.py
@@ -107,11 +107,7 @@ class FusedIO(BlockwiseIO):
 
     @functools.cached_property
     def _name(self):
-        return (
-            self.operand("_expr")._funcname
-            + "-fused-"
-            + _tokenize_deterministic(*self.operands)
-        )
+        return self.operand("_expr")._funcname + "-fused-" + self.deterministic_token
 
     @functools.cached_property
     def _meta(self):
@@ -167,7 +163,7 @@ class FusedParquetIO(FusedIO):
         return (
             funcname(type(self.operand("_expr"))).lower()
             + "-fused-parq-"
-            + _tokenize_deterministic(*self.operands)
+            + self.deterministic_token
         )
 
     @staticmethod
@@ -245,13 +241,9 @@ class FromMap(PartitionsFiltered, BlockwiseIO):
     @functools.cached_property
     def _name(self):
         if self.label is None:
-            return (
-                funcname(self.func).lower()
-                + "-"
-                + _tokenize_deterministic(*self.operands)
-            )
+            return funcname(self.func).lower() + "-" + self.deterministic_token
         else:
-            return self.label + "-" + _tokenize_deterministic(*self.operands)
+            return self.label + "-" + self.deterministic_token
 
     @functools.cached_property
     def _meta(self):
@@ -552,7 +544,7 @@ class FromPandasDivisions(FromPandas):
 
     @functools.cached_property
     def _name(self):
-        return "from_pd_divs" + "-" + _tokenize_deterministic(*self.operands)
+        return "from_pd_divs" + "-" + self.deterministic_token
 
     @property
     def _divisions_and_locations(self):

--- a/dask/dataframe/dask_expr/io/parquet.py
+++ b/dask/dataframe/dask_expr/io/parquet.py
@@ -777,15 +777,18 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
     def _funcname(self):
         return "read_parquet"
 
-    @cached_property
-    def _name(self):
-        return (
-            self._funcname
-            + "-"
-            + _tokenize_deterministic(
+    @property
+    def deterministic_token(self):
+        if not self._determ_token:
+            # TODO: Is there an actual need to overwrite this?
+            self._determ_token = _tokenize_deterministic(
                 funcname(type(self)), self.checksum, *self.operands[:-1]
             )
-        )
+        return self._determ_token
+
+    @cached_property
+    def _name(self):
+        return self._funcname + "-" + self.deterministic_token
 
     @property
     def checksum(self):

--- a/dask/dataframe/dask_expr/tests/test_core.py
+++ b/dask/dataframe/dask_expr/tests/test_core.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import pickle
+import uuid
+
 import pytest
 
 from dask._expr import Expr
+from dask.tokenize import tokenize
 
 
 class ExprB(Expr):
@@ -25,3 +29,21 @@ def test_endless_simplify():
     expr = ExprA()
     with pytest.raises(RuntimeError, match="converge"):
         expr.simplify()
+
+
+class NondeterminisitcToken:
+    def __dask_tokenize__(self):
+        return uuid.uuid4()
+
+
+def test_expr_nondeterministic_token_pickle_roundtrip():
+
+    foo = NondeterminisitcToken()
+    assert tokenize(foo) != tokenize(foo)
+    assert tokenize(Expr(foo)) != tokenize(Expr(foo))
+
+    inst = Expr(foo)
+    tok = tokenize(inst)
+    assert tokenize(inst) == tok
+    rt = pickle.loads(pickle.dumps(inst))
+    assert tokenize(rt) == tok


### PR DESCRIPTION
xref https://github.com/dask/dask/pull/11736

This caches the tokens on the expression and restores calculated tokens after a pickle roundtrip. This helps us keep tokens consistent between client and scheduler.
This is safe to do since Expr are by definition immutable (since otherwise our singleton approach would fall apart anyhow)