### PR TITLE
Consolidate getattr for expr classes

### DIFF
--- a/dask/array/_array_expr/_expr.py
+++ b/dask/array/_array_expr/_expr.py
@@ -102,32 +102,6 @@ class ArrayExpr(Expr):
     def optimize(self):
         return self.simplify().lower_completely()
 
-    def __getattr__(self, key):
-        try:
-            return object.__getattribute__(self, key)
-        except AttributeError as err:
-            if key.startswith("_meta"):
-                # Avoid a recursive loop if/when `self._meta*`
-                # produces an `AttributeError`
-                raise RuntimeError(
-                    f"Failed to generate metadata for {self}. "
-                    "This operation may not be supported by the current backend."
-                )
-
-            # Allow operands to be accessed as attributes
-            # as long as the keys are not already reserved
-            # by existing methods/properties
-            _parameters = type(self)._parameters
-            if key in _parameters:
-                idx = _parameters.index(key)
-                return self.operands[idx]
-
-            raise AttributeError(
-                f"{err}\n\n"
-                "This often means that you are attempting to use an unsupported "
-                f"API function.."
-            )
-
     def rechunk(
         self,
         chunks="auto",

--- a/dask/array/numpy_compat.py
+++ b/dask/array/numpy_compat.py
@@ -59,7 +59,7 @@ except TypeError:
             x = x.astype(dtype)
         return x
 
-    ma_divide = np.ma.core._DomainedBinaryOperation(  # type: ignore
+    ma_divide = np.ma.core._DomainedBinaryOperation(
         divide, np.ma.core._DomainSafeDivide(), 0, 1  # type: ignore
     )
 

--- a/dask/dataframe/dask_expr/_expr.py
+++ b/dask/dataframe/dask_expr/_expr.py
@@ -149,32 +149,12 @@ class Expr(core.Expr):
 
     def __getattr__(self, key):
         try:
-            return object.__getattribute__(self, key)
-        except AttributeError as err:
-            if key.startswith("_meta"):
-                # Avoid a recursive loop if/when `self._meta*`
-                # produces an `AttributeError`
-                raise RuntimeError(
-                    f"Failed to generate metadata for {self}. "
-                    "This operation may not be supported by the current backend."
-                )
+            return super().__getattr__(key)
+        except AttributeError:
 
-            # Allow operands to be accessed as attributes
-            # as long as the keys are not already reserved
-            # by existing methods/properties
-            _parameters = type(self)._parameters
-            if key in _parameters:
-                idx = _parameters.index(key)
-                return self.operands[idx]
             if is_dataframe_like(self._meta) and key in self._meta.columns:
                 return self[key]
-
-            link = "https://github.com/dask-contrib/dask-expr/blob/main/README.md#api-coverage"
-            raise AttributeError(
-                f"{err}\n\n"
-                "This often means that you are attempting to use an unsupported "
-                f"API function. Current API coverage is documented here: {link}."
-            )
+            raise
 
     def __getitem__(self, other):
         if isinstance(other, Expr):


### PR DESCRIPTION
This reduces code duplication in the expr subclasses and consolidates the `__getattr__` method. this is part of https://github.com/dask/distributed/pull/9008