### PR TITLE
Fix xarray slicing regression

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -590,7 +590,14 @@ def take(outname, inname, chunks, index, axis=0):
 
         arange = arange_safe(np.sum(chunks[axis]), like=index)
         if len(index) == len(arange) and np.abs(index - arange).sum() == 0:
-            raise SlicingNoop()
+            # TODO: This should be a real no-op, but the call stack is
+            # too deep to do this efficiently for now
+            chunk_tuples = list(product(*(range(len(c)) for i, c in enumerate(chunks))))
+            graph = {
+                (outname,) + c: Alias((outname,) + c, (inname,) + c)
+                for c in chunk_tuples
+            }
+            return tuple(chunks), graph
 
         average_chunk_size = int(sum(chunks[axis]) / len(chunks[axis]))
 

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -592,7 +592,7 @@ def take(outname, inname, chunks, index, axis=0):
         if len(index) == len(arange) and np.abs(index - arange).sum() == 0:
             # TODO: This should be a real no-op, but the call stack is
             # too deep to do this efficiently for now
-            chunk_tuples = list(product(*(range(len(c)) for i, c in enumerate(chunks))))
+            chunk_tuples = product(*(range(len(c)) for i, c in enumerate(chunks)))
             graph = {
                 (outname,) + c: Alias((outname,) + c, (inname,) + c)
                 for c in chunk_tuples

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -334,8 +334,9 @@ def test_take_sorted():
     chunks, dsk = take("y-y", "x", [(20, 20, 20, 20)], [1, 3, 5, 47], axis=0)
     assert len(dsk) == 6
     assert chunks == ((4,),)
-    with pytest.raises(SlicingNoop):
-        take("y", "x", [(20, 20, 20, 20)], np.arange(0, 80), axis=0)
+    chunks, dsk = take("y", "x", [(20, 20, 20, 20)], np.arange(0, 80), axis=0)
+    assert len(dsk) == 4
+    assert chunks == ((20, 20, 20, 20),)
 
 
 def test_slicing_chunks():

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -259,6 +259,13 @@ def test_slice_array_2d():
     assert expected == result
 
 
+def test_mixed_index():
+    da_array = da.ones((1, 1, 31, 40))
+    new = da_array[(np.array([0]), 0, slice(None), slice(None))]
+    assert isinstance(new, da.Array)
+    assert_eq(new, da_array[0])
+
+
 def test_slice_optimizations():
     # bar[:]
     with pytest.raises(SlicingNoop):

--- a/dask/array/tests/test_xarray.py
+++ b/dask/array/tests/test_xarray.py
@@ -154,3 +154,13 @@ def test_shared_tasks(wrap_xarray):
     else:
         assert isinstance(comp_res[0], np.ndarray)
     assert total_calls == in1.blocks.size
+
+
+def test_slicing():
+    ds = xr.Dataset(
+        {"z": (("t", "p", "y", "x"), np.ones((1, 1, 31, 40)))},
+    )
+    ds = ds.chunk()
+    subset = ds.isel(t=[0], p=0).z[:, ::10, ::10][:, ::-1, :]
+    subset2 = ds.isel(t=[0]).isel(p=0).z[:, ::10, ::10][:, ::-1, :]
+    assert_eq(subset.data, subset2.data)


### PR DESCRIPTION
Turns out removing this operation is not entirely safe. I wasn't truly able to understand why it is unsafe. The dask case is generating a corrupt graph while the xarray case raises a ` ValueError: dimensions` exception with this reproducer

closes https://github.com/pydata/xarray/issues/10321

This reverts a performance optimization introduced to address https://github.com/dask/dask/issues/11735