### PR TITLE
Remove nightly ``h5py`` from ``upstream`` CI job

### DIFF
--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -25,14 +25,16 @@ if [[ ${UPSTREAM_DEV} ]]; then
         git+https://github.com/dask/zict \
         git+https://github.com/dask/distributed \
         git+https://github.com/zarr-developers/zarr-python
-    mamba uninstall --force numpy pandas scipy numexpr numba sparse scikit-image h5py numbagg
+    # TODO: Add nightly `h5py` back once https://github.com/h5py/h5py/issues/2563 is resolved
+    # mamba uninstall --force numpy pandas scipy numexpr numba sparse scikit-image h5py numbagg
+    mamba uninstall --force numpy pandas scipy numexpr numba sparse scikit-image numbagg
     python -m pip install --no-deps --pre --retries 10 \
         -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
         numpy \
         pandas \
         scipy \
-        scikit-image \
-        h5py
+        scikit-image
+        # h5py
 
     # Used when automatically opening an issue when the `upstream` CI build fails
     mamba install pytest-reportlog


### PR DESCRIPTION
Looks like these aren't currently being published (xref https://github.com/h5py/h5py/issues/2563), leading to the `upstream` build failing ([latest job](https://github.com/dask/dask/actions/runs/14037827831/job/39300168373))

```
++ python -m pip install --no-deps --pre --retries 10 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy pandas scipy scikit-image h5py
Looking in indexes: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
Collecting numpy
  Downloading https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/numpy/2.3.0.dev0/numpy-2.3.0.dev0-cp312-cp312-manylinux_2_28_x86_64.whl (16.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 16.8/16.8 MB 29.7 MB/s eta 0:00:00
Collecting pandas
  Downloading https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/pandas/3.0.0.dev0%2B2022.gdc8401afea/pandas-3.0.0.dev0%2B2022.gdc8401afea-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (12.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 12.7/12.7 MB 25.6 MB/s eta 0:00:00
Collecting scipy
  Downloading https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/scipy/1.16.0.dev0/scipy-1.16.0.dev0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (37.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 37.8/37.8 MB 41.7 MB/s eta 0:00:00
Collecting scikit-image
  Downloading https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/scikit-image/0.26.0rc0.dev0/scikit_image-0.26.0rc0.dev0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (13.9 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 13.9/13.9 MB 41.0 MB/s eta 0:00:00
ERROR: Could not find a version that satisfies the requirement h5py (from versions: none)
ERROR: No matching distribution found for h5py
```
