### PR TITLE
Ensure Future value is in da.from_delayed task graph

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4007,12 +4007,16 @@ def from_delayed(value, shape, dtype=None, meta=None, name=None):
     )
 
     dsk = {task.key: task}
+
+    if is_future:
+        dsk[value.key] = value
+        dependencies = []
+    else:
+        dependencies = [value]
     chunks = tuple((d,) for d in shape)
     # TODO: value._key may not be the name of the layer in value.dask
     # This should be fixed after we build full expression graphs
-    graph = HighLevelGraph.from_collections(
-        name, dsk, dependencies=[value] if not is_future else []
-    )
+    graph = HighLevelGraph.from_collections(name, dsk, dependencies=dependencies)
     return Array(graph, name, chunks, dtype=dtype, meta=meta)
 
 


### PR DESCRIPTION
This attempts to solve the ownership issue reported in #9050. I'm not sure if it's the right fix, since the old code seemed to want to not include the `Future` (at least not in `dependencies`). Maybe including it in the layer itself is OK?

Closes https://github.com/dask/distributed/issues/9050

