### PR TITLE
Speed up slicing graph generation

### DIFF
--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -657,15 +657,16 @@ class Task(GraphNode):
         self.args = args
         self.kwargs = kwargs
         _dependencies: set[KeyType] | None = None
-        for o in (self.args, self.kwargs.values()):
-            for a in o:
-                if isinstance(a, TaskRef):
-                    if _dependencies is None:
-                        _dependencies = set()
+        for a in itertools.chain(args, kwargs.values()):
+            if isinstance(a, TaskRef):
+                if _dependencies is None:
+                    _dependencies = {a.key}
+                else:
                     _dependencies.add(a.key)
-                elif isinstance(a, GraphNode) and a.dependencies:
-                    if _dependencies is None:
-                        _dependencies = set()
+            elif isinstance(a, GraphNode) and a.dependencies:
+                if _dependencies is None:
+                    _dependencies = set(a.dependencies)
+                else:
                     _dependencies.update(a.dependencies)
         if _dependencies:
             self._dependencies = frozenset(_dependencies)

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -211,7 +211,9 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
     chunk_boundaries = np.cumsum(chunks[axis])
 
     # Get existing chunk tuple locations
-    chunk_tuples = product(*(range(len(c)) for i, c in enumerate(chunks) if i != axis))
+    chunk_tuples = list(
+        product(*(range(len(c)) for i, c in enumerate(chunks) if i != axis))
+    )
 
     intermediates = dict()
     merges = dict()

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -265,7 +265,7 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
                     if len(source_chunk_nr) == 1:
                         this_slice[axis] = this_slice[axis][np.argsort(sorter)]
 
-                    taker_key = taker_name + tokenize(in_name, out_name, this_slice)
+                    taker_key = taker_name + tokenize(this_slice)
                     # low level fusion can't deal with arrays on first position
                     intermediates[taker_key] = DataNode(
                         taker_key, (1, tuple(this_slice))

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -228,12 +228,10 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
         old_index: (in_name,) + old_index
         for old_index in np.ndindex(tuple([len(c) for c in chunks]))
     }
-
-    base_token = tokenize(in_name, out_name, indexer)
     for new_chunk_idx, new_chunk_taker in enumerate(new_chunks):
-        sorter_key = sorter_name + str(hash(hash(new_chunk_idx) + hash(base_token)))
         new_chunk_taker = np.array(new_chunk_taker)
         sorter = np.argsort(new_chunk_taker).astype(dtype)
+        sorter_key = sorter_name + tokenize(sorter)
         # low level fusion can't deal with arrays on first position
         merges[sorter_key] = DataNode(sorter_key, (1, sorter))
 

--- a/dask/array/_shuffle.py
+++ b/dask/array/_shuffle.py
@@ -231,9 +231,7 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
     for new_chunk_idx, new_chunk_taker in enumerate(new_chunks):
         new_chunk_taker = np.array(new_chunk_taker)
         sorter = np.argsort(new_chunk_taker).astype(dtype)
-        sorter_key = sorter_name + tokenize(sorter)
-        # low level fusion can't deal with arrays on first position
-        merges[sorter_key] = DataNode(sorter_key, (1, sorter))
+        sorter_key = None
 
         sorted_array = new_chunk_taker[sorter]
         source_chunk_nr, taker_boundary = np.unique(
@@ -282,6 +280,10 @@ def _shuffle(chunks, indexer, axis, in_name, out_name, token):
             merge_suffix = convert_key(chunk_tuple, new_chunk_idx, axis)
             out_name_merge = (out_name,) + merge_suffix
             if len(merge_keys) > 1:
+                if sorter_key is None:
+                    sorter_key = sorter_name + tokenize(sorter)
+                    # low level fusion can't deal with arrays on first position
+                    merges[sorter_key] = DataNode(sorter_key, (1, sorter))
                 merges[out_name_merge] = Task(
                     out_name_merge,
                     concatenate_arrays,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -45,7 +45,7 @@ from dask.array.dispatch import (  # noqa: F401
     tensordot_lookup,
 )
 from dask.array.numpy_compat import NUMPY_GE_200, _Recurser
-from dask.array.slicing import replace_ellipsis, setitem_array, slice_array
+from dask.array.slicing import SlicingNoop, replace_ellipsis, setitem_array, slice_array
 from dask.array.utils import (
     asanyarray_safe,
     asarray_safe,
@@ -2028,7 +2028,10 @@ class Array(DaskMethodsMixin):
             return self
 
         out = "getitem-" + tokenize(self, index2)
-        dsk, chunks = slice_array(out, self.name, self.chunks, index2, self.itemsize)
+        try:
+            dsk, chunks = slice_array(out, self.name, self.chunks, index2)
+        except SlicingNoop:
+            return self
 
         graph = HighLevelGraph.from_collections(out, dsk, dependencies=[self])
 

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -204,7 +204,7 @@ def slice_with_newaxes(out_name, in_name, blockdims, index):
         for k, v in dsk.items():
             if k[0] == out_name:
                 k2 = (out_name,) + expand(k[1:], 0)
-                if isinstance(v.args[1], Alias):
+                if isinstance(v.args[1], TaskRef):
                     # positional indexing with newaxis
                     indexer = expand_orig(dsk[v.args[1].key].value[1], None)
                     tok = "shuffle-taker-" + tokenize(indexer)

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -16,7 +16,7 @@ from dask._task_spec import Alias, DataNode, Task, TaskRef
 from dask.array.chunk import getitem
 from dask.base import is_dask_collection, tokenize
 from dask.highlevelgraph import HighLevelGraph
-from dask.utils import _deprecated, cached_cumsum, is_arraylike
+from dask.utils import _deprecated, cached_cumsum, disable_gc, is_arraylike
 
 colon = slice(None, None, None)
 
@@ -97,6 +97,7 @@ def sanitize_index(ind):
         raise TypeError("Invalid index type", type(ind), ind)
 
 
+@disable_gc()
 def slice_array(out_name, in_name, blockdims, index):
     """
     Main function for array slicing

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -139,10 +139,10 @@ def slice_array(out_name, in_name, blockdims, index):
     --------
     >>> from pprint import pprint
     >>> dsk, blockdims = slice_array('y', 'x', [(20, 20, 20, 20, 20)],
-    ...                              (slice(10, 35),), 8)
+    ...                              (slice(10, 35),))
     >>> pprint(dsk)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-    {('y', 0): <Task ('y', 0) getitem(Alias(('x', 0)), (slice(10, 20, 1),))>,
-     ('y', 1): <Task ('y', 1) getitem(Alias(('x', 1)), (slice(0, 15, 1),))>}
+    {('y', 0): <Task ('y', 0) getitem(TaskRef(('x', 0)), (slice(10, 20, 1),))>,
+     ('y', 1): <Task ('y', 1) getitem(TaskRef(('x', 1)), (slice(0, 15, 1),))>}
     >>> blockdims
     ((10, 15),)
 

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -14,6 +14,7 @@ import dask.array as da
 from dask import config
 from dask.array.chunk import getitem
 from dask.array.slicing import (
+    SlicingNoop,
     _sanitize_index_element,
     _slice_1d,
     make_block_sorted_slices,
@@ -184,7 +185,7 @@ def test_slice_array_1d():
         ("y", 2): Task(("y", 2), getitem, TaskRef(("x", 2)), (slice(0, 25, 2),)),
         ("y", 3): Task(("y", 3), getitem, TaskRef(("x", 3)), (slice(1, 25, 2),)),
     }
-    result, chunks = slice_array("y", "x", [[25] * 4], [slice(24, None, 2)], 8)
+    result, chunks = slice_array("y", "x", [[25] * 4], [slice(24, None, 2)])
 
     assert expected == result
 
@@ -195,7 +196,7 @@ def test_slice_array_1d():
         ("y", 2): Task(("y", 2), getitem, TaskRef(("x", 3)), (slice(1, 25, 2),)),
     }
 
-    result, chunks = slice_array("y", "x", [[25] * 4], [slice(26, None, 2)], 8)
+    result, chunks = slice_array("y", "x", [[25] * 4], [slice(26, None, 2)])
     assert expected == result
 
     # x[24::2]
@@ -205,7 +206,7 @@ def test_slice_array_1d():
         ("y", 2): Task(("y", 2), getitem, TaskRef(("x", 2)), (slice(0, 25, 2),)),
         ("y", 3): Task(("y", 3), getitem, TaskRef(("x", 3)), (slice(1, 25, 2),)),
     }
-    result, chunks = slice_array("y", "x", [(25,) * 4], (slice(24, None, 2),), 8)
+    result, chunks = slice_array("y", "x", [(25,) * 4], (slice(24, None, 2),))
 
     assert expected == result
 
@@ -216,7 +217,7 @@ def test_slice_array_1d():
         ("y", 2): Task(("y", 2), getitem, TaskRef(("x", 3)), (slice(1, 25, 2),)),
     }
 
-    result, chunks = slice_array("y", "x", [(25,) * 4], (slice(26, None, 2),), 8)
+    result, chunks = slice_array("y", "x", [(25,) * 4], (slice(26, None, 2),))
     assert expected == result
 
 
@@ -242,7 +243,6 @@ def test_slice_array_2d():
         "x",
         [[20], [20, 20, 5]],
         [slice(13, None, 2), slice(10, None, 1)],
-        itemsize=8,
     )
 
     assert expected == result
@@ -254,39 +254,28 @@ def test_slice_array_2d():
         ("y", 2): Task(("y", 2), getitem, TaskRef(("x", 0, 2)), (5, slice(None))),
     }
 
-    result, chunks = slice_array(
-        "y", "x", ([20], [20, 20, 5]), [5, slice(10, None, 1)], 8
-    )
+    result, chunks = slice_array("y", "x", ([20], [20, 20, 5]), [5, slice(10, None, 1)])
 
     assert expected == result
 
 
 def test_slice_optimizations():
     # bar[:]
-    expected = {("foo", 0): Alias(("foo", 0), ("bar", 0))}
-    result, chunks = slice_array("foo", "bar", [[100]], (slice(None, None, None),), 8)
-    assert expected == result
+    with pytest.raises(SlicingNoop):
+        slice_array("foo", "bar", [[100]], (slice(None, None, None),))
 
     # bar[:,:,:]
-    expected = {
-        ("foo", 0): Alias(("foo", 0), ("bar", 0)),
-        ("foo", 1): Alias(("foo", 1), ("bar", 1)),
-        ("foo", 2): Alias(("foo", 2), ("bar", 2)),
-    }
-    result, chunks = slice_array(
-        "foo",
-        "bar",
-        [(100, 1000, 10000)],
-        (slice(None, None, None), slice(None, None, None), slice(None, None, None)),
-        itemsize=8,
-    )
-    assert expected == result
+    with pytest.raises(SlicingNoop):
+        slice_array(
+            "foo",
+            "bar",
+            [(100, 1000, 10000)],
+            (slice(None, None, None), slice(None, None, None), slice(None, None, None)),
+        )
 
 
 def test_slicing_with_singleton_indices():
-    result, chunks = slice_array(
-        "y", "x", ([5, 5], [5, 5]), (slice(0, 5), 8), itemsize=8
-    )
+    result, chunks = slice_array("y", "x", ([5, 5], [5, 5]), (slice(0, 5), 8))
 
     expected = {
         ("y", 0): Task(
@@ -303,7 +292,6 @@ def test_slicing_with_newaxis():
         "x",
         ([5, 5], [5, 5]),
         (slice(0, 3), None, slice(None, None, None)),
-        itemsize=8,
     )
 
     expected = {
@@ -339,26 +327,20 @@ def test_take_sorted():
     chunks, dsk = take("y-y", "x", [(20, 20, 20, 20)], [1, 3, 5, 47], axis=0)
     assert len(dsk) == 6
     assert chunks == ((4,),)
-
-    chunks, dsk = take("y", "x", [(20, 20, 20, 20)], np.arange(0, 80), axis=0)
-    assert len(dsk) == 4
-    assert chunks == ((20, 20, 20, 20),)
+    with pytest.raises(SlicingNoop):
+        take("y", "x", [(20, 20, 20, 20)], np.arange(0, 80), axis=0)
 
 
 def test_slicing_chunks():
-    result, chunks = slice_array(
-        "y", "x", ([5, 5], [5, 5]), (1, np.array([2, 0, 3])), itemsize=8
-    )
+    result, chunks = slice_array("y", "x", ([5, 5], [5, 5]), (1, np.array([2, 0, 3])))
     assert chunks == ((3,),)
 
     result, chunks = slice_array(
-        "y", "x", ([5, 5], [5, 5]), (slice(0, 7), np.array([2, 0, 3])), itemsize=8
+        "y", "x", ([5, 5], [5, 5]), (slice(0, 7), np.array([2, 0, 3]))
     )
     assert chunks == ((5, 2), (3,))
 
-    result, chunks = slice_array(
-        "y", "x", ([5, 5], [5, 5]), (slice(0, 7), 1), itemsize=8
-    )
+    result, chunks = slice_array("y", "x", ([5, 5], [5, 5]), (slice(0, 7), 1))
     assert chunks == ((5, 2),)
 
 
@@ -368,14 +350,12 @@ def test_slicing_with_numpy_arrays():
         "x",
         ((3, 3, 3, 1), (3, 3, 3, 1)),
         (np.array([1, 2, 9]), slice(None, None, None)),
-        itemsize=8,
     )
     b, bd2 = slice_array(
         "y-y",
         "x",
         ((3, 3, 3, 1), (3, 3, 3, 1)),
         (np.array([1, 2, 9]), slice(None, None, None)),
-        itemsize=8,
     )
 
     assert bd1 == bd2
@@ -384,7 +364,7 @@ def test_slicing_with_numpy_arrays():
     i = [False, True, True, False, False, False, False, False, False, True]
     index = (i, slice(None, None, None))
     index = normalize_index(index, (10, 10))
-    c, bd3 = slice_array("y-y", "x", ((3, 3, 3, 1), (3, 3, 3, 1)), index, itemsize=8)
+    c, bd3 = slice_array("y-y", "x", ((3, 3, 3, 1), (3, 3, 3, 1)), index)
     assert bd1 == bd3
     np.testing.assert_equal(a, c)
 
@@ -574,7 +554,7 @@ def test_sanitize_index():
 def test_uneven_blockdims():
     blockdims = ((31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30), (100,))
     index = (slice(240, 270), slice(None))
-    dsk_out, bd_out = slice_array("in", "out", blockdims, index, itemsize=8)
+    dsk_out, bd_out = slice_array("in", "out", blockdims, index)
     sol = {
         ("in", 0, 0): Task(
             ("in", 0, 0),
@@ -594,7 +574,7 @@ def test_uneven_blockdims():
 
     blockdims = ((31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30),) * 2
     index = (slice(240, 270), slice(180, 230))
-    dsk_out, bd_out = slice_array("in", "out", blockdims, index, itemsize=8)
+    dsk_out, bd_out = slice_array("in", "out", blockdims, index)
     sol = {
         ("in", 0, 0): Task(
             ("in", 0, 0),

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -911,23 +911,23 @@ def test_take_avoids_large_chunks():
         index = np.array([0, 1] + [2] * 101 + [3])
         chunks2, dsk = take("a", "b", chunks, index)
         assert chunks2 == ((1,) * 104, (500,), (500,))
-        assert len(dsk) == 106
+        assert len(dsk) == 105
 
         index = np.array([0] * 101 + [1, 2, 3])
         chunks2, dsk = take("a", "b", chunks, index)
         assert chunks2 == ((1,) * 104, (500,), (500,))
-        assert len(dsk) == 106
+        assert len(dsk) == 105
 
         index = np.array([0, 1, 2] + [3] * 101)
         chunks2, dsk = take("a", "b", chunks, index)
         assert chunks2 == ((1,) * 104, (500,), (500,))
-        assert len(dsk) == 106
+        assert len(dsk) == 105
 
         chunks = ((500,), (1, 1, 1, 1), (500,))
         index = np.array([0, 1, 2] + [3] * 101)
         chunks2, dsk = take("a", "b", chunks, index, axis=1)
         assert chunks2 == ((500,), (1,) * 104, (500,))
-        assert len(dsk) == 106
+        assert len(dsk) == 105
 
 
 def test_take_uses_config():

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -11,7 +11,6 @@ np = pytest.importorskip("numpy")
 
 import dask
 import dask.array as da
-from dask import config
 from dask.array.chunk import getitem
 from dask.array.slicing import (
     SlicingNoop,
@@ -928,16 +927,6 @@ def test_take_avoids_large_chunks():
         chunks2, dsk = take("a", "b", chunks, index, axis=1)
         assert chunks2 == ((500,), (1,) * 104, (500,))
         assert len(dsk) == 105
-
-
-def test_take_uses_config():
-    with dask.config.set({"array.slicing.split-large-chunks": True}):
-        chunks = ((1, 1, 1, 1), (500,), (500,))
-        index = np.array([0, 1] + [2] * 101 + [3])
-        with config.set({"array.chunk-size": "10GB"}):
-            chunks2, dsk = take("a", "b", chunks, index)
-        assert chunks2 == ((1,) * 104, (500,), (500,))
-        assert len(dsk) == 106
 
 
 def test_pathological_unsorted_slicing():

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -364,10 +364,10 @@ def blockwise(
     ...     )
     ... )  # doctest: +SKIP
     {
-    ('z', 0, 0): <Task ('z', 0, 0) add(Alias(('x', 0, 0)), Alias(('y', 0, 0)))>,
-    ('z', 0, 1): <Task ('z', 0, 1) add(Alias(('x', 0, 1)), Alias(('y', 0, 1)))>,
-    ('z', 1, 0): <Task ('z', 1, 0) add(Alias(('x', 0, 0)), Alias(('y', 1, 0)))>,
-    ('z', 1, 1): <Task ('z', 1, 1) add(Alias(('x', 0, 1)), Alias(('y', 1, 1)))>
+    ('z', 0, 0): <Task ('z', 0, 0) add(TaskRef(('x', 0, 0)), TaskRef(('y', 0, 0)))>,
+    ('z', 0, 1): <Task ('z', 0, 1) add(TaskRef(('x', 0, 1)), TaskRef(('y', 0, 1)))>,
+    ('z', 1, 0): <Task ('z', 1, 0) add(TaskRef(('x', 0, 0)), TaskRef(('y', 1, 0)))>,
+    ('z', 1, 1): <Task ('z', 1, 1) add(TaskRef(('x', 0, 1)), TaskRef(('y', 1, 1)))>
     }
 
     Include literals by indexing with ``None``
@@ -381,8 +381,8 @@ def blockwise(
     ...         numblocks={'x': (2, )}
     ...     )
     ... )  # doctest: +NORMALIZE_WHITESPACE
-    {('z', 0): <Task ('z', 0) add(Alias(('x', 0)), DataNode(100))>,
-    ('z', 1): <Task ('z', 1) add(Alias(('x', 1)), DataNode(100))>}
+    {('z', 0): <Task ('z', 0) add(TaskRef(('x', 0)), DataNode(100))>,
+    ('z', 1): <Task ('z', 1) add(TaskRef(('x', 1)), DataNode(100))>}
 
     If the broadcasted value is a delayed object or other dask collection, the
     key has to be wrapped appropriately as an Alias object.
@@ -399,8 +399,8 @@ def blockwise(
     ...         numblocks={'x': (2, )}
     ...     )
     ... )  # doctest: +NORMALIZE_WHITESPACE
-    {('z', 0): <Task ('z', 0) add(Alias(('x', 0)), Alias('dinc'))>,
-    ('z', 1): <Task ('z', 1) add(Alias(('x', 1)), Alias('dinc'))>}
+    {('z', 0): <Task ('z', 0) add(TaskRef(('x', 0)), Alias('dinc'))>,
+    ('z', 1): <Task ('z', 1) add(TaskRef(('x', 1)), Alias('dinc'))>}
 
     See Also
     --------

--- a/dask/blockwise.py
+++ b/dask/blockwise.py
@@ -271,10 +271,10 @@ def blockwise(
     ...         numblocks={'x': (2, 2)}
     ...     )
     ... )  # doctest: +NORMALIZE_WHITESPACE
-    {('z', 0, 0): <Task ('z', 0, 0) inc(Alias(('x', 0, 0)))>,
-    ('z', 0, 1): <Task ('z', 0, 1) inc(Alias(('x', 0, 1)))>,
-    ('z', 1, 0): <Task ('z', 1, 0) inc(Alias(('x', 1, 0)))>,
-    ('z', 1, 1): <Task ('z', 1, 1) inc(Alias(('x', 1, 1)))>}
+    {('z', 0, 0): <Task ('z', 0, 0) inc(TaskRef(('x', 0, 0)))>,
+    ('z', 0, 1): <Task ('z', 0, 1) inc(TaskRef(('x', 0, 1)))>,
+    ('z', 1, 0): <Task ('z', 1, 0) inc(TaskRef(('x', 1, 0)))>,
+    ('z', 1, 1): <Task ('z', 1, 1) inc(TaskRef(('x', 1, 1)))>}
 
     Simple operation on two datasets x and y
 
@@ -289,10 +289,10 @@ def blockwise(
     ...         numblocks={'x': (2, 2), 'y': (2, 2)}
     ...     )
     ... )  # doctest: +NORMALIZE_WHITESPACE
-    {('z', 0, 0): <Task ('z', 0, 0) add(Alias(('x', 0, 0)), Alias(('y', 0, 0)))>,
-    ('z', 0, 1): <Task ('z', 0, 1) add(Alias(('x', 0, 1)), Alias(('y', 0, 1)))>,
-    ('z', 1, 0): <Task ('z', 1, 0) add(Alias(('x', 1, 0)), Alias(('y', 1, 0)))>,
-    ('z', 1, 1): <Task ('z', 1, 1) add(Alias(('x', 1, 1)), Alias(('y', 1, 1)))>}
+    {('z', 0, 0): <Task ('z', 0, 0) add(TaskRef(('x', 0, 0)), TaskRef(('y', 0, 0)))>,
+    ('z', 0, 1): <Task ('z', 0, 1) add(TaskRef(('x', 0, 1)), TaskRef(('y', 0, 1)))>,
+    ('z', 1, 0): <Task ('z', 1, 0) add(TaskRef(('x', 1, 0)), TaskRef(('y', 1, 0)))>,
+    ('z', 1, 1): <Task ('z', 1, 1) add(TaskRef(('x', 1, 1)), TaskRef(('y', 1, 1)))>}
 
     Operation that flips one of the datasets
 
@@ -307,10 +307,10 @@ def blockwise(
     ...         numblocks={'x': (2, 2), 'y': (2, 2)}
     ...     )
     ... )  # doctest: +NORMALIZE_WHITESPACE
-    {('z', 0, 0): <Task ('z', 0, 0) addT(Alias(('x', 0, 0)), Alias(('y', 0, 0)))>,
-    ('z', 0, 1): <Task ('z', 0, 1) addT(Alias(('x', 0, 1)), Alias(('y', 1, 0)))>,
-    ('z', 1, 0): <Task ('z', 1, 0) addT(Alias(('x', 1, 0)), Alias(('y', 0, 1)))>,
-    ('z', 1, 1): <Task ('z', 1, 1) addT(Alias(('x', 1, 1)), Alias(('y', 1, 1)))>}
+    {('z', 0, 0): <Task ('z', 0, 0) addT(TaskRef(('x', 0, 0)), TaskRef(('y', 0, 0)))>,
+    ('z', 0, 1): <Task ('z', 0, 1) addT(TaskRef(('x', 0, 1)), TaskRef(('y', 1, 0)))>,
+    ('z', 1, 0): <Task ('z', 1, 0) addT(TaskRef(('x', 1, 0)), TaskRef(('y', 0, 1)))>,
+    ('z', 1, 1): <Task ('z', 1, 1) addT(TaskRef(('x', 1, 1)), TaskRef(('y', 1, 1)))>}
 
     Dot product with contraction over ``j`` index.  Yields list arguments
 
@@ -326,24 +326,25 @@ def blockwise(
     ... )  # doctest: +SKIP
     {('z', 0,  0):
         <Task ('z', 0, 0) dotmany(
-        List((Alias(('x', 0, 0)), Alias(('x', 0, 1)))),
-        List((Alias(('y', 0, 0)), Alias(('y', 1, 0)))))
+            List((TaskRef(('x', 0, 0)), TaskRef(('x', 0, 1)))),
+            List((TaskRef(('y', 0, 0)), TaskRef(('y', 1, 0)))))
         >,
     ('z', 0,  1):
         <Task ('z', 0, 1) dotmany(
-        List((Alias(('x', 0, 0)), Alias(('x', 0, 1)))),
-        List((Alias(('y', 0, 1)), Alias(('y', 1, 1)))))
+            List((TaskRef(('x', 0, 0)), TaskRef(('x', 0, 1)))),
+            List((TaskRef(('y', 0, 1)), TaskRef(('y', 1, 1)))))
         >,
     ('z', 1,  0):
         <Task ('z', 1, 0) dotmany(
-        List((Alias(('x', 1, 0)), Alias(('x', 1, 1)))),
-        List((Alias(('y', 0, 0)), Alias(('y', 1, 0)))))
+            List((TaskRef(('x', 1, 0)), TaskRef(('x', 1, 1)))),
+            List((TaskRef(('y', 0, 0)), TaskRef(('y', 1, 0)))
+        )
         >,
-    ('z', 1,  1):
+    ('z', 1, 1):
         <Task ('z', 1, 1) dotmany(
-        List((Alias(('x', 1, 0)), Alias(('x', 1, 1)))),
-        List((Alias(('y', 0, 1)), Alias(('y', 1, 1)))))
-        >
+            List((TaskRef(('x', 1, 0)), TaskRef(('x', 1, 1)))),
+            List((TaskRef(('y', 0, 1)), TaskRef(('y', 1, 1)))
+        )
     }
 
     Pass ``concatenate=True`` to concatenate arrays ahead of time.

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -153,7 +153,7 @@ def unpack_collections(expr, _return_collections=True):
     >>> b = delayed(2, 'b')
     >>> task, collections = unpack_collections([a, b, 3])
     >>> task
-    List((Alias('a'), Alias('b'), 3))
+    List((TaskRef('a'), TaskRef('b'), 3))
     >>> collections
     (Delayed('a'), Delayed('b'))
 

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -159,7 +159,7 @@ def unpack_collections(expr, _return_collections=True):
 
     >>> task, collections = unpack_collections({a: 1, b: 2})
     >>> task
-    Dict(Alias('a'): 1, Alias('b'): 2)
+    Dict(a: 1, b: 2)
     >>> collections
     (Delayed('a'), Delayed('b'))
     """

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import codecs
 import functools
+import gc
 import inspect
 import os
 import re
@@ -12,7 +13,7 @@ import types
 import uuid
 import warnings
 from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping, Set
-from contextlib import contextmanager, nullcontext, suppress
+from contextlib import ContextDecorator, contextmanager, nullcontext, suppress
 from datetime import datetime, timedelta
 from errno import ENOENT
 from functools import wraps
@@ -2304,3 +2305,20 @@ def unzip(ls, nout):
     if not out:
         out = [()] * nout
     return out
+
+
+class disable_gc(ContextDecorator):
+    """Context manager to disable garbage collection."""
+
+    def __init__(self, collect=False):
+        self.collect = collect
+        self._gc_enabled = gc.isenabled()
+
+    def __enter__(self):
+        gc.disable()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._gc_enabled:
+            gc.enable()
+        return False

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -742,6 +742,8 @@ class Dispatch:
     def dispatch(self, cls):
         """Return the function implementation for the given ``cls``"""
         lk = self._lookup
+        if cls in lk:
+            return lk[cls]
         for cls2 in cls.__mro__:
             # Is a lazy registration function present?
             toplevel, _, _ = cls2.__module__.partition(".")
@@ -752,7 +754,10 @@ class Dispatch:
             else:
                 register()
                 self._lazy.pop(toplevel, None)
-                return self.dispatch(cls)  # recurse
+                meth = self.dispatch(cls)  # recurse
+                lk[cls] = meth
+                lk[cls2] = meth
+                return meth
             try:
                 impl = lk[cls2]
             except KeyError:


### PR DESCRIPTION
This cleans up a couple of things around slicing to speed it up and restore it to its old performance. 

Closes https://github.com/dask/dask/issues/11735 (it's arguable whether it actually closes the ticket since some things are still a bit slower)

When comparing the old slicing performance with the new one, it is also important to note that the new slicing operation implements a shuffle for most nontrivial operations which is slower during graph generation but orders of magnitude better during runtime for most, if not all, affected operations.

There are many smaller performance fixes in here. However, the majority of speedup stems from disabling automatic garbage collection while this is running.


```

# Very old version
▶ python profile_slicing.py
Dask version: 2024.9.0
Empty indexer (all)                     :       0.01 ms
Every second element (::2)              :     146.57 ms
All but last element (:-1)              :     330.51 ms
Multi dim one slice (0, slice(None))    :      62.01 ms
Multi dim (0, slice(None, None, 2))     :      33.58 ms
Multi dim (0, slice(None, -1))          :      65.67 ms


# Main
(dask-distributed)
~/workspace/dask  ae250c9ac ✗                                                                                                                                                                                                         240d17h ◒
▶ python profile_slicing.py
Dask version: 2025.4.1+8.g4914f2f58
Empty indexer (all)                     :       0.01 ms
Every second element (::2)              :     467.75 ms
All but last element (:-1)              :     636.76 ms
Multi dim one slice (0, slice(None))    :     550.30 ms
Multi dim (0, slice(None, None, 2))     :     254.68 ms
Multi dim (0, slice(None, -1))          :     498.62 ms


# this PR
(dask-distributed)
~/workspace/dask  main ✗                                                                                                                                                                                                                 7d7h ◒
▶ python profile_slicing.py
Dask version: 2025.4.1+22.g2e6c80732
Empty indexer (all)                     :       0.02 ms
Every second element (::2)              :     156.41 ms
All but last element (:-1)              :     246.63 ms
Multi dim one slice (0, slice(None))    :     168.82 ms
Multi dim (0, slice(None, None, 2))     :      84.51 ms
Multi dim (0, slice(None, -1))          :     185.94 ms
```


<details>
<summary>Benchmark code</summary>

```python
import time
import dask.array as da
import dask

print(f"Dask version: {dask.__version__}")

x = da.ones((100_000,), chunks=(1,))
niterations = 5


def benchmark(arr, indexer, identifier):
    try:
        start = time.perf_counter()
        for i in range(niterations):
            arr[indexer]
        end = time.perf_counter()
        print(f"{identifier:<40}: {(end - start)/niterations * 1000:>10.2f} ms")
    except Exception as e:
        print(f"Error with {identifier}: {e}")
        return


benchmark(x, slice(None, None, None), "Empty indexer (all)")
benchmark(x, slice(None, None, 2), "Every second element (::2)")
benchmark(x, slice(None, -1), "All but last element (:-1)")

x = da.ones((100, 1000, 100), chunks=(-1, 1, 1))

benchmark(x, (1, slice(None)), "Multi dim one slice (0, slice(None))")
benchmark(x, (1, slice(None, None, 2)), "Multi dim (0, slice(None, None, 2))")
benchmark(x, (1, slice(None, -1)), "Multi dim (0, slice(None, -1))")
```

</details>