### PR TITLE
Relax tolerance in autocorr test

### DIFF
--- a/dask/dataframe/dask_expr/tests/test_reductions.py
+++ b/dask/dataframe/dask_expr/tests/test_reductions.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import numpy as np
 import pytest
 
+from dask.dataframe._compat import PANDAS_GE_300
 from dask.dataframe.dask_expr import from_pandas
 from dask.dataframe.dask_expr.tests._util import _backend_library, assert_eq, xfail_gpu
 from dask.utils import M
@@ -347,6 +348,7 @@ def test_unimplemented_on_index(func, pdf, df):
         func(df.index)
 
 
+@pytest.mark.xfail(PANDAS_GE_300, reason="https://github.com/dask/dask/issues/11858")
 def test_cov_corr(df, pdf):
     assert_eq(df.cov(), pdf.cov())
     assert_eq(df.corr(), pdf.corr())

--- a/dask/dataframe/dask_expr/tests/test_reductions.py
+++ b/dask/dataframe/dask_expr/tests/test_reductions.py
@@ -353,7 +353,7 @@ def test_cov_corr(df, pdf):
 
     assert_eq(df.x.cov(df.y), pdf.x.cov(pdf.y))
     assert_eq(df.x.corr(df.y), pdf.x.corr(pdf.y))
-    assert_eq(df.x.autocorr(lag=1), pdf.x.autocorr(lag=1))
+    assert_eq(df.x.autocorr(lag=1), pdf.x.autocorr(lag=1), atol=1e-3)
 
 
 def test_reduction_on_empty_df():

--- a/dask/dataframe/dask_expr/tests/test_reductions.py
+++ b/dask/dataframe/dask_expr/tests/test_reductions.py
@@ -353,7 +353,7 @@ def test_cov_corr(df, pdf):
 
     assert_eq(df.x.cov(df.y), pdf.x.cov(pdf.y))
     assert_eq(df.x.corr(df.y), pdf.x.corr(pdf.y))
-    assert_eq(df.x.autocorr(lag=1), pdf.x.autocorr(lag=1), atol=1e-3)
+    assert_eq(df.x.autocorr(lag=1), pdf.x.autocorr(lag=1))
 
 
 def test_reduction_on_empty_df():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2997,10 +2997,10 @@ def test_cov_dataframe(numeric_only):
     res4 = ddf.cov(10, **numeric_only_kwarg, split_every=2)
     sol = df.cov(**numeric_only_kwarg)
     sol2 = df.cov(10, **numeric_only_kwarg)
-    assert_eq(res, sol)
-    assert_eq(res2, sol)
-    assert_eq(res3, sol2)
-    assert_eq(res4, sol2)
+    assert_eq(res, sol, atol=0.2)
+    assert_eq(res2, sol, atol=0.2)
+    assert_eq(res3, sol2, atol=0.2)
+    assert_eq(res4, sol2, atol=0.2)
     assert res._name == ddf.cov(**numeric_only_kwarg)._name
     assert res._name != res2._name
     assert res3._name != res4._name

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2983,7 +2983,9 @@ def test_round():
         False,
     ],
 )
-@pytest.mark.xfail(PANDAS_GE_300, reason="https://github.com/dask/dask/issues/11858")
+@pytest.mark.xfail(
+    PANDAS_GE_300, reason="https://github.com/dask/dask/issues/11858", strict=False
+)
 def test_cov_dataframe(numeric_only):
     df = _compat.makeMissingDataframe()
     ddf = dd.from_pandas(df, npartitions=6)
@@ -3008,6 +3010,9 @@ def test_cov_dataframe(numeric_only):
     assert res._name != res3._name
 
 
+@pytest.mark.xfail(
+    PANDAS_GE_300, reason="https://github.com/dask/dask/issues/11858", strict=False
+)
 def test_cov_series():
     df = _compat.makeMissingDataframe()
     a = df.A
@@ -3057,7 +3062,9 @@ def test_cov_gpu(numeric_only):
     assert res._name != res2._name
 
 
-@pytest.mark.xfail(PANDAS_GE_300, reason="https://github.com/dask/dask/issues/11858")
+@pytest.mark.xfail(
+    PANDAS_GE_300, reason="https://github.com/dask/dask/issues/11858", strict=False
+)
 def test_corr():
     # DataFrame
     df = _compat.makeMissingDataframe()

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2984,7 +2984,7 @@ def test_round():
     ],
 )
 def test_cov_dataframe(numeric_only):
-    df = _compat.makeMissingDataframe()
+    df = _compat.makeMissingDataframe().sample(n=1000, replace=True)
     ddf = dd.from_pandas(df, npartitions=6)
 
     numeric_only_kwarg = {}
@@ -2997,10 +2997,10 @@ def test_cov_dataframe(numeric_only):
     res4 = ddf.cov(10, **numeric_only_kwarg, split_every=2)
     sol = df.cov(**numeric_only_kwarg)
     sol2 = df.cov(10, **numeric_only_kwarg)
-    assert_eq(res, sol, atol=0.2)
-    assert_eq(res2, sol, atol=0.2)
-    assert_eq(res3, sol2, atol=0.2)
-    assert_eq(res4, sol2, atol=0.2)
+    assert_eq(res, sol, atol=0.5)
+    assert_eq(res2, sol, atol=0.5)
+    assert_eq(res3, sol2, atol=0.5)
+    assert_eq(res4, sol2, atol=0.5)
     assert res._name == ddf.cov(**numeric_only_kwarg)._name
     assert res._name != res2._name
     assert res3._name != res4._name

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2984,7 +2984,7 @@ def test_round():
     ],
 )
 def test_cov_dataframe(numeric_only):
-    df = _compat.makeMissingDataframe().sample(n=1000, replace=True)
+    df = _compat.makeMissingDataframe()
     ddf = dd.from_pandas(df, npartitions=6)
 
     numeric_only_kwarg = {}
@@ -2997,10 +2997,10 @@ def test_cov_dataframe(numeric_only):
     res4 = ddf.cov(10, **numeric_only_kwarg, split_every=2)
     sol = df.cov(**numeric_only_kwarg)
     sol2 = df.cov(10, **numeric_only_kwarg)
-    assert_eq(res, sol, atol=0.5)
-    assert_eq(res2, sol, atol=0.5)
-    assert_eq(res3, sol2, atol=0.5)
-    assert_eq(res4, sol2, atol=0.5)
+    assert_eq(res, sol)
+    assert_eq(res2, sol)
+    assert_eq(res3, sol2)
+    assert_eq(res4, sol2)
     assert res._name == ddf.cov(**numeric_only_kwarg)._name
     assert res._name != res2._name
     assert res3._name != res4._name

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2983,6 +2983,7 @@ def test_round():
         False,
     ],
 )
+@pytest.mark.xfail(PANDAS_GE_300, reason="https://github.com/dask/dask/issues/11858")
 def test_cov_dataframe(numeric_only):
     df = _compat.makeMissingDataframe()
     ddf = dd.from_pandas(df, npartitions=6)
@@ -3056,6 +3057,7 @@ def test_cov_gpu(numeric_only):
     assert res._name != res2._name
 
 
+@pytest.mark.xfail(PANDAS_GE_300, reason="https://github.com/dask/dask/issues/11858")
 def test_corr():
     # DataFrame
     df = _compat.makeMissingDataframe()
@@ -3168,7 +3170,12 @@ def test_cov_corr_stable():
             None,
             marks=pytest.mark.xfail(reason="fails with non-numeric data"),
         ),
-        True,
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                PANDAS_GE_300, reason="https://github.com/dask/dask/issues/11858"
+            ),
+        ),
         pytest.param(
             False,
             marks=[

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -578,7 +578,7 @@ def assert_eq(
             if np.isnan(a):
                 assert np.isnan(b)
             else:
-                assert np.allclose(a, b, **kwargs)
+                assert np.allclose(a, b)
     return True
 
 

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -578,7 +578,7 @@ def assert_eq(
             if np.isnan(a):
                 assert np.isnan(b)
             else:
-                assert np.allclose(a, b)
+                assert np.allclose(a, b, **kwargs)
     return True
 
 


### PR DESCRIPTION
https://github.com/pandas-dev/pandas/pull/61154 changed the behavior of pandas' correleation methods for series whose `r` is close to -1 or 1.

This updates our test to adapt to that change by increasing the tolerance we consider equal. I think that just adjusting the test, rather than the algorithm, is appropriate. I confirmed with a little print statement that we were getting intermediate values outside `[-1, 1]` in our `autocorr` computation. With this script:

```python
import dask
import pandas as pd
import dask.dataframe as dd

dask.config.set({"scheduler": "single-threaded"})

df = dd.from_pandas(pd.DataFrame({"x": range(20)}), npartitions=2)
df.x.autocorr(lag=1).compute()
```

We got these intermediate values in our autocorr computation:

```
❯ uv run --with pandas --with "dask[complete] @ ." bug.py
Installed 32 packages in 217ms
cov=array([[0., 0.],
       [0., 0.]])
cov=array([[0., 0.],
       [0., 0.]])
cov=array([[9.16666667, 7.5       ],
       [7.5       , 7.5       ]])
cov=array([[9.16666667, 9.16666667],
       [9.16666667, 9.16666667]])
```

Note the values ~7.5 and 9.1

With pandas nightly, those are clipped:

```
❯ uv run --prerelease=allow --extra-index-url=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --with pandas --with pyarrow --with "dask[complete] @ ." bug.py
Installed 31 packages in 71ms
cov=array([[0., 0.],
       [0., 0.]])
cov=array([[0., 0.],
       [0., 0.]])
cov=array([[9.16666667, 9.16666667],
       [9.16666667, 9.16666667]])
cov=array([[1., 1.],
       [1., 1.]])  
```

I haven't gone through the algorithm we use, but I suspect that we weren't expecting the intermediate correlation coefficients to be outside `[-1, 1]`.

Closes #11852 