### PR TITLE
Simplify (and speed up) culling

### DIFF
--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -1126,6 +1126,8 @@ def cull(
         raise TypeError(
             f"Expected list, set or tuple for keys, got {type(keys).__name__}"
         )
+    if len(keys) == len(dsk):
+        return dsk
     work = set(keys)
     seen: set[KeyType] = set()
     dsk2 = {}

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -584,6 +584,10 @@ class Blockwise(Layer):
         self.new_axes = new_axes or {}
 
     @property
+    def has_legacy_tasks(self):
+        return False
+
+    @property
     def dims(self):
         """Returns a dictionary mapping between each index specified in
         `self.indices` and the number of output blocks for that indice.

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -649,7 +649,7 @@ class Blockwise(Layer):
     def is_materialized(self):
         return hasattr(self, "_cached_dict")
 
-    def _cull_dependencies(self, all_hlg_keys, output_blocks):
+    def _cull_dependencies(self, output_blocks):
         """Determine the necessary dependencies to produce `output_blocks`.
 
         This method does not require graph materialization.
@@ -671,15 +671,9 @@ class Blockwise(Layer):
 
         # Gather constant dependencies (for all output keys)
         const_deps = set()
-        for arg, ind in self.indices:
+        for arg, _ in self.indices:
             if isinstance(arg, TaskRef):
-                arg = arg.key
-            if ind is None:
-                try:
-                    if arg in all_hlg_keys:
-                        const_deps.add(arg)
-                except TypeError:
-                    pass  # unhashable
+                const_deps.add(arg.key)
 
         # Get dependencies for each output block
         key_deps = {}
@@ -736,7 +730,7 @@ class Blockwise(Layer):
         for key in keys:
             if key[0] == self.output:
                 output_blocks.add(key[1:])
-        culled_deps = self._cull_dependencies(all_hlg_keys, output_blocks)
+        culled_deps = self._cull_dependencies(output_blocks)
         out_size_iter = (self.dims[i] for i in self.output_indices)
         if prod(out_size_iter) != len(culled_deps):
             culled_layer = self._cull(output_blocks)

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -765,13 +765,9 @@ class HighLevelGraph(Graph):
                 # Update `keys` with all layer's external key dependencies,
                 # which are all the layer's dependencies (`culled_deps`)
                 # excluding the layer's output keys.
-                for d in culled_deps.values():
+                for k, d in culled_deps.items():
                     keys_set |= d
-
-                # FIXME: keys_set is growing with every loop iteration
-                # by being smart about the dependencies and keeping track of
-                # culled-deps we should be able to reduce it's size once we know
-                # layer keys are no longer referenced... maybe
+                    keys_set.discard(k)
 
                 # Save the culled layer and its key dependencies
                 ret_layers[layer_name] = culled_layer

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -150,7 +150,6 @@ class Layer(Graph):
         """
 
         if self.has_legacy_tasks:
-            assert all_hlg_keys, "Cull needs all_hlg_keys to be set"
             if len(keys) == len(self):
                 # Nothing to cull if preserving all existing keys
                 return (

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -765,6 +765,8 @@ class HighLevelGraph(Graph):
             layer = self.layers[layer_name]
             if keys_set:
                 culled_layer, culled_deps = layer.cull(keys_set, all_ext_keys)
+                if not culled_deps:
+                    continue
 
                 # Update `keys` with all layer's external key dependencies,
                 # which are all the layer's dependencies (`culled_deps`)


### PR DESCRIPTION
I noticed a ping on https://github.com/dask/dask/issues/8570 and wondered if this cannot be resolved with all the recent changes to HLGs and more.

This PR...
- Removes the need to call `get_all_external_keys` iff all layers contain exclusively new-style graphs, i.e. using the `Task` class. `get_all_external_keys` is exclusively used to determine dependencies dynamically but the `Task` class knows all about that already
- It removes `get_output_keys` altogether. I don't truly get why this was ever needed.

## Summary of the benchmarks (see below)

- Everything is at least 30-40% faster
- Particularly single / few keys is at least an order of magnitude faster (still linear with graph size, see point below)
- Worst case is the most common case of no culling. This is because every layer still has to generate the `culled_deps` which is a mapping of all the input to all the output keys even if the layer isn't culling anything. Unfortunately, the optimization "if all downstream layers didn't cull, the current layer can be skipped" does not hold since some layers (e.g. slicing) have culling basically built in which breaks a couple of assumptions. I might have a way around this but not in this PR

Benchmark

```python
def benchmark(nlayers, npartitions):
    import dask.array as da
    arr = da.arange(npartitions, chunks=(1,))
    def func(*args, **kwargs):
        return args[0]
    for _ in range(nlayers):
        arr = da.blockwise(
            func,
            "i",
            arr,
            "i"
        )
    
    print("*"*50)
    print(f"Benchmark {nlayers=} with {npartitions=}")
    
    print("No culling")
    %timeit arr.dask.cull(arr.__dask_keys__())
    print("Cull 50%")
    %timeit arr.dask.cull(arr.__dask_keys__()[::2])
    print("Just one key")
    %timeit arr.dask.cull([arr.__dask_keys__()[-1]])
    print("*"*50)
```

# Main

![image](https://github.com/user-attachments/assets/8e713df5-721d-4d22-ae9b-f208c2eeec28)


# This PR

![image](https://github.com/user-attachments/assets/a937570d-23f9-41ae-9b85-4abf8e5b58d0)
