### PR TITLE
Map_partitions again accepts delayed objects

### DIFF
--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -967,7 +967,7 @@ class Dict(NestedContainer, Mapping):
         yield from self.args[::2]
 
     def __len__(self):
-        return (len(self.args) - 2) // 2
+        return len(self.args) // 2
 
     def __getitem__(self, key):
         for k, v in batched(self.args, 2, strict=True):

--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -954,18 +954,6 @@ class Dict(NestedContainer, Mapping):
     def __iter__(self):
         yield from self.args[::2]
 
-    def __getitem__(self, key):
-        for k, v in batched(self.args, 2, strict=True):
-            if k == key:
-                return v
-        raise KeyError(key)
-
-    def __len__(self):
-        return len(self.args) // 2
-
-    def __iter__(self):
-        yield from self.args[::2]
-
     def __len__(self):
         return len(self.args) // 2
 

--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -963,6 +963,18 @@ class Dict(NestedContainer, Mapping):
     def __len__(self):
         return len(self.args) // 2
 
+    def __iter__(self):
+        yield from self.args[::2]
+
+    def __len__(self):
+        return (len(self.args) - 2) // 2
+
+    def __getitem__(self, key):
+        for k, v in batched(self.args, 2, strict=True):
+            if k == key:
+                return v
+        raise KeyError(key)
+
     @staticmethod
     def constructor(args):
         return dict(batched(args, 2, strict=True))

--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -6175,7 +6175,7 @@ def map_partitions(
         if isinstance(v, Delayed):
             dexpr = _DelayedExpr(v)
             delayed_kwargs.append(dexpr)
-            newkwargs[k] = TaskRef(dexpr._name)
+            newkwargs[k] = TaskRef(dexpr.__dask_keys__()[0])
         else:
             newkwargs[k] = v
     del kwargs

--- a/dask/dataframe/dask_expr/_groupby.py
+++ b/dask/dataframe/dask_expr/_groupby.py
@@ -1391,6 +1391,7 @@ class GroupByCumulative(Expr, GroupByBase):
             None,
             None,
             {"chunk": self.chunk, "columns": columns, **dropna, **self.numeric_only},
+            len(self.by),
             *self.by,
         )
         cum_raw = frame
@@ -1420,6 +1421,7 @@ class GroupByCumulative(Expr, GroupByBase):
             None,
             None,
             {"chunk": M.last, "columns": columns, **dropna},
+            len(by),
             *by,
         )
         return GroupByCumulativeFinalizer(

--- a/dask/dataframe/dask_expr/_merge_asof.py
+++ b/dask/dataframe/dask_expr/_merge_asof.py
@@ -132,6 +132,7 @@ class MergeAsof(Merge):
                 None,
                 None,
                 self._kwargs,
+                1,
                 self.right,
             )
 
@@ -154,6 +155,7 @@ class MergeAsof(Merge):
                 None,
                 None,
                 {"left_index": True, "right_index": True},
+                1,
                 right,
             )
 

--- a/dask/dataframe/dask_expr/tests/test_distributed.py
+++ b/dask/dataframe/dask_expr/tests/test_distributed.py
@@ -350,8 +350,9 @@ def test_merge_combine_similar_squash_merges(add_repartition):
     )
 
 
+@pytest.mark.parametrize("kind", ["future", "delayed"])
 @gen_cluster(client=True)
-async def test_future_in_map_partitions(c, s, a, b):
+async def test_future_in_map_partitions(c, s, a, b, kind):
     # xgboost uses this pattern
 
     def test_func(n):
@@ -361,34 +362,22 @@ async def test_future_in_map_partitions(c, s, a, b):
 
     df = from_pandas(pd.DataFrame({"a": [1, 2, 3, 4]}), npartitions=2)
 
-    f = c.submit(test_func, 100)
-    q = map_partitions(lambda x, y: y + x.sum(), f, df, meta=df._meta)
-    result = c.compute(q)
-    result = await result
-    expected = pd.DataFrame({"a": [4951, 4952, 4953, 4954]})
-    pd.testing.assert_frame_equal(result, expected)
-
-
-@gen_cluster(client=True)
-async def test_delayed_in_map_partitions(c, s, a, b):
-    # xgboost uses this pattern
-
-    def test_func(n):
-        import pandas as pd
-
-        return pd.DataFrame({"a": list(range(n))})
-
-    df = from_pandas(pd.DataFrame({"a": [1, 2, 3, 4]}), npartitions=2)
+    if kind == "future":
+        f = c.submit(test_func, 100)
+        z = c.submit(test_func, 10)
+    elif kind == "delayed":
+        f = dask.delayed(test_func)(100)
+        z = dask.delayed(test_func)(10)
+    else:
+        raise ValueError("kind must be 'future' or 'delayed'")
 
     def _foo(x, y, z):
-        return y + x.sum()
+        return x.sum() + y + z.sum()
 
-    f = dask.delayed(test_func)(100)
-    z = dask.delayed(test_func)(50)
     q = map_partitions(_foo, f, df, z=z, meta=df._meta)
     result = c.compute(q)
     result = await result
-    expected = pd.DataFrame({"a": [4951, 4952, 4953, 4954]})
+    expected = pd.DataFrame({"a": [4996, 4997, 4998, 4999]})
     pd.testing.assert_frame_equal(result, expected)
 
 

--- a/dask/tests/test_task_spec.py
+++ b/dask/tests/test_task_spec.py
@@ -1022,13 +1022,13 @@ def test_dict_class():
     }
     assert len(t) == len(dict(t)) == 2
 
-    def test_as_kwargs(**kwargs):
-        assert kwargs == {
+    def as_kwargs(**kwargs):
+        return kwargs == {
             "k": Task("key-1", func, "a", "b"),
             "v": Task("key-2", func, "c", "d"),
         }
 
-    test_as_kwargs(**t)
+    assert as_kwargs(**t)
 
 
 def test_block_io_fusion():

--- a/dask/tests/test_task_spec.py
+++ b/dask/tests/test_task_spec.py
@@ -1020,6 +1020,7 @@ def test_dict_class():
         "k": Task("key-1", func, "a", "b"),
         "v": Task("key-2", func, "c", "d"),
     }
+    assert len(t) == len(dict(t)) == 2
 
     def test_as_kwargs(**kwargs):
         assert kwargs == {

--- a/dask/tests/test_task_spec.py
+++ b/dask/tests/test_task_spec.py
@@ -4,6 +4,7 @@ import itertools
 import pickle
 import sys
 from collections import namedtuple
+from collections.abc import Mapping
 
 import pytest
 
@@ -1013,6 +1014,20 @@ def test_dict_class():
 
     d = Dict([["columns", ["a", "b"]]])
     assert d() == {"columns": ["a", "b"]}
+    # Can be converted to a dict, e.g. also used as **kwargs
+    assert isinstance(t, Mapping)
+    assert dict(t) == {
+        "k": Task("key-1", func, "a", "b"),
+        "v": Task("key-2", func, "c", "d"),
+    }
+
+    def test_as_kwargs(**kwargs):
+        assert kwargs == {
+            "k": Task("key-1", func, "a", "b"),
+            "v": Task("key-2", func, "c", "d"),
+        }
+
+    test_as_kwargs(**t)
 
 
 def test_block_io_fusion():


### PR DESCRIPTION
With the move to dask-expr we apparently lost the feature that map_partitions accepts delayed objects. Maybe other APIs are also affected but I don' tknow of a good way to test this.