### PR TITLE
Ensure keyword futures to Delayed are resolved

### DIFF
--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -816,7 +816,8 @@ def call_function(func, func_token, args, kwargs, pure=None, nout=None):
     dask_kwargs, collections2 = unpack_collections(kwargs)
     collections.extend(collections2)
     if dask_kwargs:
-        task = Task(name, _apply2, func, *args2, dask_kwargs=dask_kwargs)
+        # task = Task(name, apply, func, args2, dask_kwargs)
+        task = (apply, func, list(args2), dask_kwargs)
     else:
         task = Task(name, func, *args2, **kwargs)
 

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -1064,6 +1064,14 @@ async def test_release_persisted_futures_without_gc(c, s, a, b):
 
 
 @gen_cluster(client=True)
+async def test_delayed_future_with_kwargs(c, s, a, b):
+    fut = await c.scatter(1)
+
+    result = dask.delayed(inc)(x=fut)
+    assert await c.compute(result) == 2
+
+
+@gen_cluster(client=True)
 async def test_fusion_barrier_task(c, s, a, b):
     np = pytest.importorskip("numpy")
     da = pytest.importorskip("dask.array")


### PR DESCRIPTION
A (probably unintended) consequence of https://github.com/dask/dask/pull/11881 is that `delayed(myfunc)(obj=obj)` will no longer identify `obj` as a dependency in the task graph:

```python
In [1]: import sys
   ...: import dask
   ...: import distributed
   ...: import pathlib
   ...:
   ...:
   ...: from distributed import Client, Future
   ...: import dask
   ...:

In [2]: def inc(x): return x + 1

In [3]: client = Client(n_workers=1)
In [4]: fut = client.scatter(1)

In [5]: a = dask.delayed(inc)(fut)

In [6]: b = dask.delayed(inc)(x=fut)

In [7]: dict(a.dask)
Out[7]: {'inc-4e21d6cb-c6bb-4bc7-ad5c-2b88673f8523': <Task 'inc-4e21d6cb-c6bb-4bc7-ad5c-2b88673f8523' inc(...)>}

In [8]: dict(b[0].dask)
Out[8]:
{'inc-265506cd-b0f7-4afb-8e61-6b6d8d2ac85d': <Task 'inc-265506cd-b0f7-4afb-8e61-6b6d8d2ac85d' _apply2(..., ...)>,
 'getitem-835cad005de1733e200f092914217749': <Task 'getitem-835cad005de1733e200f092914217749' getitem(...)>}
```

This is at least partly because of how the `Task` is constructed: it doesn't recognize that the Future passed in the kwarg is something that needs dereferencing:

```python
In [21]: list(list(a.dask.layers.values())[0].mapping.values())[0].args  # passed by argument
Out[21]: (Alias('int-c0a8a20f903a4915b94db8de3ea63195'),)

In [22]: list(list(a.dask.layers.values())[0].mapping.values())[0].kwargs
Out[22]: {}

In [25]: list(list(b.dask.layers.values())[0].mapping.values())[0].args  # passed by keyword
Out[25]: (<function __main__.inc(x)>,)

In [26]: list(list(b.dask.layers.values())[0].mapping.values())[0].kwargs
Out[26]: {'dask_kwargs': {'x': <Future: finished, type: int, key: int-c0a8a20f903a4915b94db8de3ea63195>}}

```

This fix simply restores the old implementation. I don't think it's ideal and probably has downsides I'm not aware of. I spent a bit of time trying to get the `Alias` resolved and dependencies updated correctly when we have a `dask_kwargs` where some values are `Futures` but wasn't able to get it working :/


Closes https://github.com/dask/dask/issues/11910