### PR TITLE
Ensure only classes without custom init are singletons

### DIFF
--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -837,7 +837,7 @@ class SingletonExpr(Expr):
             cls._instances = weakref.WeakValueDictionary()
         inst = super().__new__(cls, *args, _determ_token=_determ_token, **kwargs)
         _name = inst._name
-        if _name in cls._instances:
+        if _name in cls._instances and cls.__init__ == object.__init__:
             return cls._instances[_name]
 
         cls._instances[_name] = inst

--- a/dask/tests/test_expr.py
+++ b/dask/tests/test_expr.py
@@ -119,8 +119,8 @@ def test_singleton_expr():
 
 @pytest.mark.slow()
 def test_refcounting_futures():
-    dd = pytest.importorskip("dask.dataframe")
     pd = pytest.importorskip("pandas")
+    dd = pytest.importorskip("dask.dataframe")
     distributed = pytest.importorskip("distributed")
 
     # See https://github.com/dask/distributed/issues/9041

--- a/dask/tests/test_expr.py
+++ b/dask/tests/test_expr.py
@@ -126,7 +126,7 @@ def test_refcounting_futures():
     # See https://github.com/dask/distributed/issues/9041
     # Didn't reproduce with any of our fixtures
     with distributed.Client(
-        n_workers=2, worker_class=distributed.Worker, dashboard=":0"
+        n_workers=2, worker_class=distributed.Worker, dashboard_address=":0"
     ) as client:
 
         def gen(i):

--- a/dask/tests/test_expr.py
+++ b/dask/tests/test_expr.py
@@ -115,3 +115,29 @@ def test_singleton_expr():
     assert MySingletonInheritsCustomInitAsMixin(
         1, 2
     ) is not MySingletonInheritsCustomInitAsMixin(1, 2)
+
+
+@pytest.mark.slow()
+def test_refcounting_futures():
+    dd = pytest.importorskip("dask.dataframe")
+    pd = pytest.importorskip("pandas")
+    distributed = pytest.importorskip("distributed")
+
+    # See https://github.com/dask/distributed/issues/9041
+    # Didn't reproduce with any of our fixtures
+    with distributed.Client(
+        n_workers=2, worker_class=distributed.Worker, dashboard=":0"
+    ) as client:
+
+        def gen(i):
+            return pd.DataFrame({"A": [i]}, index=[i])
+
+        futures = [client.submit(gen, i) for i in range(3)]
+
+        meta = gen(0)[:0]
+        df = dd.from_delayed(futures, meta)
+        df.compute()
+
+        del futures
+
+        df.compute()

--- a/dask/tests/test_expr.py
+++ b/dask/tests/test_expr.py
@@ -5,7 +5,7 @@ import pickle
 
 import pytest
 
-from dask._expr import Expr
+from dask._expr import Expr, SingletonExpr
 
 
 class MyExpr(Expr):
@@ -85,3 +85,33 @@ def test_pickle_cached_properties():
         await c.submit(f, expr)
 
     test()
+
+
+class MySingleton(SingletonExpr): ...
+
+
+class MySingletonWithCustomInit(SingletonExpr):
+    def __init__(self, *args, **kwargs): ...
+
+
+class MySingletonInheritsCustomInit(MySingletonWithCustomInit): ...
+
+
+class Mixin:
+    def __init__(self, *args, **kwargs): ...
+
+
+class MySingletonInheritsCustomInitAsMixin(MySingleton, Mixin): ...
+
+
+def test_singleton_expr():
+    assert MySingleton(1, 2) is MySingleton(1, 2)
+    # We don't want to deduplicate if there is an __init__ since that may
+    # mutatate our singleton reference and we have no way to know
+    assert MySingletonWithCustomInit(1, 2) is not MySingletonWithCustomInit(1, 2)
+    assert MySingletonInheritsCustomInit(1, 2) is not MySingletonInheritsCustomInit(
+        1, 2
+    )
+    assert MySingletonInheritsCustomInitAsMixin(
+        1, 2
+    ) is not MySingletonInheritsCustomInitAsMixin(1, 2)


### PR DESCRIPTION
I still don't entirely understand what is happening but it seems like we're able to sneak futures/objects into our expressions without the garbage collector learning about it. This is somehow related to our singleton / object deduplication logic but it still eludes me what is happening. I believe this change makes sense regardless of what is actually happening since objects with `__init__` are somewhat unpredictable and we shouldn't try to be smart about them.

Below are [graphs of backreferences](https://mg.pov.lt/objgraph/) of one of the futures objects right before we call `del futures` in the script https://github.com/dask/distributed/issues/9041 
The first shows the `main` branch. As you can see, the `Future` object is only referenced by the `list` in the local context. Therefore, once the list is finalized, the futures are finalized and the scheduler is notified about the futures being released.

However, without the deduplication (or if we remove the custom `__init__`) the DataFrame assumes ownership of the `Future`

With singleton deduplication

![futures](https://github.com/user-attachments/assets/61e641fa-d2eb-48ff-8c86-b9dbc8e20eb6)

without singleton deduplication
![futures](https://github.com/user-attachments/assets/36868541-34ec-426d-8444-0f5d3b3d1c26)

closes https://github.com/dask/distributed/issues/9041

Note: I'll dig into this a little more, trying to understand what's wrong and add a better test case
