### PR TITLE
Ensure dictionaries tokenize deterministically

### DIFF
--- a/dask/tests/test_tokenize.py
+++ b/dask/tests/test_tokenize.py
@@ -848,6 +848,7 @@ def test_nested_tokenize_seen():
 
 def test_tokenize_dict():
     # Insertion order is ignored. Keys can be an unsortable mix of types.
+    assert check_tokenize({"x": 1, 1: "x"}) == "ba2498a4c5583cc3ec540865185cdafd"
     assert check_tokenize({"x": 1, 1: "x"}) == check_tokenize({1: "x", "x": 1})
     assert check_tokenize({"x": 1, 1: "x"}) != check_tokenize({"x": 1, 2: "x"})
     assert check_tokenize({"x": 1, 1: "x"}) != check_tokenize({"x": 2, 1: "x"})

--- a/dask/tokenize.py
+++ b/dask/tokenize.py
@@ -120,7 +120,7 @@ def normalize_dict(d):
         _SEEN[id(d)] = len(_SEEN), d
         try:
             return "dict", _normalize_seq_func(
-                sorted(d.items(), key=lambda kv: hash(kv[0]))
+                sorted(d.items(), key=lambda kv: str(kv[0]))
             )
         finally:
             _SEEN.pop(id(d), None)


### PR DESCRIPTION
In https://github.com/dask/dask/pull/11373 I changed this sorting key to a hash to pick up a little speed. However, this broke determinism and at least for trivial data types like these, determinism would be nice. I don't think the additional speed from saved str comparison is truly worth is