### PR TITLE
Fix dtype preservation in str.split for string[pyarrow]

### DIFF
--- a/dask/dataframe/dask_expr/_str_accessor.py
+++ b/dask/dataframe/dask_expr/_str_accessor.py
@@ -182,13 +182,17 @@ class SplitMap(FunctionMap):
     @functools.cached_property
     def _meta(self):
         delimiter = " " if self.pat is None else self.pat
+
         meta = meta_nonempty(self.frame._meta)
-        sample_dtype = self.frame._meta.dtypes
+
+        sample_dtype = self.frame._meta.dtype
+
         meta = self.frame._meta._constructor(
             [delimiter.join(["a"] * (self.n + 1))],
             index=meta.iloc[:1].index,
             dtype=sample_dtype if not self.expand else None,
         )
+
         meta = getattr(meta.str, self.attr)(n=self.n, expand=self.expand, pat=self.pat)
 
         if self.expand:

--- a/dask/dataframe/dask_expr/_str_accessor.py
+++ b/dask/dataframe/dask_expr/_str_accessor.py
@@ -183,10 +183,16 @@ class SplitMap(FunctionMap):
     def _meta(self):
         delimiter = " " if self.pat is None else self.pat
         meta = meta_nonempty(self.frame._meta)
+        sample_dtype = self.frame._meta.dtypes
         meta = self.frame._meta._constructor(
             [delimiter.join(["a"] * (self.n + 1))],
             index=meta.iloc[:1].index,
+            dtype=sample_dtype if not self.expand else None,
         )
-        return make_meta(
-            getattr(meta.str, self.attr)(n=self.n, expand=self.expand, pat=self.pat)
-        )
+        meta = getattr(meta.str, self.attr)(n=self.n, expand=self.expand, pat=self.pat)
+
+        if self.expand:
+            for col in meta.columns:
+                meta[col] = meta[col].astype(sample_dtype)
+
+        return make_meta(meta)

--- a/dask/dataframe/dask_expr/tests/test_string_accessor.py
+++ b/dask/dataframe/dask_expr/tests/test_string_accessor.py
@@ -157,3 +157,19 @@ def test_partition():
     result = df[1]
     expected = pd.DataFrame.from_dict({"A": ["A|B", "C|D"]})["A"].str.partition("|")[1]
     assert_eq(result, expected)
+
+
+def test_str_split_preserves_pyarrow_dtype():
+    import pandas as pd
+
+    import dask.dataframe as dd
+
+    df = pd.DataFrame({"col": ["a,b", "c,d"]}, dtype="string[pyarrow]")
+    ddf = dd.from_pandas(df, npartitions=1)
+
+    result = ddf["col"].str.split(",", expand=True, n=1)
+
+    assert all(dtype == "string[pyarrow]" for dtype in result.dtypes)
+
+    computed = result.compute()
+    assert all(dtype == "string[pyarrow]" for dtype in computed.dtypes)

--- a/dask/dataframe/tests/test_pyarrow.py
+++ b/dask/dataframe/tests/test_pyarrow.py
@@ -182,16 +182,3 @@ def test_is_object_string_series(series, expected):
 )
 def tests_is_object_string_dataframe(series, expected):
     assert is_object_string_dataframe(series) is expected
-
-
-def test_str_split_preserves_pyarrow_dtype():
-    import pandas as pd
-
-    import dask.dataframe as dd
-
-    df = pd.DataFrame({"col": ["a,b", "c,d"]}, dtype="string[pyarrow]")
-    ddf = dd.from_pandas(df, npartitions=1)
-
-    result = ddf["col"].str.split(",", expand=True, n=1)
-
-    assert all(dtype == "string[pyarrow]" for dtype in result.dtypes)

--- a/dask/dataframe/tests/test_pyarrow.py
+++ b/dask/dataframe/tests/test_pyarrow.py
@@ -182,3 +182,16 @@ def test_is_object_string_series(series, expected):
 )
 def tests_is_object_string_dataframe(series, expected):
     assert is_object_string_dataframe(series) is expected
+
+
+def test_str_split_preserves_pyarrow_dtype():
+    import pandas as pd
+
+    import dask.dataframe as dd
+
+    df = pd.DataFrame({"col": ["a,b", "c,d"]}, dtype="string[pyarrow]")
+    ddf = dd.from_pandas(df, npartitions=1)
+
+    result = ddf["col"].str.split(",", expand=True, n=1)
+
+    assert all(dtype == "string[pyarrow]" for dtype in result.dtypes)


### PR DESCRIPTION
Closes #11884
Supersedes #11955

### What does this PR do?

Fixes an issue where using `.str.split(..., expand=True)` on a column with `string[pyarrow]` dtype would result in `object` dtype outputs.

This PR updates `_meta` construction in the string accessor to preserve the original dtype for all columns resulting from the split.

### Why is this important?

It ensures dtype consistency with pandas and prevents downstream type issues when using pyarrow-backed string columns.

### Tests

-  Added a test to `test_pyarrow.py`
-  Test confirms that split columns retain `string[pyarrow]` dtype
-  All existing tests pass

- [x] Closes #11884
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

