### PR TITLE
Fix missing imports in array-expr

### DIFF
--- a/dask/array/_array_expr/_creation.py
+++ b/dask/array/_array_expr/_creation.py
@@ -6,6 +6,7 @@ from functools import partial
 import numpy as np
 
 from dask._collections import new_collection
+from dask._task_spec import Task
 from dask.array._array_expr._expr import ArrayExpr
 from dask.array.chunk import arange as _arange
 from dask.array.chunk import linspace as _linspace

--- a/dask/array/_array_expr/_expr.py
+++ b/dask/array/_array_expr/_expr.py
@@ -11,6 +11,7 @@ import toolz
 from tlz import accumulate
 
 from dask._expr import Expr
+from dask._task_spec import Task, TaskRef
 from dask.array.chunk import getitem
 from dask.array.core import T_IntOrNaN, common_blockdim, unknown_chunk_message
 from dask.blockwise import broadcast_dimensions


### PR DESCRIPTION
This slipped in when merging https://github.com/dask/dask/pull/11783 I'm surprised CI didn't see this (or we might've missed the failure)