### PR TITLE
Factor out singleton logic from base Expr class

### DIFF
--- a/dask/array/_array_expr/_expr.py
+++ b/dask/array/_array_expr/_expr.py
@@ -10,7 +10,7 @@ import numpy as np
 import toolz
 from tlz import accumulate
 
-from dask._expr import Expr, FinalizeCompute
+from dask._expr import FinalizeCompute, SingletonExpr
 from dask._task_spec import List, Task, TaskRef
 from dask.array.chunk import getitem
 from dask.array.core import T_IntOrNaN, common_blockdim, unknown_chunk_message
@@ -19,7 +19,7 @@ from dask.layers import ArrayBlockwiseDep
 from dask.utils import cached_cumsum
 
 
-class ArrayExpr(Expr):
+class ArrayExpr(SingletonExpr):
 
     def _operands_for_repr(self):
         return []

--- a/dask/dataframe/dask_expr/_expr.py
+++ b/dask/dataframe/dask_expr/_expr.py
@@ -64,7 +64,7 @@ from dask.utils import (
 optimize = core.optimize
 
 
-class Expr(core.Expr):
+class Expr(core.SingletonExpr):
     """Primary class for all Expressions
 
     This mostly includes Dask protocols and various Pandas-like method

--- a/dask/tests/test_expr.py
+++ b/dask/tests/test_expr.py
@@ -80,10 +80,6 @@ def test_pickle_cached_properties():
         assert rt.cached_property == 3
         assert MyExprCachedProperty.called_cached_property is True
 
-        # Expressions are singletons, i.e. this doesn't crash
-        expr2 = MyExprCachedProperty(foo=1, bar=2)
-        assert expr2.cached_property == 3
-
         # But this does
         expr3 = MyExprCachedProperty(foo=1, bar=3)
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
This ensures that only expressions that opt into it use the singleton mechanism. Particularly the HLG, LLG, sequence expressions are mere container/wrapper and do not benefit at all from this singleton approach.

So far, I've been dealing with this in a rather... inelegant way by setting the dask tokens for the HLG, LLG expressions, etc. to be their python ID.
Python IDs *can* be reused if the lifetime of objects do not overlap. I figured this is safe enough since expressions that go out of scope should also be cleared from the weakref dictionary. However, over the last week I've seen a couple of different cases that suspiciously look like "hash collisions" where certain expressions "remember" state that should've been released already. That causes all kinds of weird errors. I suspect that the weakref semantics are somehow breaking my assumptions about the ids and I've been seeing some object resurrections. Really hard to track down and debug.

Therefore, let's just opt in/out of this singleton thing explicitly. This was only introduced to have a way to propagate caches easily and isn't required for all types.