### PR TITLE
Fix Array.setitem with nan shapes on both sides

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1934,7 +1934,14 @@ class Array(DaskMethodsMixin):
         if isinstance(key, Array):
             from dask.array.routines import where
 
-            if key.shape != self.shape:
+            left_shape = np.array(key.shape)
+            right_shape = np.array(self.shape)
+
+            # We want to treat unknown shape on *either* sides as a match
+            match = left_shape == right_shape
+            match |= np.isnan(left_shape) | np.isnan(right_shape)
+
+            if not match.all():
                 raise IndexError(
                     f"boolean index shape {key.shape} must match indexed array's "
                     f"{self.shape}."

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -1156,7 +1156,6 @@ def test_positional_indexer_newaxis():
 def test_boolean_mask_with_unknown_shape(
     shapes: tuple[float | int, float | int],
 ) -> None:
-    # Currently failing with a ValueError: operands could not be broadcast together with shapes
     x_shape, mask_shape = shapes
     arr = delayed(np.ones(10))
     x = da.concatenate(

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -1140,10 +1140,6 @@ def test_positional_indexer_newaxis():
     assert_eq(new, arr.compute()[[True, True, False], np.newaxis])
 
 
-# @pytest.mark.parametrize("x_shape", [10, np.nan])
-# @pytest.mark.parametrize("mask_shape", [10, np.nan])
-
-
 @pytest.mark.parametrize(
     "shapes",
     [
@@ -1158,7 +1154,7 @@ def test_positional_indexer_newaxis():
     ],
 )
 def test_boolean_mask_with_unknown_shape(
-    shapes: tuple[float | int, float | int]
+    shapes: tuple[float | int, float | int],
 ) -> None:
     # Currently failing with a ValueError: operands could not be broadcast together with shapes
     x_shape, mask_shape = shapes

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -6,6 +6,7 @@ import warnings
 import pytest
 
 from dask._task_spec import Alias, Task, TaskRef
+from dask.delayed import delayed
 
 np = pytest.importorskip("numpy")
 
@@ -1137,3 +1138,44 @@ def test_positional_indexer_newaxis():
     arr = da.array([0, 1, 2])
     new = arr[[True, True, False], np.newaxis]
     assert_eq(new, arr.compute()[[True, True, False], np.newaxis])
+
+
+# @pytest.mark.parametrize("x_shape", [10, np.nan])
+# @pytest.mark.parametrize("mask_shape", [10, np.nan])
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        (10, 10),
+        (np.nan, np.nan),
+        pytest.param(
+            (10, np.nan), marks=pytest.mark.xfail(reason="Not implemented", strict=True)
+        ),
+        pytest.param(
+            (np.nan, 10), marks=pytest.mark.xfail(reason="Not implemented", strict=True)
+        ),
+    ],
+)
+def test_boolean_mask_with_unknown_shape(
+    shapes: tuple[float | int, float | int]
+) -> None:
+    # Currently failing with a ValueError: operands could not be broadcast together with shapes
+    x_shape, mask_shape = shapes
+    arr = delayed(np.ones(10))
+    x = da.concatenate(
+        [
+            da.from_delayed(arr, shape=(x_shape,), dtype=float),
+            da.from_delayed(arr, shape=(x_shape,), dtype=float),
+        ]
+    )
+    mask = da.concatenate(
+        [
+            da.from_delayed(arr, shape=(mask_shape,), dtype=bool),
+            da.from_delayed(arr, shape=(mask_shape,), dtype=bool),
+        ]
+    )
+    x[mask] = 2
+
+    expected = np.full(20, 2.0)
+    assert_eq(x, expected)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,16 @@ Changelog
 
     This is not exhaustive. For an exhaustive list of changes, see the git log.
 
+
+.. _v2025.5.0:
+
+2025.5.0
+--------
+
+- Fixed Array setitem when both the array and the indexer have unknown shape (:issue:`11753`) `Tom Augspurger`_
+
+
+
 .. _v2025.4.1:
 
 2025.4.1


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/11753, specifically https://github.com/dask/dask/issues/11753#issuecomment-2868902284
