### PR TITLE
Ensure that `delayed(future).compute()` resolves correctly

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -620,6 +620,15 @@ def delayed(obj, name=None, pure=None, nout=None, traverse=True):
     if not (nout is None or (type(nout) is int and nout >= 0)):
         raise ValueError("nout must be None or a non-negative integer, got %s" % nout)
     if task is obj:
+        try:
+            from distributed import Future
+        except ImportError:
+            pass
+        else:
+            if isinstance(obj, Future):
+                # https://github.com/dask/dask/issues/11908
+                name = name or obj.key
+
         if not name:
             try:
                 prefix = obj.__name__

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -661,7 +661,7 @@ def test_default_imports():
     out = subprocess.check_output([sys.executable, "-c", code])
     modules = set(eval(out.decode()))
     assert "dask" in modules
-    blacklist = [
+    blocklist = [
         "dask.array",
         "dask.dataframe",
         "numpy",
@@ -670,7 +670,7 @@ def test_default_imports():
         "s3fs",
         "distributed",
     ]
-    for mod in blacklist:
+    for mod in blocklist:
         assert mod not in modules
 
 

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -1074,3 +1074,11 @@ async def test_fusion_barrier_task(c, s, a, b):
     x2 = da.rechunk(x, chunks=new, method="p2p")
     result = await c.compute(x2)
     da.assert_eq(result, a)
+
+
+@gen_cluster(client=True)
+async def test_delayed_future(c, s, a, b):
+    fut = await c.scatter(1)
+    result = dask.delayed(fut)
+    assert result.key == fut.key
+    assert await c.compute(result) == 1


### PR DESCRIPTION
This restores some previous behavior that enabled `dask.delayed(future).compute()` to resolve to the same value as `future.result()`.

Closes https://github.com/dask/dask/issues/11908