### PR TITLE
Avoid always parsing list inputs to `DataFrame.isin` as object type numpy arrays

### DIFF
--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -753,7 +753,6 @@ Expr={expr}"""
                 inferred_type = pd.api.types.infer_dtype(values, skipna=False)
                 object_like = {
                     "mixed-integer",
-                    "mixed-integer-float",
                     "decimal",
                     "categorical",
                     "time",

--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -751,7 +751,16 @@ Expr={expr}"""
             if not any(is_dask_collection(v) for v in values):
                 # Avoid always passing a numpy array of object dtype
                 inferred_type = pd.api.types.infer_dtype(values, skipna=False)
-                object_like = {"mixed-integer", "mixed-integer-float", "decimal", "categorical", "time", "period", "mixed", "unknown-array"}
+                object_like = {
+                    "mixed-integer",
+                    "mixed-integer-float",
+                    "decimal",
+                    "categorical",
+                    "time",
+                    "period",
+                    "mixed",
+                    "unknown-array",
+                }
                 if inferred_type in object_like:
                     values = np.fromiter(values, dtype=object, count=len(values))
                 else:


### PR DESCRIPTION
The values of an `isin` expression is always expressed as a `numpy.ndarray[object]` from a `list` input even if the inputs are of all homogeneous type (e.g. `[1, 2, 3]`). Over in `dask_cudf`, there is no native support for `object` types and would prefer avoiding re-inferring the types of these inputs. Additionally, the utility and performance of a `numpy.ndarray[object]` of homogeneous objects is less ideal than its statically typed counterpart (e.g. `int64`).

This PR adds type inference to `list` inputs before determining whether `object` is a necessary result type.


