### PR TITLE
Fixed `Expr.__setattr__` for subclasses

### DIFF
--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -176,7 +176,7 @@ class Expr:
             object.__setattr__(self, name, value)
             return
         try:
-            params = object.__getattribute__(type(self), "_parameters")
+            params = type(self)._parameters
             operands = object.__getattribute__(self, "operands")
             operands[params.index(name)] = value
         except ValueError:

--- a/dask/tests/test_expr.py
+++ b/dask/tests/test_expr.py
@@ -5,11 +5,25 @@ import pytest
 from dask._expr import Expr
 
 
-def test_setattr():
-    class MyExpr(Expr):
-        _parameters = ["foo", "bar"]
+class MyExpr(Expr):
+    _parameters = ["foo", "bar"]
 
+
+class MyExpr2(MyExpr):
+    # A subclass that inherits parameters
+    pass
+
+
+def test_setattr():
     e = MyExpr(foo=1, bar=2)
+    e.bar = 3
+    assert e.bar == 3
+    with pytest.raises(AttributeError):
+        e.baz = 4
+
+
+def test_setattr2():
+    e = MyExpr2(foo=1, bar=2)
     e.bar = 3
     assert e.bar == 3
     with pytest.raises(AttributeError):


### PR DESCRIPTION
I'm seeing some issues in dask-cudf after https://github.com/dask/dask/pull/11836/files and https://github.com/dask/dask/pull/11835/files were merged. I get an infinite recursion error when setting an attribute on a (subclass of) an `Expr` object.

The line I really don't understand is https://github.com/dask/dask/pull/11836/files#diff-224f6706e0d593558390ff212eeb043a9fd411ab927a830c416ad84ff192aa9eR172.

```
            params = object.__getattribute__(type(self), "_parameters")
```

IIUC, that's supposed to get the `Expr._parameters` list of the class. For reasons I don't fully understand, this doesn't work well when `self` is a *non-direct* subclass of `Expr`, like in dask-cudf's case where our class inherits from `ReadParquetFSSpec`. When you're a grandchild of `Expr`, that fails with

```
dask/tests/test_expr.py::test_setattr2 FAILED

======================================================================================================================== FAILURES =========================================================================================================================
______________________________________________________________________________________________________________________ test_setattr2 ______________________________________________________________________________________________________________________

    def test_setattr2():
        e = MyExpr2(foo=1, bar=2)
>       e.bar = 3

dask/tests/test_expr.py:25: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = MyExpr2(foo=1, bar=2), name = 'bar', value = 3

    def __setattr__(self, name: str, value: Any) -> None:
        if name in ["operands", "_determ_token"]:
            object.__setattr__(self, name, value)
            return
        try:
>           params = object.__getattribute__(type(self), "_parameters")
E           AttributeError: 'type' object has no attribute '_parameters'
```

I'm really not sure why Python behaves like this. But I believe that this PR has a compatible change that works for grandchildren too, by using (the simpler?) `type(self).<param>`.