### PR TITLE
Update link to Quansight in community doc

### DIFF
--- a/docs/source/support.rst
+++ b/docs/source/support.rst
@@ -99,4 +99,4 @@ following organizations (listed in alphabetical order):
 
 -   `Anaconda <https://www.anaconda.com/products/professional-services>`_
 -  `Coiled <https://coiled.io?utm_source=dask-docs&utm_medium=support>`_
--   `Quansight <https://www.quansight.com/open-source-support>`_
+-   `Quansight <https://www.quansight.com/>`_


### PR DESCRIPTION
The Quansight webpage linked there doesn't exist anymore, so a tiny change to link to the homepage instead. :)