### PR TITLE
Make missing meta warning more ergonomic

### DIFF
--- a/dask/dataframe/core.py
+++ b/dask/dataframe/core.py
@@ -406,7 +406,7 @@ def has_parallel_type(x):
     return get_parallel_type(x) is not Scalar
 
 
-def meta_warning(df):
+def meta_warning(df, method="apply"):
     """
     Provide an informative message when the user is asked to provide metadata
     """
@@ -421,14 +421,14 @@ def meta_warning(df):
         "function on a small dataset to guess output types. "
         "It is possible that Dask will guess incorrectly.\n"
         "To provide an explicit output types or to silence this message, "
-        "please provide the `meta=` keyword, as described in the map or "
-        "apply function that you are using."
+        f"please provide the `meta=` keyword, as described in the {method} function "
+        f"that you are using."
     )
     if meta_str:
         msg += (
             "\n"
-            "  Before: .apply(func)\n"
-            "  After:  .apply(func, meta=%s)\n" % str(meta_str)
+            f"  Before: .{method}(func)\n"
+            f"  After:  .{method}(func, meta=%s)\n" % str(meta_str)
         )
     return msg
 

--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -3108,7 +3108,7 @@ class DataFrame(FrameBase):
             )
         if meta is None:
             meta = expr.emulate(M.map, self, func, na_action=na_action, udf=True)
-            warnings.warn(meta_warning(meta))
+            warnings.warn(meta_warning(meta, method="map"))
         return new_collection(expr.Map(self, arg=func, na_action=na_action, meta=meta))
 
     @derived_from(pd.DataFrame)
@@ -4201,13 +4201,13 @@ class Series(FrameBase):
         if isinstance(arg, Series):
             if not expr.are_co_aligned(self.expr, arg.expr):
                 if meta is None:
-                    warnings.warn(meta_warning(meta))
+                    warnings.warn(meta_warning(meta, method="map"))
                 return new_collection(
                     expr.MapAlign(self, arg, op=None, na_action=na_action, meta=meta)
                 )
         if meta is None:
             meta = expr.emulate(M.map, self, arg, na_action=na_action, udf=True)
-            warnings.warn(meta_warning(meta))
+            warnings.warn(meta_warning(meta, method="map"))
         return new_collection(expr.Map(self, arg=arg, na_action=na_action, meta=meta))
 
     @derived_from(pd.Series)
@@ -4728,13 +4728,13 @@ class Index(Series):
         if isinstance(arg, Series):
             if not expr.are_co_aligned(self.expr, arg.expr):
                 if meta is None:
-                    warnings.warn(meta_warning(meta))
+                    warnings.warn(meta_warning(meta, method="map"))
                 return new_collection(
                     expr.MapIndexAlign(self, arg, na_action, meta, is_monotonic)
                 )
         if meta is None:
             meta = expr.emulate(M.map, self, arg, na_action=na_action, udf=True)
-            warnings.warn(meta_warning(meta))
+            warnings.warn(meta_warning(meta, method="map"))
         return new_collection(
             expr.Map(
                 self, arg=arg, na_action=na_action, meta=meta, is_monotonic=is_monotonic

--- a/dask/dataframe/dask_expr/_groupby.py
+++ b/dask/dataframe/dask_expr/_groupby.py
@@ -1962,8 +1962,7 @@ class GroupBy:
 
     def _warn_if_no_meta(self, meta, method="apply"):
         if meta is no_default:
-            msg = f"""
-`meta` is not specified, inferred from partial data.
+            msg = f"""`meta` is not specified, inferred from partial data.
 Please provide `meta` if the result is unexpected.
   Before: .{method}(func)
   After:  .{method}(func, meta={{'x': 'f8', 'y': 'f8'}}) for dataframe result

--- a/dask/dataframe/dask_expr/_groupby.py
+++ b/dask/dataframe/dask_expr/_groupby.py
@@ -1960,15 +1960,15 @@ class GroupBy:
     def agg(self, *args, **kwargs):
         return self.aggregate(*args, **kwargs)
 
-    def _warn_if_no_meta(self, meta):
+    def _warn_if_no_meta(self, meta, method="apply"):
         if meta is no_default:
-            msg = (
-                "`meta` is not specified, inferred from partial data. "
-                "Please provide `meta` if the result is unexpected.\n"
-                "  Before: .apply(func)\n"
-                "  After:  .apply(func, meta={'x': 'f8', 'y': 'f8'}) for dataframe result\n"
-                "  or:     .apply(func, meta=('x', 'f8'))            for series result"
-            )
+            msg = f"""
+`meta` is not specified, inferred from partial data.
+Please provide `meta` if the result is unexpected.
+  Before: .{method}(func)
+  After:  .{method}(func, meta={{'x': 'f8', 'y': 'f8'}}) for dataframe result
+  or:     .{method}(func, meta=('x', 'f8'))            for series result
+"""
             warnings.warn(msg, stacklevel=3)
 
     @insert_meta_param_description(pad=12)
@@ -2073,7 +2073,7 @@ class GroupBy:
         -------
         applied : Series or DataFrame depending on columns keyword
         """
-        self._warn_if_no_meta(meta)
+        self._warn_if_no_meta(meta, method="transform")
         return self._transform_like_op(
             GroupByTransform, func, meta, shuffle_method, *args, **kwargs
         )
@@ -2109,7 +2109,7 @@ class GroupBy:
         """
         if "axis" in kwargs:
             raise TypeError("axis is not supported in shift.")
-        self._warn_if_no_meta(meta)
+        self._warn_if_no_meta(meta, method="shift")
         kwargs = {"periods": periods, **kwargs}
         return self._transform_like_op(
             GroupByShift, None, meta, shuffle_method, *args, **kwargs

--- a/dask/dataframe/dask_expr/tests/test_groupby.py
+++ b/dask/dataframe/dask_expr/tests/test_groupby.py
@@ -981,7 +981,7 @@ def test_groupby_size_drop_columns(df, pdf):
 
 
 @pytest.mark.filterwarnings("ignore:`meta` is not specified|DataFrameGroupBy.apply")
-def test_groupy_respect_shuffle_context(df, pdf):
+def test_groupby_respect_shuffle_context(df, pdf):
     def _check_task_shuffle(q):
         result = q.optimize(fuse=False)
         assert len([x for x in result.walk() if isinstance(x, TaskShuffle)]) > 0


### PR DESCRIPTION
- [ ] Closes #11804
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`


This makes the warning a lot more applicable and easier to understand for other methods than apply