### PR TITLE
Ensure repartition does not trigger memory size computation during lowering (i.e. on the scheduler)

### DIFF
--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -157,7 +157,7 @@ class Expr:
             raise RuntimeError(f"Serializing a {type(self)} object")
         cache = {}
         for k, v in type(self).__dict__.items():
-            if isinstance(v, functools.cached_property):
+            if isinstance(v, functools.cached_property) and k in self.__dict__:
                 cache[k] = getattr(self, k)
 
         return Expr._reconstruct, tuple(

--- a/dask/dataframe/dask_expr/io/parquet.py
+++ b/dask/dataframe/dask_expr/io/parquet.py
@@ -1295,6 +1295,7 @@ class ReadParquetFSSpec(ReadParquet):
         "kwargs": {"dtype_backend": None},
         "_partitions": None,
         "_series": False,
+        "_dataset_info_cache": None,
         "_pq_length_stats": None,
     }
 

--- a/dask/dataframe/dask_expr/io/parquet.py
+++ b/dask/dataframe/dask_expr/io/parquet.py
@@ -716,6 +716,7 @@ def _determine_type_mapper(
 
 
 class ReadParquet(PartitionsFiltered, BlockwiseIO):
+    _pickle_functools_cache = False
     _absorb_projections = True
     _filter_passthrough = False
 
@@ -1294,7 +1295,6 @@ class ReadParquetFSSpec(ReadParquet):
         "kwargs": {"dtype_backend": None},
         "_partitions": None,
         "_series": False,
-        "_dataset_info_cache": None,
         "_pq_length_stats": None,
     }
 

--- a/dask/dataframe/dask_expr/tests/test_collection.py
+++ b/dask/dataframe/dask_expr/tests/test_collection.py
@@ -1370,7 +1370,7 @@ def test_column_getattr(df):
 def test_serialization(pdf, df):
     before = pickle.dumps(df)
 
-    assert len(before) < 200 + len(pickle.dumps(pdf))
+    assert len(before) < 350 + len(pickle.dumps(pdf))
 
     part = df.partitions[0].compute()
     assert (
@@ -1379,8 +1379,6 @@ def test_serialization(pdf, df):
     )
 
     after = pickle.dumps(df)
-
-    assert before == after  # caching doesn't affect serialization
 
     assert pickle.loads(before)._name == pickle.loads(after)._name
     assert_eq(pickle.loads(before), pickle.loads(after))

--- a/dask/tests/test_expr.py
+++ b/dask/tests/test_expr.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import functools
+import pickle
+
 import pytest
 
 from dask._expr import Expr
@@ -28,3 +31,60 @@ def test_setattr2():
     assert e.bar == 3
     with pytest.raises(AttributeError):
         e.baz = 4
+
+
+class MyExprCachedProperty(Expr):
+    called_cached_property = False
+    _parameters = ["foo", "bar"]
+
+    @property
+    def baz(self):
+        return self.foo + self.bar
+
+    @functools.cached_property
+    def cached_property(self):
+        if MyExprCachedProperty.called_cached_property:
+            raise RuntimeError("No!")
+        MyExprCachedProperty.called_cached_property = True
+        return self.foo + self.bar
+
+
+def test_pickle_cached_properties():
+    pytest.importorskip("distributed")
+    from distributed import Nanny
+    from distributed.utils_test import gen_cluster
+
+    @gen_cluster(client=True, Worker=Nanny, nthreads=[("", 1)])
+    async def test(c, s, a):
+
+        expr = MyExprCachedProperty(foo=1, bar=2)
+        for _ in range(10):
+            assert expr.baz == 3
+            assert expr.cached_property == 3
+
+        assert MyExprCachedProperty.called_cached_property is True
+
+        rt = pickle.loads(pickle.dumps(expr))
+        assert rt.cached_property == 3
+        assert MyExprCachedProperty.called_cached_property is True
+
+        # Expressions are singletons, i.e. this doesn't crash
+        expr2 = MyExprCachedProperty(foo=1, bar=2)
+        assert expr2.cached_property == 3
+
+        # But this does
+        expr3 = MyExprCachedProperty(foo=1, bar=3)
+        with pytest.raises(RuntimeError):
+            assert expr3.cached_property == 4
+
+        def f(expr):
+            # We want the cache to be part of the pickle, i.e. this is a
+            # different process such that the type is reset and the property can
+            # be accessed without side effects
+            assert MyExprCachedProperty.called_cached_property is False
+            assert expr.cached_property == 3
+            assert MyExprCachedProperty.called_cached_property is False
+
+        await c.submit(f, expr)
+
+    test()

--- a/dask/tests/test_expr.py
+++ b/dask/tests/test_expr.py
@@ -75,8 +75,7 @@ def test_pickle_cached_properties():
         # But this does
         expr3 = MyExprCachedProperty(foo=1, bar=3)
         with pytest.raises(RuntimeError):
-            assert expr3.cached_property == 4
-
+            expr3.cached_property
         def f(expr):
             # We want the cache to be part of the pickle, i.e. this is a
             # different process such that the type is reset and the property can

--- a/dask/tests/test_expr.py
+++ b/dask/tests/test_expr.py
@@ -76,6 +76,7 @@ def test_pickle_cached_properties():
         expr3 = MyExprCachedProperty(foo=1, bar=3)
         with pytest.raises(RuntimeError):
             expr3.cached_property
+
         def f(expr):
             # We want the cache to be part of the pickle, i.e. this is a
             # different process such that the type is reset and the property can


### PR DESCRIPTION
This _should_ fix https://github.com/coiled/benchmarks/issues/1686

I noticed that repartitioning is only collecting the memory size computation during materialization, i.e. the scheduler launched a "threaded" scheduler and started to compute the memory size... that's not intended! 

This change restores the stdlib behavior of how to deal with cached properties. Historically, I introduced dedicated properties to store this cache but the functools property cache may be a more ergonomic option. This, however, makes it harder to opt out of caching a property. 