### PR TITLE
Expr setattr

### DIFF
--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -164,6 +164,19 @@ class Expr:
                     cache[expr._name] = result[-1]
             return max(result)
 
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in ["operands", "_determ_token"]:
+            object.__setattr__(self, name, value)
+            return
+        try:
+            params = object.__getattribute__(type(self), "_parameters")
+            operands = object.__getattribute__(self, "operands")
+            operands[params.index(name)] = value
+        except ValueError:
+            raise AttributeError(
+                f"{type(self).__name__} object has no attribute {name}"
+            )
+
     def operand(self, key):
         # Access an operand unambiguously
         # (e.g. if the key is reserved by a method/property)

--- a/dask/array/_array_expr/_expr.py
+++ b/dask/array/_array_expr/_expr.py
@@ -11,7 +11,7 @@ import toolz
 from tlz import accumulate
 
 from dask._expr import Expr
-from dask._task_spec import Task, TaskRef
+from dask._task_spec import List, Task, TaskRef
 from dask.array.chunk import getitem
 from dask.array.core import T_IntOrNaN, common_blockdim, unknown_chunk_message
 from dask.blockwise import broadcast_dimensions
@@ -21,7 +21,6 @@ from dask.utils import cached_cumsum
 
 
 class ArrayExpr(Expr):
-    _cached_keys = None
 
     def _operands_for_repr(self):
         return []
@@ -76,25 +75,35 @@ class ArrayExpr(Expr):
             raise ValueError(msg)
         return int(sum(self.chunks[0]))
 
-    def __dask_keys__(self):
+    @functools.cached_property
+    def _cached_keys(self):
         out = self.lower_completely()
-        if self._cached_keys is not None:
-            return self._cached_keys
 
         name, chunks, numblocks = out.name, out.chunks, out.numblocks
 
         def keys(*args):
             if not chunks:
-                return [(name,)]
+                return List(TaskRef((name,)))
             ind = len(args)
             if ind + 1 == len(numblocks):
-                result = [(name,) + args + (i,) for i in range(numblocks[ind])]
+                result = List(
+                    *(TaskRef((name,) + args + (i,)) for i in range(numblocks[ind]))
+                )
             else:
-                result = [keys(*(args + (i,))) for i in range(numblocks[ind])]
+                result = List(*(keys(*(args + (i,))) for i in range(numblocks[ind])))
             return result
 
-        self._cached_keys = result = keys()
-        return result
+        return keys()
+
+    def __dask_keys__(self):
+        key_refs = self._cached_keys
+
+        def unwrap(task):
+            if isinstance(task, List):
+                return [unwrap(t) for t in task.args]
+            return task.key
+
+        return unwrap(key_refs)
 
     def __hash__(self):
         return hash(self._name)

--- a/dask/dataframe/dask_expr/_expr.py
+++ b/dask/dataframe/dask_expr/_expr.py
@@ -458,8 +458,7 @@ class Expr(core.Expr):
     @property
     def npartitions(self):
         if "npartitions" in self._parameters:
-            idx = self._parameters.index("npartitions")
-            return self.operands[idx]
+            return self.operand("npartitions")
         else:
             return len(self.divisions) - 1
 

--- a/dask/dataframe/dask_expr/io/io.py
+++ b/dask/dataframe/dask_expr/io/io.py
@@ -398,6 +398,7 @@ class FromPandas(PartitionsFiltered, BlockwiseIO):
         "pyarrow_strings_enabled",
         "_partitions",
         "_series",
+        "_pd_length_stats",
     ]
     _defaults = {
         "npartitions": None,
@@ -407,8 +408,9 @@ class FromPandas(PartitionsFiltered, BlockwiseIO):
         "_series": False,
         "chunksize": None,
         "pyarrow_strings_enabled": True,
+        "_pd_length_stats": None,
     }
-    _pd_length_stats = None
+    _pd_length_stats: tuple | None
     _absorb_projections = True
 
     @functools.cached_property
@@ -538,8 +540,14 @@ class FromPandasDivisions(FromPandas):
         "pyarrow_strings_enabled",
         "_partitions",
         "_series",
+        "_pd_length_stats",
     ]
-    _defaults = {"columns": None, "_partitions": None, "_series": False}
+    _defaults = {
+        "columns": None,
+        "_partitions": None,
+        "_series": False,
+        "_pd_length_stats": None,
+    }
     sort = True
 
     @functools.cached_property

--- a/dask/tests/test_expr.py
+++ b/dask/tests/test_expr.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import pytest
+
+from dask._expr import Expr
+
+
+def test_setattr():
+    class MyExpr(Expr):
+        _parameters = ["foo", "bar"]
+
+    e = MyExpr(foo=1, bar=2)
+    e.bar = 3
+    assert e.bar == 3
+    with pytest.raises(AttributeError):
+        e.baz = 4


### PR DESCRIPTION
I believe this is an important first step towards making the Expr classes more traditional classes. The concept with _parameters, etc. has been causing issues in the past in the context of inheritance (not to mention the confusion around recursion errors and other things)

This change also further highlights a couple of anti patterns where some implementations set attributes on the classes without them being registered as parameters which poses challenges to serialization and tokenization

This needs https://github.com/dask/dask/pull/11835 since otherwise I cannot properly subclass `Expr` for the test