### PR TITLE
Do not inject median in describe for pandas 3

### DIFF
--- a/dask/dataframe/dask_expr/_describe.py
+++ b/dask/dataframe/dask_expr/_describe.py
@@ -5,6 +5,7 @@ import functools
 import numpy as np
 from pandas.core.dtypes.common import is_datetime64_any_dtype, is_timedelta64_dtype
 
+from dask.dataframe._compat import PANDAS_GE_300
 from dask.dataframe.dask_expr._expr import (
     Blockwise,
     DropnaSeries,
@@ -43,7 +44,8 @@ class DescribeNumeric(Reduction):
             percentiles = self.percentiles or [0.25, 0.5, 0.75]
         else:
             percentiles = np.array(self.percentiles)
-            percentiles = np.append(percentiles, 0.5)
+            if not PANDAS_GE_300:
+                percentiles = np.append(percentiles, 0.5)
             percentiles = np.unique(percentiles)
             percentiles = list(percentiles)
 


### PR DESCRIPTION
Our CI upstream build is currently failing. 

We're intentionally appending the median to be consistent with pandas

```python
# Behavior stable
In [1]: import pandas as pd
In [2]: pd.DataFrame({"A": range(10)}).describe(percentiles=[0.2, 0.6])
Out[2]:
              A
count  10.00000
mean    4.50000
std     3.02765
min     0.00000
20%     1.80000
50%     4.50000
60%     5.40000
max     9.00000
```

the dev version is no longer returning the 50% quantil if it wasn't provided. I'm not sure if this was an intentional change in pandas since I couldn't find anything mentioning this in the changelog

cc @TomAugspurger 