### PR TITLE
Ensure FusedIO does not break Blockwise alignment Assign

### DIFF
--- a/dask/dataframe/dask_expr/_repartition.py
+++ b/dask/dataframe/dask_expr/_repartition.py
@@ -174,20 +174,23 @@ class RepartitionToFewer(Repartition):
     def _divisions(self):
         return tuple(self.frame.divisions[i] for i in self._partitions_boundaries)
 
+    @staticmethod
+    def _compute_partition_boundaries(n_new_partitions, n_old_partitions):
+        npartitions_ratio = n_old_partitions / n_new_partitions
+        new_partitions_boundaries = [
+            int(new_partition_index * npartitions_ratio)
+            for new_partition_index in range(n_new_partitions + 1)
+        ]
+        return _clean_new_division_boundaries(
+            new_partitions_boundaries, n_old_partitions
+        )
+
     @functools.cached_property
     def _partitions_boundaries(self):
         npartitions = self.new_partitions
         npartitions_input = self.frame.npartitions
         assert npartitions_input > npartitions
-
-        npartitions_ratio = npartitions_input / npartitions
-        new_partitions_boundaries = [
-            int(new_partition_index * npartitions_ratio)
-            for new_partition_index in range(npartitions + 1)
-        ]
-        return _clean_new_division_boundaries(
-            new_partitions_boundaries, self.frame.npartitions
-        )
+        return self._compute_partition_boundaries(npartitions, npartitions_input)
 
     def _layer(self):
         new_partitions_boundaries = self._partitions_boundaries

--- a/dask/dataframe/dask_expr/io/io.py
+++ b/dask/dataframe/dask_expr/io/io.py
@@ -23,6 +23,7 @@ from dask.dataframe.dask_expr._expr import (
     no_default,
 )
 from dask.dataframe.dask_expr._reductions import Len
+from dask.dataframe.dask_expr._repartition import Repartition, RepartitionToFewer
 from dask.dataframe.dask_expr._util import _BackendData, _convert_to_list
 from dask.dataframe.dispatch import make_meta
 from dask.dataframe.io.io import _meta_from_array, sorted_division_locations
@@ -96,7 +97,17 @@ class BlockwiseIO(Blockwise, IO):
             return
         if isinstance(parent, FusedIO):
             return
-        return parent.substitute(self, FusedIO(self))
+        fused = FusedIO(self)
+        if isinstance(parent, Blockwise):
+            nparts = fused.npartitions
+            for arg in parent.dependencies():
+                if arg is self:
+                    continue
+                if not parent._broadcast_dep(arg):
+                    parent = parent.substitute(
+                        arg, Repartition(arg, new_partitions=nparts)
+                    )
+        return parent.substitute(self, fused)
 
 
 class FusedIO(BlockwiseIO):
@@ -137,15 +148,25 @@ class FusedIO(BlockwiseIO):
             _data_producer=True,
         )
 
-    @functools.cached_property
+    @property
     def _fusion_buckets(self):
         partitions = self.operand("_expr")._partitions
         npartitions = len(partitions)
 
-        step = math.ceil(1 / self.operand("_expr")._fusion_compression_factor)
-        step = min(step, math.ceil(math.sqrt(npartitions)), 100)
+        bucket_size = math.ceil(1 / self.operand("_expr")._fusion_compression_factor)
+        bucket_size = min(bucket_size, math.ceil(math.sqrt(npartitions)), 100)
 
-        buckets = [partitions[i : i + step] for i in range(0, npartitions, step)]
+        new_npartitions = math.ceil(npartitions / bucket_size)
+        # Keep this aligned with RepartitionToFewer such that binops (e.g.
+        # Assign) are always properly aligned
+        partition_boundaries = RepartitionToFewer._compute_partition_boundaries(
+            new_npartitions, npartitions
+        )
+
+        buckets = [
+            partitions[start:end]
+            for (start, end) in zip(partition_boundaries, partition_boundaries[1:])
+        ]
         return buckets
 
     def _tune_up(self, parent):

--- a/dask/dataframe/dask_expr/io/tests/test_io.py
+++ b/dask/dataframe/dask_expr/io/tests/test_io.py
@@ -527,3 +527,14 @@ def test_from_array_partition_pruning():
     result = df.partitions[1]
     expected = arr[100:]
     assert_eq(result, pd.DataFrame(expected, index=list(range(100, 200))))
+
+
+def test_map_partitions_assign_fusedio(tmpdir):
+    data = {"country": ["se", "dk", "no"], "value": [0.1, 0.2, 0.3]}
+    pd.DataFrame(data).to_parquet(tmpdir, partition_cols=["country"])
+    df = dd.read_parquet(tmpdir)
+    y_pred = df.map_partitions(len)
+    df["y_pred"] = y_pred
+    assert assert_eq(
+        df["y_pred"], pd.Series([1, 1, 1], name="y_pred"), check_index=False
+    )

--- a/dask/dataframe/dask_expr/io/tests/test_io.py
+++ b/dask/dataframe/dask_expr/io/tests/test_io.py
@@ -535,6 +535,4 @@ def test_map_partitions_assign_fusedio(tmpdir):
     df = dd.read_parquet(tmpdir)
     y_pred = df.map_partitions(len)
     df["y_pred"] = y_pred
-    assert_eq(
-        df["y_pred"], pd.Series([1, 1, 1], name="y_pred"), check_index=False
-    )
+    assert_eq(df["y_pred"], pd.Series([1, 1, 1], name="y_pred"), check_index=False)

--- a/dask/dataframe/dask_expr/io/tests/test_io.py
+++ b/dask/dataframe/dask_expr/io/tests/test_io.py
@@ -535,6 +535,6 @@ def test_map_partitions_assign_fusedio(tmpdir):
     df = dd.read_parquet(tmpdir)
     y_pred = df.map_partitions(len)
     df["y_pred"] = y_pred
-    assert assert_eq(
+    assert_eq(
         df["y_pred"], pd.Series([1, 1, 1], name="y_pred"), check_index=False
     )


### PR DESCRIPTION
The IO fusion step is breaking alignment in blockwise / align. This should fix it


- [x] Closes https://github.com/dask/dask/issues/11897
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
