### PR TITLE
Ensure default dask scheduler only compute what's needed

### DIFF
--- a/dask/local.py
+++ b/dask/local.py
@@ -110,15 +110,16 @@ See the function ``inline_functions`` for more information.
 from __future__ import annotations
 
 import os
+from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from concurrent.futures import Executor, Future
 from functools import partial
 from queue import Empty, Queue
 
 from dask import config
-from dask._task_spec import DataNode, DependenciesMapping, convert_legacy_graph
+from dask._task_spec import DataNode, convert_legacy_graph
 from dask.callbacks import local_callbacks, unpack_callbacks
-from dask.core import flatten, get_dependencies, reverse_dict
+from dask.core import flatten, get_dependencies
 from dask.order import order
 from dask.typing import Key
 
@@ -140,7 +141,7 @@ else:
         return q.get()
 
 
-def start_state_from_dask(dsk, cache=None, sortkey=None):
+def start_state_from_dask(dsk, cache=None, sortkey=None, keys=None):
     """Start state from a dask
 
     Examples
@@ -166,35 +167,54 @@ def start_state_from_dask(dsk, cache=None, sortkey=None):
         cache = config.get("cache", None)
     if cache is None:
         cache = dict()
-
+    if keys is None:
+        keys = list(set(dsk) - set(cache))
     dsk = convert_legacy_graph(dsk, all_keys=set(dsk) | set(cache))
-    data_keys = set()
-    for k, v in dsk.items():
-        if isinstance(v, DataNode):
-            cache[k] = v()
-            data_keys.add(k)
+    stack = list(keys)
+    dependencies = defaultdict(set)
+    dependents = defaultdict(set)
+    waiting = defaultdict(set)
+    waiting_data = defaultdict(set)
+    ready_set = set()
 
-    dsk2 = dsk.copy()
-    dsk2.update(cache)
+    while stack:
+        key = stack.pop()
+        dependents[key]
+        waiting_data[key]
+        task = dsk.get(key, None)
+        if task is None:
+            continue
+        elif isinstance(task, DataNode):
+            cache[key] = task()
+            dependencies[key]
+            for d in dependents[key]:
+                if d in waiting:
+                    waiting[d].discard(key)
+                    if not waiting[d]:
+                        del waiting[d]
+                        ready_set.add(d)
+                else:
+                    ready_set.add(d)
+        else:
+            dependencies[key] = set(task.dependencies)
+            _wait = task.dependencies - set(cache)
+            if not _wait:
+                ready_set.add(key)
+            else:
+                waiting[key] = set(_wait)
+            for dep in task.dependencies:
+                dependents[dep].add(key)
+                if dep not in waiting:
+                    stack.append(dep)
+                    waiting_data[dep].add(key)
 
-    dependencies = DependenciesMapping(dsk)
-    waiting = {k: set(v) for k, v in dependencies.items() if k not in data_keys}
-
-    dependents = reverse_dict(dependencies)
-    for a in cache:
-        for b in dependents.get(a, ()):
-            waiting[b].remove(a)
-    waiting_data = {k: v.copy() for k, v in dependents.items() if v}
-
-    ready_set = {k for k, v in waiting.items() if not v}
     ready = sorted(ready_set, key=sortkey, reverse=True)
-    waiting = {k: v for k, v in waiting.items() if v}
 
     state = {
-        "dependencies": dependencies,
-        "dependents": dependents,
-        "waiting": waiting,
-        "waiting_data": waiting_data,
+        "dependencies": dict(dependencies),
+        "dependents": dict(dependents),
+        "waiting": dict(waiting),
+        "waiting_data": dict(waiting_data),
         "cache": cache,
         "ready": ready,
         "running": set(),
@@ -444,7 +464,9 @@ def get_async(
 
             keyorder = order(dsk)
 
-            state = start_state_from_dask(dsk, cache=cache, sortkey=keyorder.get)
+            state = start_state_from_dask(
+                dsk, keys=results, cache=cache, sortkey=keyorder.get
+            )
 
             for _, start_state, _, _, _ in callbacks:
                 if start_state:
@@ -480,7 +502,7 @@ def get_async(
 
                     # Prep args to send
                     data = {
-                        dep: state["cache"][dep] for dep in get_dependencies(dsk, key)
+                        dep: state["cache"][dep] for dep in state["dependencies"][key]
                     }
                     args.append(
                         (

--- a/dask/tests/test_local.py
+++ b/dask/tests/test_local.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import dask
+from dask._task_spec import Task
 from dask.local import finish_task, get_sync, sortkey, start_state_from_dask
 from dask.order import order
 from dask.utils_test import GetFunctionTestMixin, add, inc
@@ -28,7 +29,7 @@ def test_start_state():
         "running": set(),
         "ready": ["z"],
         "waiting": {"w": {"z"}},
-        "waiting_data": {"x": {"z"}, "y": {"w"}, "z": {"w"}},
+        "waiting_data": {"w": set(), "x": {"z"}, "y": {"w"}, "z": {"w"}},
     }
     assert result == expected
 
@@ -87,7 +88,7 @@ def test_finish_task():
         "dependents": {"w": set(), "x": {"z"}, "y": {"w"}, "z": {"w"}},
         "ready": ["w"],
         "waiting": {},
-        "waiting_data": {"y": {"w"}, "z": {"w"}},
+        "waiting_data": {"w": set(), "y": {"w"}, "z": {"w"}},
     }
 
 
@@ -190,3 +191,25 @@ def test_complex_ordering():
     with Callback(pretask=track_order):
         get_sync(dsk, exp_order[-1])
     assert actual_order == exp_order
+
+
+def test_ensure_calculate_only_whats_needed():
+    counter = 0
+
+    def only_once():
+        nonlocal counter
+        if counter > 0:
+            raise RuntimeError("Should only be called once")
+        counter += 1
+        return 1
+
+    def add(x, y):
+        return x + y
+
+    tasks = [
+        Task("x1", only_once),
+        (t1 := Task("x2", only_once)),
+        Task("y", add, 1, t1.ref()),
+    ]
+    dsk = {t.key: t for t in tasks}
+    assert get_sync(dsk, "y") == 2


### PR DESCRIPTION
Looks like the default schedulers are not culling and therefore may compute unnecessary results if the provided dsk contains too many keys. That's not something that should actually happen in reality but it's also not great. 

I noticed this in https://github.com/dask/dask/pull/11859 because the code was producing malformed graphs but only a single test in the entire test suite tripped. The test was concerning some bag optimization and was only caught due to the particular way the test was written. This should be more robust.