### PR TITLE
Implement an Array Scalar

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -650,10 +650,12 @@ if _array_expr_enabled():
             from_array,
             linspace,
             map_blocks,
+            ones,
             random,
             rechunk,
             reduction,
             stack,
+            zeros,
         )
         from dask.array.reductions import (
             all,
@@ -669,13 +671,11 @@ if _array_expr_enabled():
             nanstd,
             nansum,
             nanvar,
-            ones,
             prod,
             reduction,
             std,
             sum,
             var,
-            zeros,
         )
 
         backends = raise_not_implemented_error("backends")

--- a/dask/array/_array_expr/_backends.py
+++ b/dask/array/_array_expr/_backends.py
@@ -106,3 +106,23 @@ if scipy_installed and hasattr(sp, "sparray"):  # type: ignore[misc]
     @get_collection_type.register(sp.csr_array)
     def get_collection_type_array(_):
         return create_array_collection
+
+
+@get_collection_type.register(object)
+def get_collection_type_object(_):
+
+    return create_scalar_collection
+
+
+def create_scalar_collection(expr):
+    from dask.array._array_expr._expr import ArrayExpr
+
+    if isinstance(expr, ArrayExpr):
+        # This mirrors the legacy implementation in dask.array
+        from dask.array._array_expr._collection import Array
+
+        return Array(expr)
+
+    from dask.dataframe.dask_expr._collection import Scalar
+
+    return Scalar(expr)

--- a/dask/dataframe/dask_expr/_backends.py
+++ b/dask/dataframe/dask_expr/_backends.py
@@ -66,13 +66,6 @@ def get_collection_type_index(_):
     return Index
 
 
-@get_collection_type.register(object)
-def get_collection_type_object(_):
-    from dask.dataframe.dask_expr._collection import Scalar
-
-    return Scalar
-
-
 ######################################
 # cuDF: Pandas Dataframes on the GPU #
 ######################################


### PR DESCRIPTION
- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`


So, the current Dask Array implementation just uses an Array to capture scalar elements, which is unfortunate. I tried implementing a proper Scalar class but that blew up left and right and it's currently too hard to tell if the failures are legit or not. I went with this approach now but I think we should solve this with a proper scalar implementation after the tests are green

cc @fjetter 