### PR TITLE
Dont handle tuple in task_spec.parse_input

### DIFF
--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -143,17 +143,13 @@ def parse_input(obj: Any) -> object:
         if any(isinstance(v, GraphNode) for v in parsed_dict.values()):
             return Dict(parsed_dict)
 
-    if isinstance(obj, (list, set, tuple)):
+    if isinstance(obj, (list, set)):
         parsed_collection = tuple(parse_input(o) for o in obj)
         if any(isinstance(o, GraphNode) for o in parsed_collection):
             if isinstance(obj, list):
                 return List(*parsed_collection)
             if isinstance(obj, set):
                 return Set(*parsed_collection)
-            if isinstance(obj, tuple):
-                if is_namedtuple_instance(obj):
-                    return _wrap_namedtuple_task(None, obj, parse_input)
-                return Tuple(*parsed_collection)
 
     return obj
 

--- a/dask/tests/test_task_spec.py
+++ b/dask/tests/test_task_spec.py
@@ -499,32 +499,6 @@ def test_parse_graph_namedtuple_legacy(typ, args, kwargs):
     assert new_dsk["foo"]() == typ(*args, **kwargs)
 
 
-@pytest.mark.parametrize(
-    "typ, args, kwargs",
-    [
-        (PlainNamedTuple, ["some-data"], {}),
-        (NewArgsNamedTuple, ["some", "data", "more"], {}),
-        (NewArgsExNamedTuple, ["some", "data", "more"], {"another": "data"}),
-    ],
-)
-def test_parse_namedtuple(typ, args, kwargs):
-    def func(x):
-        return x
-
-    obj = typ(*args, **kwargs)
-    t = Task("foo", func, parse_input(obj))
-
-    assert t() == obj
-
-    # The other test tuple do weird things to their input
-    if typ is PlainNamedTuple:
-        args = tuple([TaskRef("b")] + list(args)[1:])
-        obj = typ(*args, **kwargs)
-        t = Task("foo", func, parse_input(obj))
-        assert t.dependencies == {"b"}
-        assert t({"b": "foo"}) == typ(*tuple(["foo"] + list(args)[1:]), **kwargs)
-
-
 def test_pickle_literals():
     np = pytest.importorskip("numpy")
     obj = DataNode("foo", np.transpose)


### PR DESCRIPTION
This is also an improvement in the slicing optimization context I've been working on the last days. This piece of code is slowing down graph generation of a blockwise graph in a nontrivial way (like 10-20%).

I think removing the recursion into tuples is in alignment with other functions we use to walk collections. CI seems to agree for now.