### PR TITLE
(fix): `name` not passed to `blockwise`

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -818,7 +818,7 @@ def map_blocks(
         )
         name = token
 
-    token = f"{name or funcname(func)}"
+    name = f"{name or funcname(func)}"
     new_axes = {}
 
     if isinstance(drop_axis, Number):
@@ -892,7 +892,7 @@ def map_blocks(
             *concat(argpairs),
             expected_ndim=len(out_ind),
             _func=func,
-            token=token,
+            name=name,
             new_axes=new_axes,
             dtype=dtype,
             concatenate=True,
@@ -906,7 +906,7 @@ def map_blocks(
             func,
             out_ind,
             *concat(argpairs),
-            token=token,
+            name=name,
             new_axes=new_axes,
             dtype=dtype,
             concatenate=True,

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3699,6 +3699,11 @@ def test_map_blocks_with_invalid_drop_axis():
             )
 
 
+def test_map_blocks_custom_name():
+    res = da.map_blocks(lambda _: np.arange(4), chunks=(4,), name="foo", dtype=np.int64)
+    assert res.name == "foo", res.name
+
+
 def test_map_blocks_with_changed_dimension_and_broadcast_chunks():
     # https://github.com/dask/dask/issues/4299
     a = da.from_array([1, 2, 3], 3)


### PR DESCRIPTION
I think my intention is clear here although I'm genuinely unsure of how to go about it.  I _think_ this is the intended behavior given that `token` is meant to be deprecated and the only place it is used inside `blockwise` is in the case where `name` is not `None`

- [x] See https://github.com/scverse/anndata/issues/1989
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
