### PR TITLE
Optimize slicing graph generation

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -325,31 +325,40 @@ def slice_slices_and_integers(
     sorted_block_slices = [sorted(i.items()) for i in block_slices]
 
     # (in_name, 1, 1, 2), (in_name, 1, 1, 4), (in_name, 2, 1, 2), ...
-    in_names = list(product([in_name], *[pluck(0, s) for s in sorted_block_slices]))
+    in_names = product([in_name], *[pluck(0, s) for s in sorted_block_slices])
 
     # (out_name, 0, 0, 0), (out_name, 0, 0, 1), (out_name, 0, 1, 0), ...
-    out_names = list(
-        product(
-            [out_name],
-            *[
-                range(len(d))[::-1] if i.step and i.step < 0 else range(len(d))
-                for d, i in zip(block_slices, index)
-                if not isinstance(i, Integral)
-            ],
-        )
+    out_names = product(
+        [out_name],
+        *[
+            range(len(d))[::-1] if i.step and i.step < 0 else range(len(d))
+            for d, i in zip(block_slices, index)
+            if not isinstance(i, Integral)
+        ],
     )
 
-    all_slices = list(product(*[pluck(1, s) for s in sorted_block_slices]))
-
-    dsk_out = {
-        out_name: (
-            Task(out_name, getitem, TaskRef(in_name), slices)
-            if not allow_getitem_optimization
-            or not all(sl == slice(None, None, None) for sl in slices)
-            else Alias(out_name, in_name)
+    all_slices = product(*[pluck(1, s) for s in sorted_block_slices])
+    if not allow_getitem_optimization:
+        dsk_out = {
+            out_name: (Task(out_name, getitem, TaskRef(in_name), slices))
+            for out_name, in_name, slices in zip(out_names, in_names, all_slices)
+        }
+    else:
+        all_slices = list(all_slices)
+        empty_slice = slice(None, None, None)
+        not_all_empty_slices = list(
+            not all(sl == empty_slice for sl in slices) for slices in all_slices
         )
-        for out_name, in_name, slices in zip(out_names, in_names, all_slices)
-    }
+        dsk_out = {
+            out_name: (
+                Task(out_name, getitem, TaskRef(in_name), slices)
+                if all_empty_slices
+                else Alias(out_name, in_name)
+            )
+            for out_name, in_name, all_empty_slices, slices in zip(
+                out_names, in_names, not_all_empty_slices, all_slices
+            )
+        }
 
     new_blockdims = [
         new_blockdim(d, db, i)


### PR DESCRIPTION
This shaves off another 20-30% of the slicing case presented in https://github.com/dask/dask/issues/11735#issuecomment-2876708328

On this PR I get something like 900-1000ms
Main is somewhere between 1200-1300ms
Pre-Task-class: ~750ms

So, we're still about 70% slower than the 2024.X versions. I ran some more realistic end-to-end benchmarks that includes optimization, dependency calculation and materialization and with this we're either equally slow or faster than we were on the 2024.11.2 version.

```
Dask version: 2024.11.2
Empty indexer (all)                     :    2086.02 ms
Every second element (::2)              :    2503.59 ms
All but last element (:-1)              :    4553.73 ms
Multi dim one slice (0, slice(None))    :    5283.48 ms
Multi dim (0, slice(None, None, 2))     :    2486.43 ms
Multi dim (0, slice(None, -1))          :    4965.22 ms
Multi dim (slice(None, -1), slice(None, 10)):   11988.26 ms
(dask-distributed)
~/workspace/dask  f0e08da76 ✗                                                                                                                                                                                                      181d22h ◒

# This PR
▶ python profile_slicing.py
Dask version: 2025.4.1+16.g0a0f974b2
Empty indexer (all)                     :    2196.06 ms
Every second element (::2)              :    2177.34 ms
All but last element (:-1)              :    4955.38 ms
Multi dim one slice (0, slice(None))    :    4464.50 ms
Multi dim (0, slice(None, None, 2))     :    2201.39 ms
Multi dim (0, slice(None, -1))          :    4561.45 ms
Multi dim (slice(None, -1), slice(None, 10)):   10419.56 ms

```

```python
from __future__ import annotations

import statistics
import time

import dask
import dask.array as da
from dask.core import get_deps
from dask.utils import ensure_dict

try:
    from dask.base import collections_to_expr

    new_style = True
except ImportError:
    from dask.base import collections_to_dsk

    new_style = False


print(f"Dask version: {dask.__version__}")

niterations = 10


def benchmark(shape, chunks, indexer, identifier):
    try:
        durations = []
        for i in range(niterations):
            arr = da.ones(shape, chunks=chunks)
            start = time.perf_counter()
            new = arr[indexer]
            if new_style:
                dsk = collections_to_expr([new]).optimize().__dask_graph__()
            else:
                dsk = ensure_dict(collections_to_dsk([new]))
            get_deps(dsk)
            end = time.perf_counter()
            durations.append(end - start)
        print(
            f"{identifier:<40}: {sum(durations)/niterations * 1000:>10.2f} ms"
            # ± {statistics.stdev(durations):.2f} ms"
        )
    except Exception as e:
        print(f"Error with {identifier}: {e}")
        return


benchmark((100_000,), (1,), slice(None, None, None), "Empty indexer (all)")
benchmark((100_000,), (1,), slice(None, None, 2), "Every second element (::2)")
benchmark((100_000,), (1,), slice(None, -1), "All but last element (:-1)")


benchmark(
    (100, 1000, 100),
    (-1, 1, 1),
    (1, slice(None)),
    "Multi dim one slice (0, slice(None))",
)
benchmark(
    (100, 1000, 100),
    (-1, 1, 1),
    (1, slice(None, None, 2)),
    "Multi dim (0, slice(None, None, 2))",
)
benchmark(
    (100, 1000, 100), (-1, 1, 1), (1, slice(None, -1)), "Multi dim (0, slice(None, -1))"
)

benchmark(
    (1000, 35, 720, 1440, 31),
    (1, -1, 72, 72, -1),
    (slice(None, -1), slice(None, 10)),
    "Multi dim (slice(None, -1), slice(None, 10))",
)

```