### PR TITLE
Revert "Dont handle tuple in task_spec.parse_input"

### DIFF
--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -143,13 +143,17 @@ def parse_input(obj: Any) -> object:
         if any(isinstance(v, GraphNode) for v in parsed_dict.values()):
             return Dict(parsed_dict)
 
-    if isinstance(obj, (list, set)):
+    if isinstance(obj, (list, set, tuple)):
         parsed_collection = tuple(parse_input(o) for o in obj)
         if any(isinstance(o, GraphNode) for o in parsed_collection):
             if isinstance(obj, list):
                 return List(*parsed_collection)
             if isinstance(obj, set):
                 return Set(*parsed_collection)
+            if isinstance(obj, tuple):
+                if is_namedtuple_instance(obj):
+                    return _wrap_namedtuple_task(None, obj, parse_input)
+                return Tuple(*parsed_collection)
 
     return obj
 


### PR DESCRIPTION
Reverts dask/dask#11948

This broke a bunch of things in distributed