### PR TITLE
Raise on local executor if tasks are missing dependency

### DIFF
--- a/dask/local.py
+++ b/dask/local.py
@@ -187,6 +187,12 @@ def start_state_from_dask(dsk, cache=None, sortkey=None, keys=None):
         dependencies[key]
         task = dsk.get(key, None)
         if task is None:
+            if dependents[key] and not cache.get(key, None):
+                raise ValueError(
+                    "Missing dependency {} for dependents {}".format(
+                        key, dependents[key]
+                    )
+                )
             continue
         elif isinstance(task, DataNode):
             cache[key] = task()


### PR DESCRIPTION
If graphs are provided with keys that are missing dependencies, the local executor is silently getting stuck. The distributed scheduler cancels the computation and logs and raises an appropriate error message. The local one should do the same. This is otherwise infuriating to debug.

xref https://github.com/dask/dask/issues/11927