### PR TITLE
Don't run post ``setup-miniconda`` step in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,7 @@ jobs:
           environment-file: continuous_integration/environment-${{ matrix.environment }}.yaml
           activate-environment: test-environment
           auto-activate-base: false
+          run-post: ${{ matrix.os != 'windows-latest' }}
 
       - name: Test pandas nightlies (only with dask-expr)
         if: ${{ matrix.extra == 'pandas-nightly' }}


### PR DESCRIPTION
Looks like our Windows CI jobs are timing out after tests have run and the post cleanup step for the `setup-miniconda` action is running. I'm not sure why we started running into this all the sudden, but there are similar reports of this happening elsewhere (xref https://github.com/conda-incubator/setup-miniconda/issues/380, https://github.com/conda-incubator/setup-miniconda/issues/280, https://github.com/conda-incubator/setup-miniconda/issues/277). This PR proposes we just step the post cleanup step on Windows builds. Let's see if that helps. 