### PR TITLE
Ensure HLGs are using dependencies properly in optimization

### DIFF
--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -975,7 +975,7 @@ class HLGExpr(Expr):
         # see `dask.blockwise.(_fuse_annotations|_can_fuse_annotations)`
         dsk = self._optimized_dsk()
         if isinstance(dsk, dict):
-            dsk = self.dsk
+            dsk = self.hlg
         annotations_by_type: defaultdict[str, dict[Key, object]] = defaultdict(dict)
         for layer in dsk.layers.values():
             if layer.annotations:

--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -1236,7 +1236,7 @@ class HLGFinalizeCompute(HLGExpr):
         return f"finalize-{self.deterministic_token}"
 
     def __dask_graph__(self):
-        # The baseclass __dask_graph__ will not just materialie this layer but
+        # The baseclass __dask_graph__ will not just materialize this layer but
         # also that of its dependencies, i.e. it will render the finalized and
         # the non-finalized graph and combine them. We only want the finalized
         # so we're overriding this.

--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -1093,6 +1093,10 @@ class _HLGExprSequence(Expr):
 
     _layer = __dask_graph__
 
+    def _simplify_down(self):
+        if len(self.operands) == 1:
+            return self.operands[0]
+
     def __dask_annotations__(self):
         annotations_by_type = {}
         for hlg in self.operands:

--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -1113,7 +1113,6 @@ class _HLGExprSequence(Expr):
                 all_keys.extend(op.__dask_keys__())
             else:
                 all_keys.append(op.__dask_keys__())
-        assert all_keys is not None
         return all_keys
 
 

--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -1230,6 +1230,16 @@ class HLGFinalizeCompute(HLGExpr):
     def _name(self):
         return f"finalize-{self.deterministic_token}"
 
+    def __dask_graph__(self):
+        # The baseclass __dask_graph__ will not just materialie this layer but
+        # also that of its dependencies, i.e. it will render the finalized and
+        # the non-finalized graph and combine them. We only want the finalized
+        # so we're overriding this.
+        # This is an artifact generated since the wrapped expression is
+        # identified automatically as a dependency but HLG expressions are not
+        # working in this layered way.
+        return self._layer()
+
     @property
     def hlg(self):
         expr = self.operand("dsk")

--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -1006,10 +1006,8 @@ class HLGExpr(Expr):
     def _optimized_dsk(self):
         if self._cached_optimized:
             return self._cached_optimized
-        keys = self.output_keys
         optimizer = self.low_level_optimizer
-        if keys is None and optimizer is not None:
-            keys = self.__dask_keys__()
+        keys = self.__dask_keys__()
         dsk = self.hlg
         if (optimizer := self.low_level_optimizer) is not None:
             dsk = optimizer(dsk, keys)

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -819,7 +819,10 @@ def test_optimize_globals():
     x = da.ones(10, chunks=(5,))
 
     def optimize_double(dsk, keys):
-        return {k: (mul, 2, v) for k, v in dsk.items()}
+        return {
+            k: (mul, 2, v) if not key_split(k).startswith("finalize") else v
+            for k, v in dsk.items()
+        }
 
     from dask.array.utils import assert_eq
 

--- a/dask/tests/test_expr.py
+++ b/dask/tests/test_expr.py
@@ -60,6 +60,7 @@ class MyExprCachedProperty(Expr):
         return self.foo + self.bar
 
 
+@pytest.mark.slow()
 def test_pickle_cached_properties():
     pytest.importorskip("distributed")
     from distributed import Nanny


### PR DESCRIPTION
There was a bug in the earlier code that would not actually optimize HLGs jointly under some circumstances.

The fix I am proposing here is to perform the HLG merging during the Expression optimization step. From all I can tell this still does not materialize the layers sooner than they did before (there are still cases, e.g. if materialization is triggered to compute `__dask_keys__` but we've done this before already) 

Further, the `FinalizeComputeHLG` class no longer assembles the low level graph but instead the HighlevelGraph assembly is a separate step and this step is overriden in the finalizer. The way, the sequence can properly bubble down the finalize without compromising joint optimization

Actually closes https://github.com/dask/dask/issues/8380

cc @djhoese