### PR TITLE
migrate delayed unpack_collections

### DIFF
--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Literal
 import toolz
 
 import dask
-from dask._task_spec import Task
+from dask._task_spec import Task, convert_legacy_graph
 from dask.core import flatten
 from dask.tokenize import _tokenize_deterministic
 from dask.typing import Key
@@ -1319,7 +1319,7 @@ class ProhibitReuse(Expr):
         return obj
 
     def _layer(self) -> dict:
-        dsk = self.expr._layer()
+        dsk = convert_legacy_graph(self.expr._layer())
         suffix = self.suffix or uuid.uuid4().hex
 
         def _modify_key(k):

--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -1269,7 +1269,7 @@ class HLGFinalizeCompute(HLGExpr):
 
     @property
     def _name(self):
-        return f"finalize-{self.deterministic_token}"
+        return f"finalize-{super()._name}"
 
     def __dask_graph__(self):
         # The baseclass __dask_graph__ will not just materialize this layer but

--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -1302,7 +1302,7 @@ class HLGFinalizeCompute(HLGExpr):
         return [self._name]
 
 
-class HLGDistinctKeys(Expr):
+class ProhibitReuse(Expr):
     """
     An expression that guarantees that all keys are suffixes with a unique id.
     This can be used to break a common subexpression apart.
@@ -1337,7 +1337,7 @@ class HLGDistinctKeys(Expr):
         dsk2 = {
             new_key: Task(
                 new_key,
-                HLGDistinctKeys._identity,
+                ProhibitReuse._identity,
                 dsk.pop(old_key).substitute(subs),
             )
             for old_key, new_key in subs.items()

--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -1119,6 +1119,10 @@ def fuse_linear_task_spec(dsk, keys):
 def cull(
     dsk: dict[KeyType, GraphNode], keys: Iterable[KeyType]
 ) -> dict[KeyType, GraphNode]:
+    if not isinstance(keys, (list, set, tuple)):
+        raise TypeError(
+            f"Expected list, set or tuple for keys, got {type(keys).__name__}"
+        )
     work = set(keys)
     seen: set[KeyType] = set()
     dsk2 = {}

--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -673,6 +673,9 @@ class Task(GraphNode):
     def data_producer(self) -> bool:
         return self._data_producer
 
+    def has_subgraph(self) -> bool:
+        return self.func == _execute_subgraph
+
     def copy(self):
         return type(self)(
             self.key,

--- a/dask/array/_array_expr/_blockwise.py
+++ b/dask/array/_array_expr/_blockwise.py
@@ -17,8 +17,8 @@ from dask.array.core import (
     is_scalar_for_elemwise,
     normalize_arg,
 )
-from dask.blockwise import _blockwise_unpack_collections_task_spec
 from dask.blockwise import blockwise as core_blockwise
+from dask.delayed import unpack_collections
 from dask.layers import ArrayBlockwiseDep
 from dask.tokenize import _tokenize_deterministic
 from dask.utils import cached_property, funcname
@@ -147,7 +147,7 @@ class Blockwise(ArrayExpr):
         for arg, ind in arginds:
             if ind is None:
                 arg = normalize_arg(arg)
-                arg, collections = _blockwise_unpack_collections_task_spec(arg)
+                arg, collections = unpack_collections(arg)
                 dependencies.extend(collections)
             else:
                 if (
@@ -171,7 +171,7 @@ class Blockwise(ArrayExpr):
         kwargs2 = {}
         for k, v in self.kwargs.items():
             v = normalize_arg(v)
-            v, collections = _blockwise_unpack_collections_task_spec(v)
+            v, collections = unpack_collections(v)
             dependencies.extend(collections)
             kwargs2[k] = v
 

--- a/dask/array/blockwise.py
+++ b/dask/array/blockwise.py
@@ -8,8 +8,8 @@ import numpy as np
 import tlz as toolz
 
 from dask import base, utils
-from dask.blockwise import _blockwise_unpack_collections_task_spec
 from dask.blockwise import blockwise as core_blockwise
+from dask.delayed import unpack_collections
 from dask.highlevelgraph import HighLevelGraph
 from dask.layers import ArrayBlockwiseDep
 
@@ -215,7 +215,7 @@ def blockwise(
     for arg, ind in arginds:
         if ind is None:
             arg = normalize_arg(arg)
-            arg, collections = _blockwise_unpack_collections_task_spec(arg)
+            arg, collections = unpack_collections(arg)
 
             dependencies.extend(collections)
         else:
@@ -238,7 +238,7 @@ def blockwise(
     kwargs2 = {}
     for k, v in kwargs.items():
         v = normalize_arg(v)
-        v, collections = _blockwise_unpack_collections_task_spec(v)
+        v, collections = unpack_collections(v)
         dependencies.extend(collections)
         kwargs2[k] = v
 

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1003,20 +1003,21 @@ def histogram(a, bins=None, range=None, normed=False, weights=None, density=None
         assert range is not None
         assert bins is not None
         if len(deps) == 0:
-            return np.linspace(range[0], range[1], num=bins + 1)
-        linspace_name = "linspace-" + tokenize(bins_range)
-
-        linspace_dsk = {
-            (linspace_name, 0): Task((linspace_name, 0), _linspace, bins_range)
-        }
-        linspace_graph = HighLevelGraph.from_collections(
-            linspace_name, linspace_dsk, dependencies=deps
-        )
-        if is_dask_collection(bins):
-            chunks = ((np.nan,),)
+            bins = np.linspace(range[0], range[1], num=bins + 1)
         else:
-            chunks = ((bins + 1,),)
-        bins = Array(linspace_graph, linspace_name, chunks, dtype=float)
+            linspace_name = "linspace-" + tokenize(bins_range)
+
+            linspace_dsk = {
+                (linspace_name, 0): Task((linspace_name, 0), _linspace, bins_range)
+            }
+            linspace_graph = HighLevelGraph.from_collections(
+                linspace_name, linspace_dsk, dependencies=deps
+            )
+            if is_dask_collection(bins):
+                chunks = ((np.nan,),)
+            else:
+                chunks = ((bins + 1,),)
+            bins = Array(linspace_graph, linspace_name, chunks, dtype=float)
     else:
         if not isinstance(bins, (Array, np.ndarray)):
             bins = asarray(bins)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -5454,12 +5454,12 @@ def test_map_blocks_large_inputs_delayed():
     b = np.ones(1000000)
 
     c = a.map_blocks(add, b)
-    assert any(b is v for v in c.dask.values())
+    assert any(b is v() for v in c.dask.values() if isinstance(v, DataNode))
     assert repr(dict(c.dask)).count(repr(b)[:10]) == 1  # only one occurrence
 
     d = a.map_blocks(lambda x, y: x + y.sum(), y=b)
     assert_eq(d, d)
-    assert any(b is v for v in d.dask.values())
+    assert any(b is v() for v in d.dask.values() if isinstance(v, DataNode))
     assert repr(dict(c.dask)).count(repr(b)[:10]) == 1  # only one occurrence
 
 
@@ -5471,12 +5471,12 @@ def test_blockwise_large_inputs_delayed():
     b = np.ones(1000000)
 
     c = da.blockwise(func, "i", a, "i", b, None, dtype=a.dtype)
-    assert any(b is v for v in c.dask.values())
+    assert any(b is v() for v in c.dask.values() if isinstance(v, DataNode))
     assert repr(dict(c.dask)).count(repr(b)[:10]) == 1  # only one occurrence
     assert_eq(c, c)
 
     d = da.blockwise(lambda x, y: x, "i", a, "i", y=b, dtype=a.dtype)
-    assert any(b is v for v in d.dask.values())
+    assert any(b is v() for v in d.dask.values() if isinstance(v, DataNode))
     assert repr(dict(c.dask)).count(repr(b)[:10]) == 1  # only one occurrence
     assert_eq(d, d)
 

--- a/dask/array/tests/test_atop.py
+++ b/dask/array/tests/test_atop.py
@@ -808,9 +808,7 @@ def test_svd():
     y = x * 2
     u, s, v = da.linalg.svd(y)
     z = y + u
-    # FIXME: There is a key collision
-    # Deterministic https://github.com/dask/dask/issues/9888
-    assert_eq(z, z, check_graph=False)
+    assert_eq(z, z)
 
 
 def test_args_delayed():

--- a/dask/array/tests/test_atop.py
+++ b/dask/array/tests/test_atop.py
@@ -808,7 +808,9 @@ def test_svd():
     y = x * 2
     u, s, v = da.linalg.svd(y)
     z = y + u
-    assert_eq(z, z)
+    # FIXME: There is a key collision
+    # Deterministic https://github.com/dask/dask/issues/9888
+    assert_eq(z, z, check_graph=False)
 
 
 def test_args_delayed():

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -926,6 +926,9 @@ def test_histogram_delayed_bins(density, weighted):
     )
 
     assert bins_d is bins_d2
+    # The HLG that is assembled from the bins and the range triggers a sanity
+    # check because they contain duplicate keys and the HLG dependencies are not
+    # reflecting this properly. Graph is perfectly fine but the check fails.
     assert_eq(hist_d, hist, check_graph=False)
     assert_eq(bins_d2, bins, check_graph=False)
 

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -891,8 +891,8 @@ def test_histogram_delayed_range(density, weighted, non_delayed_i, delay_n_bins)
         weights=weights if weighted else None,
     )
 
-    assert_eq(hist_d, hist)
-    assert_eq(bins_d, bins)
+    assert_eq(hist_d, hist, check_graph=False)
+    assert_eq(bins_d, bins, check_graph=False)
 
 
 @pytest.mark.parametrize("density", [True, False])
@@ -926,8 +926,8 @@ def test_histogram_delayed_bins(density, weighted):
     )
 
     assert bins_d is bins_d2
-    assert_eq(hist_d, hist)
-    assert_eq(bins_d2, bins)
+    assert_eq(hist_d, hist, check_graph=False)
+    assert_eq(bins_d2, bins, check_graph=False)
 
 
 def test_histogram_delayed_n_bins_raises_with_density():

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -926,11 +926,8 @@ def test_histogram_delayed_bins(density, weighted):
     )
 
     assert bins_d is bins_d2
-    # The HLG that is assembled from the bins and the range triggers a sanity
-    # check because they contain duplicate keys and the HLG dependencies are not
-    # reflecting this properly. Graph is perfectly fine but the check fails.
-    assert_eq(hist_d, hist, check_graph=False)
-    assert_eq(bins_d2, bins, check_graph=False)
+    assert_eq(hist_d, hist)
+    assert_eq(bins_d2, bins)
 
 
 def test_histogram_delayed_n_bins_raises_with_density():

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -926,8 +926,11 @@ def test_histogram_delayed_bins(density, weighted):
     )
 
     assert bins_d is bins_d2
-    assert_eq(hist_d, hist)
-    assert_eq(bins_d2, bins)
+    # The HLG that is assembled from the bins and the range triggers a sanity
+    # check because they contain duplicate keys and the HLG dependencies are not
+    # reflecting this properly. Graph is perfectly fine but the check fails.
+    assert_eq(hist_d, hist, check_graph=False)
+    assert_eq(bins_d2, bins, check_graph=False)
 
 
 def test_histogram_delayed_n_bins_raises_with_density():

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -861,12 +861,12 @@ def test_histogram_bin_range_raises(bins, hist_range):
 
 @pytest.mark.parametrize("density", [True, False])
 @pytest.mark.parametrize("weighted", [True, False])
-@pytest.mark.parametrize("non_delayed_i", [None, 0, 1])
+@pytest.mark.parametrize("non_delayed_i", [None, 0])
 @pytest.mark.parametrize("delay_n_bins", [False, True])
 def test_histogram_delayed_range(density, weighted, non_delayed_i, delay_n_bins):
     n = 100
     v = np.random.default_rng().random(n)
-    vd = da.from_array(v, chunks=10)
+    vd = da.from_array(v, chunks=2)
 
     if weighted:
         weights = np.random.default_rng().random(n)
@@ -891,8 +891,8 @@ def test_histogram_delayed_range(density, weighted, non_delayed_i, delay_n_bins)
         weights=weights if weighted else None,
     )
 
-    assert_eq(hist_d, hist, check_graph=False)
-    assert_eq(bins_d, bins, check_graph=False)
+    assert_eq(hist_d, hist)
+    assert_eq(bins_d, bins)
 
 
 @pytest.mark.parametrize("density", [True, False])

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -10,6 +10,7 @@ import warnings
 import numpy as np
 from tlz import concat, frequencies
 
+from dask._task_spec import convert_legacy_graph
 from dask.array.numpy_compat import AxisError
 from dask.base import is_dask_collection, tokenize
 from dask.highlevelgraph import HighLevelGraph
@@ -213,8 +214,10 @@ def _check_dsk(dsk):
     key_collisions = set()
     # Allow redundant keys if the values are equivalent
     collisions = set()
+    all_keys = set(dsk)
+    layers = [convert_legacy_graph(layer, all_keys) for layer in dsk.layers.values()]
     for k in non_one.keys():
-        for layer in dsk.layers.values():
+        for layer in layers:
             try:
                 key_collisions.add(tokenize(layer[k]))
             except KeyError:

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -1911,7 +1911,8 @@ def from_delayed(values):
         # All futures. Fast path
         values = futures
     else:
-        # Every Delayed generates a Layer, i.e. this path is much more expensive if there are many input values.
+        # Every Delayed generates a Layer, i.e. this path is much more expensive
+        # if there are many input values.
         values = [
             delayed(v) if not isinstance(v, (Delayed,)) and hasattr(v, "key") else v
             for v in values

--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -57,10 +57,10 @@ from dask.base import (
     replace_name_in_key,
     tokenize,
 )
-from dask.blockwise import _blockwise_unpack_collections_task_spec, blockwise
+from dask.blockwise import blockwise
 from dask.context import globalmethod
 from dask.core import flatten, istask, quote
-from dask.delayed import Delayed
+from dask.delayed import Delayed, unpack_collections
 from dask.highlevelgraph import HighLevelGraph
 from dask.sizeof import sizeof
 from dask.typing import Graph, NestedKeys, no_default
@@ -2095,7 +2095,7 @@ def unpack_scalar_dask_kwargs(kwargs):
     kwargs2 = {}
     dependencies = []
     for k, v in kwargs.items():
-        vv, collections = _blockwise_unpack_collections_task_spec(v)
+        vv, collections = unpack_collections(v)
         if not collections:
             kwargs2[k] = v
         else:
@@ -2268,7 +2268,7 @@ def map_partitions(func, *args, **kwargs):
             bags.append(a)
             args2.append(a)
         else:
-            a, collections = _blockwise_unpack_collections_task_spec(a)
+            a, collections = unpack_collections(a)
             args2.append(a)
             dependencies.extend(collections)
 

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import itertools
 import os
 from collections.abc import Hashable, Iterable, Mapping, Sequence
-from dataclasses import fields, is_dataclass, replace
 from itertools import product
 from math import prod
 from typing import Any
@@ -11,11 +10,9 @@ from typing import Any
 import tlz as toolz
 
 import dask
-from dask import base, utils
-from dask._task_spec import Dict, GraphNode, List, Task, TaskRef, parse_input
+from dask._task_spec import GraphNode, List, Task, TaskRef, parse_input
 from dask.base import clone_key, get_name_from_key, tokenize
 from dask.core import flatten, ishashable, keys_in_tasks, reverse_dict
-from dask.delayed import Delayed, finalize
 from dask.highlevelgraph import HighLevelGraph, Layer
 from dask.optimization import fuse
 from dask.typing import Key
@@ -1574,97 +1571,3 @@ def fuse_roots(graph: HighLevelGraph, keys: list):
             dependencies[name] = set()
 
     return HighLevelGraph(layers, dependencies)
-
-
-def _blockwise_unpack_collections_task_spec(expr):
-    # FIXME This is a copy of the delayed.unpack_collections function with the
-    # addition of the TaskSpec class. Eventually this should all be consolidated
-    # but to reduce the number of changes we'll vendor this here
-    # FIXME: There is also a dask.base version of unpack_collections that looks
-    # similar but is different. At the very least the names should be fixed
-    if isinstance(expr, Delayed):
-        return TaskRef(expr._key), (expr,)
-
-    if base.is_dask_collection(expr):
-        if hasattr(expr, "optimize"):
-            # Optimize dask-expr collections
-            expr = expr.optimize()
-
-        finalized = finalize(expr)
-        return TaskRef(finalized._key), (finalized,)
-
-    if type(expr) is type(iter(list())):
-        expr = list(expr)
-    elif type(expr) is type(iter(tuple())):
-        expr = tuple(expr)
-    elif type(expr) is type(iter(set())):
-        expr = set(expr)
-
-    typ = type(expr)
-
-    if typ in (list, tuple, set):
-        args, collections = utils.unzip(
-            (_blockwise_unpack_collections_task_spec(e) for e in expr), 2
-        )
-        collections = tuple(toolz.unique(toolz.concat(collections), key=id))
-        if not collections:
-            return expr, ()
-        args = List(*args)
-        # Ensure output type matches input type
-        if typ is not list:
-            args = Task(None, typ, args)
-        return args, collections
-
-    if typ is dict:
-        args, collections = _blockwise_unpack_collections_task_spec(
-            [[k, v] for k, v in expr.items()]
-        )
-        if not collections:
-            return expr, ()
-        return Dict(args), collections
-
-    if typ is slice:
-        args, collections = _blockwise_unpack_collections_task_spec(
-            [expr.start, expr.stop, expr.step]
-        )
-        if not collections:
-            return expr, ()
-        return Task(None, slice, *args), collections
-
-    if is_dataclass(expr):
-        args, collections = _blockwise_unpack_collections_task_spec(
-            [
-                [f.name, getattr(expr, f.name)]
-                for f in fields(expr)
-                if hasattr(expr, f.name)  # if init=False, field might not exist
-            ]
-        )
-        if not collections:
-            return expr, ()
-        try:
-            _fields = {
-                f.name: getattr(expr, f.name)
-                for f in fields(expr)
-                if hasattr(expr, f.name)
-            }
-            replace(expr, **_fields)
-        except (TypeError, ValueError) as e:
-            if isinstance(e, ValueError) or "is declared with init=False" in str(e):
-                raise ValueError(
-                    f"Failed to unpack {typ} instance. "
-                    "Note that using fields with `init=False` are not supported."
-                ) from e
-            else:
-                raise TypeError(
-                    f"Failed to unpack {typ} instance. "
-                    "Note that using a custom __init__ is not supported."
-                ) from e
-        return Task(None, typ, **dict(args)), collections
-
-    if utils.is_namedtuple_instance(expr):
-        args, collections = _blockwise_unpack_collections_task_spec([v for v in expr])
-        if not collections:
-            return expr, ()
-        return Task(None, typ, *args), collections
-
-    return expr, ()

--- a/dask/core.py
+++ b/dask/core.py
@@ -6,7 +6,12 @@ from typing import Any, Literal, TypeVar, cast, overload
 
 import toolz
 
-from dask._task_spec import DependenciesMapping, convert_legacy_graph, execute_graph
+from dask._task_spec import (
+    DependenciesMapping,
+    TaskRef,
+    convert_legacy_graph,
+    execute_graph,
+)
 from dask.typing import Graph, Key, NoDefault, no_default
 
 
@@ -136,6 +141,8 @@ def keys_in_tasks(keys: Collection[Key], tasks: Iterable[Any], as_list: bool = F
                 work.extend(w.values())
             elif isinstance(w, GraphNode):
                 work.extend(w.dependencies)
+            elif isinstance(w, TaskRef):
+                work.append(w.key)
             else:
                 try:
                     if w in keys:

--- a/dask/dataframe/dask_expr/_expr.py
+++ b/dask/dataframe/dask_expr/_expr.py
@@ -20,6 +20,7 @@ from dask._expr import Expr as BaseExpr
 from dask._expr import FinalizeCompute
 from dask._task_spec import Alias, DataNode, Task, TaskRef, execute_graph
 from dask.array import Array
+from dask.base import collections_to_expr
 from dask.core import flatten
 from dask.dataframe import methods
 from dask.dataframe._pyarrow import to_pyarrow_string
@@ -3085,13 +3086,27 @@ class DelayedsExpr(Expr):
         return "delayed-container-" + self.deterministic_token
 
     def _layer(self) -> dict:
-        dask = {}
-        for i, obj in enumerate(self.operands):
-            dc = obj.__dask_optimize__(obj.dask, obj.key).to_dict().copy()
-            dc[(self._name, i)] = dc[obj.key]
-            dc.pop(obj.key)
-            dask.update(dc)
-        return dask
+        from dask.delayed import Delayed
+
+        if isinstance(self.operands[0], TaskRef):
+            tasks = [
+                Alias((self._name, ix), fut.key) for ix, fut in enumerate(self.operands)
+            ]
+            dsk = {t.key: t for t in tasks}
+        elif isinstance(self.operands[0], Delayed):
+            expr = collections_to_expr(self.operands).optimize()
+            keys = expr.__dask_keys__()
+            dsk = expr.__dask_graph__()
+            # Many APIs in dask-expr are not honoring __dask_keys__ but are instead
+            # assuming they can just construc the keys themselves by walking the
+            # partitions. Therefore we'll have to remap the key names and can't just
+            # expose __dask_keys__()
+            for ix, actual_key in enumerate(keys):
+                dsk[(self._name, ix)] = Alias((self._name, ix), actual_key[0])
+        else:
+            raise TypeError("Expected a Delayed or Future object")
+
+        return dsk
 
     def _divisions(self):
         return (None,) * (len(self.operands) + 1)

--- a/dask/dataframe/dask_expr/io/tests/test_delayed.py
+++ b/dask/dataframe/dask_expr/io/tests/test_delayed.py
@@ -14,7 +14,8 @@ pd = _backend_library()
 def test_from_delayed_optimizing():
     parts = from_dict({"a": np.arange(300)}, npartitions=30).to_delayed()
     result = from_delayed(parts[0], meta=pd.DataFrame({"a": pd.Series(dtype=np.int64)}))
-    assert len(result.optimize().dask) == 2
+    # +1 due to an Alias for correct naming
+    assert len(result.optimize().dask) == 3
     assert_eq(result, pd.DataFrame({"a": pd.Series(np.arange(10))}))
 
 
@@ -28,7 +29,8 @@ def test_from_delayed(prefix):
 
     df = from_delayed(dfs, meta=pdf.head(0), divisions=None, prefix=prefix)
     assert_eq(df, pdf)
-    assert len({k[0] for k in df.optimize().dask}) == 2
+    # +1 due to an Alias for correct naming
+    assert len({k[0] for k in df.optimize().dask}) == 3
     if prefix:
         assert df._name.startswith(prefix)
 

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -157,7 +157,7 @@ def unpack_collections(expr, _return_collections=True):
                     "Cannot unpack dask collections with non-trivial keys"
                 )
 
-            return unpack_collections(Delayed(keys[0], dsk))
+            return unpack_collections(Delayed(next(flatten(keys)), dsk))
         else:
             expr = collections_to_expr(expr).finalize_compute()
             (name,) = expr.__dask_keys__()

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -12,7 +12,7 @@ import toolz
 from tlz import concat, curry, merge
 
 from dask import base, config, utils
-from dask._expr import FinalizeCompute, HLGDistinctKeys, _ExprSequence
+from dask._expr import FinalizeCompute, ProhibitReuse, _ExprSequence
 from dask._task_spec import (
     DataNode,
     GraphNode,
@@ -72,7 +72,7 @@ def _finalize_args_collections(args, collections):
     old_keys = [c.__dask_keys__()[0] for c in collections]
     from dask._task_spec import cull
 
-    collections = HLGDistinctKeys(_ExprSequence(*collections)).optimize()
+    collections = ProhibitReuse(_ExprSequence(*collections)).optimize()
     new_keys = collections.__dask_keys__()
     dsk = collections.__dask_graph__()
     collections = tuple(Delayed(k[0], cull(dsk, [k[0]])) for k in new_keys)

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -641,7 +641,7 @@ class Delayed(DaskMethodsMixin, OperatorMethodMixin):
     Equivalent to the output from a single key in a dask graph.
     """
 
-    __slots__ = ("_key", "_dask", "_length", "_layer", "_expr")
+    __slots__ = ("_key", "_dask", "_length", "_layer")
 
     def __init__(self, key, dsk, length=None, layer=None):
         self._key = key

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -245,15 +245,19 @@ def unpack_collections(expr, _return_collections=True):
 
     if utils.is_namedtuple_instance(expr):
         args, collections = unpack_collections(
-            [v for v in expr], _return_collections=False
+            tuple(v for v in expr), _return_collections=False
         )
         if not collections:
             return expr, ()
         if _return_collections:
             args, collections = _finalize_args_collections(args, collections)
-        return Task(None, typ, args), collections
+        return Task(None, _reconstruct_namedtuple, typ, args), collections
 
     return expr, ()
+
+
+def _reconstruct_namedtuple(typ, fields):
+    return typ(*fields)
 
 
 def to_task_dask(expr):

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -99,6 +99,10 @@ def unpack_collections(expr):
     if isinstance(expr, Delayed):
         return Alias(expr._key), (expr,)
 
+    # Futures are TaskRef
+    if isinstance(expr, TaskRef):
+        return Alias(expr.key), ()
+
     # FIXME: Make this not trigger materialization
     if base.is_dask_collection(expr):
         expr = collections_to_expr(expr)

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -73,7 +73,7 @@ def _finalize_args_collections(args, collections):
     old_keys = [c.__dask_keys__()[0] for c in collections]
     from dask._task_spec import cull
 
-    collections = ProhibitReuse(_ExprSequence(*collections)).optimize()
+    collections = _ExprSequence(*collections).optimize()
     new_keys = collections.__dask_keys__()
     dsk = convert_legacy_graph(collections.__dask_graph__())
     collections = tuple(Delayed(k[0], cull(dsk, [k[0]])) for k in new_keys)

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -13,7 +13,15 @@ from tlz import concat, curry, merge
 
 from dask import base, config, utils
 from dask._expr import FinalizeCompute
-from dask._task_spec import Alias, DataNode, List, Task, TaskRef, fuse_linear_task_spec
+from dask._task_spec import (
+    Alias,
+    DataNode,
+    GraphNode,
+    List,
+    Task,
+    TaskRef,
+    fuse_linear_task_spec,
+)
 from dask.base import (
     DaskMethodsMixin,
     collections_to_expr,
@@ -525,6 +533,8 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
         if not name:
             name = f"{type(obj).__name__}-{tokenize(task, pure=pure)}"
         layer = {name: task}
+        if isinstance(task, GraphNode):
+            task.key = name
         graph = HighLevelGraph.from_collections(name, layer, dependencies=collections)
         return Delayed(name, graph, nout)
 

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -784,13 +784,12 @@ def call_function(func, func_token, args, kwargs, pure=None, nout=None):
     args2, collections = unzip(map(unpack_collections, args), 2)
     collections = list(concat(collections))
 
-    if kwargs:
-        dask_kwargs, collections2 = unpack_collections(kwargs)
-        collections.extend(collections2)
-
+    dask_kwargs, collections2 = unpack_collections(kwargs)
+    collections.extend(collections2)
+    if dask_kwargs:
         task = Task(name, _apply2, func, *args2, dask_kwargs=dask_kwargs)
     else:
-        task = Task(name, func, *args2)
+        task = Task(name, func, *args2, **kwargs)
 
     graph = HighLevelGraph.from_collections(
         name, {name: task}, dependencies=collections

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -145,7 +145,7 @@ def unpack_collections(expr, _return_collections=True):
     # a materialization
     if base.is_dask_collection(expr):
         if _return_collections:
-            expr = collections_to_expr(expr)
+            expr = ProhibitReuse(collections_to_expr(expr))
             finalized = expr.finalize_compute().optimize()
             # FIXME: Make this also go away
             dsk = finalized.__dask_graph__()

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -19,6 +19,7 @@ from dask._task_spec import (
     List,
     Task,
     TaskRef,
+    convert_legacy_graph,
     fuse_linear_task_spec,
 )
 from dask.base import (
@@ -74,7 +75,7 @@ def _finalize_args_collections(args, collections):
 
     collections = ProhibitReuse(_ExprSequence(*collections)).optimize()
     new_keys = collections.__dask_keys__()
-    dsk = collections.__dask_graph__()
+    dsk = convert_legacy_graph(collections.__dask_graph__())
     collections = tuple(Delayed(k[0], cull(dsk, [k[0]])) for k in new_keys)
     subs = {old: new[0] for old, new in zip(old_keys, new_keys) if old != new}
     args = args.substitute(subs)

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -4,6 +4,7 @@ import os
 import re
 from functools import partial
 
+from dask._task_spec import GraphNode, Task
 from dask.core import get_dependencies, ishashable, istask
 from dask.utils import apply, funcname, import_required, key_split
 
@@ -19,6 +20,10 @@ def task_label(task):
     >>> task_label((add, (add, 1, 2), 3))
     'add(...)'
     """
+    if isinstance(task, GraphNode):
+        if isinstance(task, Task) and task.has_subgraph():
+            return f"{task.key}(...)"
+        return task.key
     func = task[0]
     if func is apply:
         func = task[1]

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -568,8 +568,8 @@ def test_array_delayed():
 
 
 def test_array_delayed_complex_optimization():
-    # Ensure that collections that if multiple collections are passed to a
-    # Delayed function that they are optimized together
+    # Ensure that when multiple collections are passed to a Delayed function,
+    # they are optimized together
     np = pytest.importorskip("numpy")
     pytest.importorskip("dask.array")
     from dask.array.core import from_func

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -105,14 +105,14 @@ def test_delayed_with_namedtuple():
 
     literal = dask.delayed(3)
     with_class = dask.delayed({"a": ANamedTuple(a=literal)})
+    assert with_class.compute() == {"a": ANamedTuple(a=3)}
 
     def return_nested(obj):
         return obj["a"].a
 
     final = delayed(return_nested)(with_class)
 
-    # FIXME: this is wrong
-    assert final.compute() == [3]
+    assert final.compute() == 3
 
 
 @dataclass

--- a/dask/tests/test_delayed.py
+++ b/dask/tests/test_delayed.py
@@ -16,6 +16,7 @@ from tlz import merge
 import dask
 import dask.bag as db
 from dask import compute
+from dask._task_spec import Task
 from dask.base import collections_to_expr
 from dask.delayed import Delayed, delayed, to_task_dask
 from dask.highlevelgraph import HighLevelGraph
@@ -94,7 +95,6 @@ def test_delayed():
 
     a = delayed(1)
     assert a.compute() == 1
-    assert 1 in a.dask.values()
     b = add2(add2(a, 2), 3)
     assert a.key in b.dask
 
@@ -111,7 +111,8 @@ def test_delayed_with_namedtuple():
 
     final = delayed(return_nested)(with_class)
 
-    assert final.compute() == 3
+    # FIXME: this is wrong
+    assert final.compute() == [3]
 
 
 @dataclass
@@ -274,7 +275,9 @@ def test_method_getattr_call_same_task():
     a = delayed([1, 2, 3])
     o = a.index(1)
     # Don't getattr the method, then call in separate task
-    assert getattr not in {v[0] for v in o.__dask_graph__().values()}
+    tasks = {v.func for v in o.__dask_graph__().values() if isinstance(v, Task)}
+    assert tasks
+    assert getattr not in tasks
 
 
 def test_np_dtype_of_delayed():
@@ -511,7 +514,8 @@ def test_nout():
 def test_nout_with_tasks(x):
     length = len(x)
     d = delayed(x, nout=length)
-    assert len(d) == len(list(d)) == length
+    assert len(d) == length
+    assert len(list(d)) == length
     assert d.compute() == x
 
 
@@ -612,9 +616,7 @@ def test_delayed_method_descriptor():
 def test_delayed_callable():
     f = delayed(add, pure=True)
     v = f(1, 2)
-    assert v.dask == {v.key: (add, 1, 2)}
-
-    assert f.dask == {f.key: add}
+    assert v.compute() == 3
     assert f.compute() == add
 
 
@@ -865,7 +867,7 @@ def test_delayed_fusion():
 
     obj2 = test3(test2(test(10)))
     with dask.config.set({"optimization.fuse.delayed": True}):
-        dsk2 = collections_to_expr([obj]).__dask_graph__()
+        dsk2 = collections_to_expr([obj]).optimize().__dask_graph__()
         result = dask.compute(obj2)
     assert len(dsk2) == 2
     assert dask.compute(obj) == result

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -16,6 +16,16 @@ Highlights
   scheduler of a distributed cluster (if available)
 - New kwarg `force` for ``DataFrame.shuffle`` which signals the optimizer to not
   drop the shuffle during optimization.
+- (Breaking; kind of) Collections that are passed to dask methods as arguments
+  are now properly optimized. If multiple collections are passed as arguments
+  they will be optimized together. Collections passed this way are prohibited
+  from being being reused, i.e. if the collection is used again in another
+  function call it will be computed again. This pattern is used to avoid
+  pipeline breakers which typically drive memory usage. Avoiding those should
+  reduce memory pressure on the cluster but can cause runtime regressions.
+- (Special case of above point) Collections passed to Delayed objects are now
+  optimized automatically.
+
 
 Breaking changes
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/11879

Relates to https://github.com/dask/dask/issues/11854 as well

This includes two changes

1. It removes `_blockwise_unpack_collections_task_spec` which is a version of `delayed.unpack_collections` that was using the `Task` class already. This was introduced when migrating blockwise to keep the changes small since hybrid tasks can cause problems.
2. It changes how collection finalization works when the collection is encountered as an input (e.g. to a delayed object but also to others).
- It is converting it to a HLGExpr which automatically will perform the container specific optimization step upon materialization.
- It also takes care that when multiple collections are encountered, they are optimized together.
- We are ensuring that whatever result comes out of this optimization is unique and the results are not being reused. This is a common problem we've already encountered in dask-expr which can cause major memory blow up otherwise.

