### PR TITLE
Remove custom initializers for delayed expressions

### DIFF
--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -51,7 +51,7 @@ class Expr:
 
     _pickle_functools_cache: bool = True
 
-    _operands: list
+    operands: list
 
     _determ_token: str | None
 
@@ -66,15 +66,11 @@ class Expr:
         inst = object.__new__(cls)
 
         inst._determ_token = _determ_token
-        inst._operands = [_unpack_collections(o) for o in operands]
+        inst.operands = [_unpack_collections(o) for o in operands]
         # This is typically cached. Make sure the cache is populated by calling
         # it once
         inst._name
         return inst
-
-    @property
-    def operands(self):
-        return self._operands
 
     def _tune_down(self):
         return None

--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -34,10 +34,12 @@ OptimizerStage: TypeAlias = Literal[
 
 
 def _unpack_collections(o):
+    from dask.delayed import Delayed
+
     if isinstance(o, Expr):
         return o
 
-    if hasattr(o, "expr"):
+    if hasattr(o, "expr") and not isinstance(o, Delayed):
         return o.expr
     else:
         return o
@@ -49,7 +51,7 @@ class Expr:
 
     _pickle_functools_cache: bool = True
 
-    operands: list
+    _operands: list
 
     _determ_token: str | None
 
@@ -64,11 +66,15 @@ class Expr:
         inst = object.__new__(cls)
 
         inst._determ_token = _determ_token
-        inst.operands = [_unpack_collections(o) for o in operands]
+        inst._operands = [_unpack_collections(o) for o in operands]
         # This is typically cached. Make sure the cache is populated by calling
         # it once
         inst._name
         return inst
+
+    @property
+    def operands(self):
+        return self._operands
 
     def _tune_down(self):
         return None

--- a/dask/dataframe/dask_expr/_expr.py
+++ b/dask/dataframe/dask_expr/_expr.py
@@ -3051,14 +3051,7 @@ class PartitionsFiltered(Expr):
 
 
 class _DelayedExpr(Expr):
-    # Wraps a Delayed object to make it an Expr for now. This is hacky and we should
-    # integrate this properly...
-    # TODO
     _parameters = ["obj"]
-
-    def __init__(self, obj, _determ_token=None):
-        self.obj = obj
-        self.operands = [obj]
 
     def __str__(self):
         return f"{type(self).__name__}({str(self.obj)})"
@@ -3082,11 +3075,6 @@ class _DelayedExpr(Expr):
 
 
 class DelayedsExpr(Expr):
-    _parameters = []
-
-    def __init__(self, *delayed_objects, _determ_token=None):
-        self.operands = delayed_objects
-
     def __str__(self):
         return f"{type(self).__name__}({str(self.operands[0])})"
 


### PR DESCRIPTION
See https://github.com/dask/dask/pull/11886 

My best working thesis right now is that these two classes are not just implementing an initializer (which I think should be fine, generally. After all, the entire "please do not mutate the expression since otherwise our singleton cache will be dirty" is true for the entire code base) but they are setting `operands` explicitly.

Let's look at `DelayedsExpr` which is just setting operands to the input arguments. That's **almost** what `__new__` does with the exception of new unpacking collections, see https://github.com/dask/dask/blob/0fa5e18d511c49f1a9cd5f98c675a9f6cd2fc02f/dask/_expr.py#L67

Additionally, the `unpack_collections` is not implemented thoroughly and only cover the most trivial cases. In particular, the case of `Delayed` is explicitly not handled since `hasattr` is always True for a Delayed. Therefore, the `__new__` implementation will set `operands` to a list of `[op.expr for op in operands]` instead of just `operands`. Therefore, the class is created in a corrupt state since `expr` attribute on a Delayed object does not refer to the expr of the collection (yet) but rather generates a new `DelayedAttr`. That's likely the reason why the init was introduced in the first place.

Subsequently, we're calculating the `_name` of the instance to cache it right away which triggers a tokenization of the faulty operands and stores the deterministic token in the cache. Therefore, after the `__init__` operates on the instance, we have an instance that does no longer match its token.

At this point I'm lost again. Since this inconsistency should consistently applied to all instances, it should still work as expected. Regardless, cleaning this up fixes the problem and removes some anomaly in the code.