### PR TITLE
Unskip pandas-dev cov/corr tests

### DIFF
--- a/dask/dataframe/dask_expr/tests/test_reductions.py
+++ b/dask/dataframe/dask_expr/tests/test_reductions.py
@@ -5,7 +5,6 @@ from datetime import datetime
 import numpy as np
 import pytest
 
-from dask.dataframe._compat import PANDAS_GE_300
 from dask.dataframe.dask_expr import from_pandas
 from dask.dataframe.dask_expr.tests._util import _backend_library, assert_eq, xfail_gpu
 from dask.utils import M
@@ -348,7 +347,6 @@ def test_unimplemented_on_index(func, pdf, df):
         func(df.index)
 
 
-@pytest.mark.xfail(PANDAS_GE_300, reason="https://github.com/dask/dask/issues/11858")
 def test_cov_corr(df, pdf):
     assert_eq(df.cov(), pdf.cov())
     assert_eq(df.corr(), pdf.corr())

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2983,9 +2983,6 @@ def test_round():
         False,
     ],
 )
-@pytest.mark.xfail(
-    PANDAS_GE_300, reason="https://github.com/dask/dask/issues/11858", strict=False
-)
 def test_cov_dataframe(numeric_only):
     df = _compat.makeMissingDataframe()
     ddf = dd.from_pandas(df, npartitions=6)
@@ -3010,9 +3007,6 @@ def test_cov_dataframe(numeric_only):
     assert res._name != res3._name
 
 
-@pytest.mark.xfail(
-    PANDAS_GE_300, reason="https://github.com/dask/dask/issues/11858", strict=False
-)
 def test_cov_series():
     df = _compat.makeMissingDataframe()
     a = df.A
@@ -3062,9 +3056,6 @@ def test_cov_gpu(numeric_only):
     assert res._name != res2._name
 
 
-@pytest.mark.xfail(
-    PANDAS_GE_300, reason="https://github.com/dask/dask/issues/11858", strict=False
-)
 def test_corr():
     # DataFrame
     df = _compat.makeMissingDataframe()
@@ -3179,9 +3170,6 @@ def test_cov_corr_stable():
         ),
         pytest.param(
             True,
-            marks=pytest.mark.xfail(
-                PANDAS_GE_300, reason="https://github.com/dask/dask/issues/11858"
-            ),
         ),
         pytest.param(
             False,


### PR DESCRIPTION
Last week, we added a couple skips for a regression on pandas `main`. Those have been fixed in https://github.com/pandas-dev/pandas/pull/61214, so we can remove the skips here.

Closes https://github.com/dask/dask/issues/11858
Closes https://github.com/dask/dask/issues/11870