### PR TITLE
Account for ``__main__`` in ``pickle`` normalization

### DIFF
--- a/dask/tests/test_tokenize.py
+++ b/dask/tests/test_tokenize.py
@@ -1205,6 +1205,18 @@ def test_tokenize_functions_main():
         return y + 1
 
     assert tokenize(inc2) != tokenize(inc)
+
+    # Test that redefining a function changes the token
+    def func(x):
+        return x + 1
+
+    result = tokenize(func)
+
+    def func(x):
+        return x + 2
+
+    result2 = tokenize(func)
+    assert result != result2
     """
     proc = subprocess.run([sys.executable, "-c", textwrap.dedent(script)])
     proc.check_returncode()


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/11964 

In https://github.com/dask/dask/pull/11320 we dropped logic that checks for if an object is defined in `__main__` (where `cloudpickle` should be used instead of `pickle`). Specifically these lines https://github.com/dask/dask/pull/11320/files#diff-10422b02c591d63ee295724faa14f7698b4a742c98ba20771c5f70d1a6926d06L1240-L1243

This PR proposes we just always use `cloudpickle` instead of `pickle` first and then, if some conditions are met, going to `cloudpickle` instead (though I'll admit I'm not totally sure why the previous "try pickle first" logic existed). Another option would be to restore the `if b"__main__" in pik:` logic. 

cc @hendrikmakait 