### PR TITLE
Ensure operands does not have a setter

### DIFF
--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -51,7 +51,7 @@ class Expr:
 
     _pickle_functools_cache: bool = True
 
-    operands: list
+    _operands: list
 
     _determ_token: str | None
 
@@ -66,11 +66,18 @@ class Expr:
         inst = object.__new__(cls)
 
         inst._determ_token = _determ_token
-        inst.operands = [_unpack_collections(o) for o in operands]
+        inst._operands = [_unpack_collections(o) for o in operands]
         # This is typically cached. Make sure the cache is populated by calling
         # it once
         inst._name
         return inst
+
+    @property
+    def operands(self):
+        # Make this not writable, see for context
+        # https://github.com/dask/dask/pull/11888
+        # https://github.com/dask/dask/pull/11886
+        return self._operands
 
     def _tune_down(self):
         return None


### PR DESCRIPTION
I believe the safest way to move forward with our odd classes is to ensure that core internal attributes are not easily set downstream, i.e. operands should not be set

see for context
- https://github.com/dask/dask/pull/11888
- https://github.com/dask/dask/pull/11886


comes after https://github.com/dask/dask/pull/11888 since otherwise the dealyed expr won't work