### PR TITLE
Ensure HLGExpr tokenize uniquely

### DIFF
--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -136,7 +136,9 @@ class Expr:
         return hash(self._name)
 
     def __dask_tokenize__(self):
-        return self._name
+        if not self._determ_token:
+            self._determ_token = _tokenize_deterministic(self.operands)
+        return self._determ_token
 
     @staticmethod
     def _reconstruct(*args):
@@ -494,7 +496,7 @@ class Expr:
     @property
     def deterministic_token(self):
         if not self._determ_token:
-            self._determ_token = _tokenize_deterministic(*self.operands)
+            self._determ_token = _tokenize_deterministic(self)
         return self._determ_token
 
     @functools.cached_property

--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -137,6 +137,10 @@ class Expr:
 
     def __dask_tokenize__(self):
         if not self._determ_token:
+            # If the subclass does not implement a __dask_tokenize__ we'll want
+            # to tokenize all operands.
+            # Note how this differs to the implementation of
+            # Expr.deterministic_token
             self._determ_token = _tokenize_deterministic(self.operands)
         return self._determ_token
 
@@ -496,6 +500,8 @@ class Expr:
     @property
     def deterministic_token(self):
         if not self._determ_token:
+            # Just tokenize self to fall back on __dask_tokenize__
+            # Note how this differs to the implementation of __dask_tokenize__
             self._determ_token = _tokenize_deterministic(self)
         return self._determ_token
 

--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -141,7 +141,7 @@ class Expr:
             # to tokenize all operands.
             # Note how this differs to the implementation of
             # Expr.deterministic_token
-            self._determ_token = _tokenize_deterministic(self.operands)
+            self._determ_token = _tokenize_deterministic(type(self), *self.operands)
         return self._determ_token
 
     @staticmethod
@@ -1081,6 +1081,11 @@ class _ExprSequence(Expr):
         for op in self.operands:
             all_keys.append(op.__dask_keys__())
         return all_keys
+
+    def __repr__(self):
+        return "ExprSequence(" + ", ".join(map(repr, self.operands)) + ")"
+
+    __str__ = __repr__
 
     def finalize_compute(self):
         return _ExprSequence(

--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -502,7 +502,7 @@ class Expr:
         if not self._determ_token:
             # Just tokenize self to fall back on __dask_tokenize__
             # Note how this differs to the implementation of __dask_tokenize__
-            self._determ_token = _tokenize_deterministic(self)
+            self._determ_token = self.__dask_tokenize__()
         return self._determ_token
 
     @functools.cached_property

--- a/dask/array/_array_expr/_blockwise.py
+++ b/dask/array/_array_expr/_blockwise.py
@@ -116,8 +116,7 @@ class Blockwise(ArrayExpr):
     def dtype(self):
         return self.operand("dtype")
 
-    @property
-    def deterministic_token(self):
+    def __dask_tokenize__(self):
         if not self._determ_token:
             # TODO: Is there an actual need to overwrite this?
             self._determ_token = _tokenize_deterministic(

--- a/dask/array/_array_expr/_expr.py
+++ b/dask/array/_array_expr/_expr.py
@@ -104,9 +104,6 @@ class ArrayExpr(Expr):
 
         return unwrap(key_refs)
 
-    def __dask_tokenize__(self):
-        return self._name
-
     def __hash__(self):
         return hash(self._name)
 

--- a/dask/array/_array_expr/_reductions.py
+++ b/dask/array/_array_expr/_reductions.py
@@ -276,8 +276,7 @@ class PartialReduce(ArrayExpr):
         "reduced_meta": None,
     }
 
-    @property
-    def deterministic_token(self):
+    def __dask_tokenize__(self):
         if not self._determ_token:
             # TODO: Is there an actual need to overwrite this?
             self._determ_token = _tokenize_deterministic(

--- a/dask/dataframe/dask_expr/_expr.py
+++ b/dask/dataframe/dask_expr/_expr.py
@@ -49,7 +49,6 @@ from dask.dataframe.utils import (
     raise_on_meta_error,
     valid_divisions,
 )
-from dask.tokenize import normalize_token
 from dask.typing import Key, no_default
 from dask.utils import (
     M,
@@ -3110,11 +3109,6 @@ class DelayedsExpr(Expr):
     @property
     def ndim(self):
         return 0
-
-
-@normalize_token.register(Expr)
-def normalize_expression(expr):
-    return expr._name
 
 
 def is_broadcastable(dfs, s):

--- a/dask/dataframe/dask_expr/io/parquet.py
+++ b/dask/dataframe/dask_expr/io/parquet.py
@@ -776,8 +776,7 @@ class ReadParquet(PartitionsFiltered, BlockwiseIO):
     def _funcname(self):
         return "read_parquet"
 
-    @property
-    def deterministic_token(self):
+    def __dask_tokenize__(self):
         if not self._determ_token:
             # TODO: Is there an actual need to overwrite this?
             self._determ_token = _tokenize_deterministic(

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -19,7 +19,6 @@ import dask.bag as db
 from dask.base import (
     DaskMethodsMixin,
     clone_key,
-    collections_to_expr,
     compute,
     compute_as_if_collection,
     get_collection_names,
@@ -929,16 +928,6 @@ def test_num_workers_config(scheduler):
     workers = {i.worker_id for i in prof.results}
 
     assert len(workers) == num_workers
-
-
-def test_optimizations_ctd():
-    pytest.importorskip("numpy")
-    da = pytest.importorskip("dask.array")
-    x = da.arange(2, chunks=1)[:1]
-    dsk1 = collections_to_expr([x])
-    with dask.config.set({"optimizations": [lambda dsk, keys: dsk]}):
-        dsk2 = collections_to_expr([x])
-    assert dsk1 == dsk2
 
 
 def test_clone_key():

--- a/dask/tests/test_expr.py
+++ b/dask/tests/test_expr.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import pytest
 
-from dask._expr import Expr
+from dask._expr import Expr, HLGExpr
+from dask.tokenize import tokenize
 
 
 class MyExpr(Expr):
@@ -28,3 +29,20 @@ def test_setattr2():
     assert e.bar == 3
     with pytest.raises(AttributeError):
         e.baz = 4
+
+
+def test_hlgexpr():
+    # Ensure tokens are different for different high-level graphs The current
+    # implementation actually ensures that no HLGExpr are tokenizing equally.
+    # Technically, we do not need such a strong guarantee. but tokenizing a full
+    # HLG reliably is tricky and we do not require the reproducibility for
+    # HLGExpr since they do not undergo the same kind of optimization as the
+    # rest of the graph.
+    from dask.highlevelgraph import HighLevelGraph
+
+    dsk = HighLevelGraph.from_collections("x", {"foo": None})
+    dsk2 = HighLevelGraph.from_collections("x", {"bar": None})
+    dsk3 = HighLevelGraph.from_collections("y", {"foo": None})
+    assert tokenize(HLGExpr(dsk)) != tokenize(HLGExpr(dsk2))
+    assert tokenize(HLGExpr(dsk)) != tokenize(HLGExpr(dsk3))
+    assert tokenize(HLGExpr(dsk2)) != tokenize(HLGExpr(dsk3))

--- a/dask/tests/test_expr.py
+++ b/dask/tests/test_expr.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import pickle
-
 import pytest
 
-from dask._expr import Expr, HLGExpr
-from dask.tokenize import tokenize
+from dask._expr import Expr
 
 
 class MyExpr(Expr):
@@ -31,24 +28,3 @@ def test_setattr2():
     assert e.bar == 3
     with pytest.raises(AttributeError):
         e.baz = 4
-
-
-def test_hlgexpr():
-    # Ensure tokens are different for different high-level graphs The current
-    # implementation actually ensures that no HLGExpr are tokenizing equally.
-    # Technically, we do not need such a strong guarantee. but tokenizing a full
-    # HLG reliably is tricky and we do not require the reproducibility for
-    # HLGExpr since they do not undergo the same kind of optimization as the
-    # rest of the graph.
-    from dask.highlevelgraph import HighLevelGraph
-
-    dsk = HighLevelGraph.from_collections("x", {"foo": None})
-    dsk2 = HighLevelGraph.from_collections("x", {"bar": None})
-    dsk3 = HighLevelGraph.from_collections("y", {"foo": None})
-    assert tokenize(HLGExpr(dsk)) != tokenize(HLGExpr(dsk2))
-    assert tokenize(HLGExpr(dsk)) != tokenize(HLGExpr(dsk3))
-    assert tokenize(HLGExpr(dsk2)) != tokenize(HLGExpr(dsk3))
-
-    # Roundtrip preserves the tokens
-    for expr in [HLGExpr(dsk), HLGExpr(dsk2), HLGExpr(dsk3)]:
-        assert tokenize(pickle.loads(pickle.dumps(expr))) == tokenize(expr)

--- a/dask/tests/test_expr.py
+++ b/dask/tests/test_expr.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pickle
+
 import pytest
 
 from dask._expr import Expr, HLGExpr
@@ -46,3 +48,7 @@ def test_hlgexpr():
     assert tokenize(HLGExpr(dsk)) != tokenize(HLGExpr(dsk2))
     assert tokenize(HLGExpr(dsk)) != tokenize(HLGExpr(dsk3))
     assert tokenize(HLGExpr(dsk2)) != tokenize(HLGExpr(dsk3))
+
+    # Roundtrip preserves the tokens
+    for expr in [HLGExpr(dsk), HLGExpr(dsk2), HLGExpr(dsk3)]:
+        assert tokenize(pickle.loads(pickle.dumps(expr))) == tokenize(expr)

--- a/dask/tests/test_hlgexpr.py
+++ b/dask/tests/test_hlgexpr.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pickle
+
+from dask._expr import HLGExpr
+from dask.tokenize import tokenize
+
+
+def test_tokenize():
+    # Ensure tokens are different for different high-level graphs The current
+    # implementation actually ensures that no HLGExpr are tokenizing equally.
+    # Technically, we do not need such a strong guarantee. but tokenizing a full
+    # HLG reliably is tricky and we do not require the reproducibility for
+    # HLGExpr since they do not undergo the same kind of optimization as the
+    # rest of the graph.
+    from dask.highlevelgraph import HighLevelGraph
+
+    dsk = HighLevelGraph.from_collections("x", {"foo": None})
+    dsk2 = HighLevelGraph.from_collections("x", {"bar": None})
+    dsk3 = HighLevelGraph.from_collections("y", {"foo": None})
+    assert tokenize(HLGExpr(dsk)) != tokenize(HLGExpr(dsk2))
+    assert tokenize(HLGExpr(dsk)) != tokenize(HLGExpr(dsk3))
+    assert tokenize(HLGExpr(dsk2)) != tokenize(HLGExpr(dsk3))
+
+    # Roundtrip preserves the tokens
+    for expr in [HLGExpr(dsk), HLGExpr(dsk2), HLGExpr(dsk3)]:
+        assert tokenize(pickle.loads(pickle.dumps(expr))) == tokenize(expr)


### PR DESCRIPTION
Closes https://github.com/pydata/xarray/issues/10171

I've seen these kind of failures during development. I don't fully understand why dask CI was fine with the current code but it might've been related to serialization. This fixes the xarray issue