### PR TITLE
Implement distributed Kronecker product (kron) for Dask Array

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -919,10 +919,9 @@ if _array_expr_enabled():
         from_tiledb = raise_not_implemented_error("from_tiledb")
         to_tiledb = raise_not_implemented_error("to_tiledb")
 
+        from dask.array.kron import kron
         from dask.array.utils import assert_eq
         from dask.base import compute
-        from .kron import kron
-
 
     except ImportError:
         import dask.array as da  # type: ignore

--- a/dask/array/kron.py
+++ b/dask/array/kron.py
@@ -1,8 +1,12 @@
 # dask/array/kron.py
 
+from __future__ import annotations
+
 import numpy as np
+
 import dask.array as da
 from dask.array.blockwise import blockwise
+
 
 def kron(x, y):
     """
@@ -45,12 +49,14 @@ def kron(x, y):
     # np.kron(x_block, y_block) with shape ((i1-i0)*(k1-k0), (j1-j0)*(l1-l0))
     # np.kron(x_block, y_block) de forma ((i1-i0)*(k1-k0), (j1-j0)*(l1-l0))
     return blockwise(
-        np.kron,                # function to apply per block / función por bloque
-        "ab",                   # output axes / ejes de salida
-        x, "ij",                # x has axes i,j / x tiene ejes i,j
-        y, "kl",                # y has axes k,l / y tiene ejes k,l
+        np.kron,  # function to apply per block / función por bloque
+        "ab",  # output axes / ejes de salida
+        x,
+        "ij",  # x has axes i,j / x tiene ejes i,j
+        y,
+        "kl",  # y has axes k,l / y tiene ejes k,l
         dtype=dtype,
-        concatenate=True,       # concatenate resulting blocks / concatena bloques
+        concatenate=True,  # concatenate resulting blocks / concatena bloques
         new_axes={
             "a": x.shape[0] * y.shape[0],  # total size of axis a / tamaño total eje a
             "b": x.shape[1] * y.shape[1],  # total size of axis b / tamaño total eje b

--- a/dask/array/tests/test_kron.py
+++ b/dask/array/tests/test_kron.py
@@ -1,9 +1,13 @@
-#test_kron.py
+# test_kron.py
+from __future__ import annotations
+
 import numpy as np
-import dask.array as da
 import pytest
+
+import dask.array as da
 from dask.array.kron import kron
 from dask.array.utils import assert_eq
+
 
 def test_kron_1d():
     """
@@ -12,46 +16,52 @@ def test_kron_1d():
     """
     # Test del caso unidimensional:
     # Calcula el producto de Kronecker entre dos vectores 1D
-    x_np = np.array([1, 2, 3])               # array NumPy base
-    y_np = np.array([4, 5])                  # otro array NumPy base
-    x = da.from_array(x_np, chunks=(2,))     # Dask Array con chunks de tamaño 2
-    y = da.from_array(y_np, chunks=(1,))     # Dask Array con chunks de tamaño 1
-    result = kron(x, y)                      # resultado Dask
-    expected = np.kron(x_np, y_np)           # resultado NumPy
-    assert_eq(result, expected)              # comprueba valores y chunks
+    x_np = np.array([1, 2, 3])  # array NumPy base
+    y_np = np.array([4, 5])  # otro array NumPy base
+    x = da.from_array(x_np, chunks=(2,))  # Dask Array con chunks de tamaño 2
+    y = da.from_array(y_np, chunks=(1,))  # Dask Array con chunks de tamaño 1
+    result = kron(x, y)  # resultado Dask
+    expected = np.kron(x_np, y_np)  # resultado NumPy
+    assert_eq(result, expected)  # comprueba valores y chunks
+
 
 def test_kron_rectangular():
     # Test de matrices rectangulares (1×3 por 2×1):
-    x_np = np.array([[1, 2, 3]])             # matriz de forma (1,3)
-    y_np = np.array([[0], [1]])              # matriz de forma (2,1)
-    x = da.from_array(x_np, chunks=(1, 2))   # chunks: 1 fila, 2 columnas
-    y = da.from_array(y_np, chunks=(1, 1))   # chunks: 1 fila, 1 columna
+    x_np = np.array([[1, 2, 3]])  # matriz de forma (1,3)
+    y_np = np.array([[0], [1]])  # matriz de forma (2,1)
+    x = da.from_array(x_np, chunks=(1, 2))  # chunks: 1 fila, 2 columnas
+    y = da.from_array(y_np, chunks=(1, 1))  # chunks: 1 fila, 1 columna
     result = kron(x, y)
     expected = np.kron(x_np, y_np)
     assert_eq(result, expected)
+
 
 def test_kron_empty():
     # Test de arrays con dimensión vacía:
     # Cuando uno de los arrays tiene tamaño cero, debe funcionar sin errores
-    x_np = np.empty((0, 3))                  # matriz de 0 filas y 3 columnas
-    y_np = np.array([[1, 2], [3, 4]])        # matriz de 2×2 normal
-    x = da.from_array(x_np, chunks=(0, 3))   # chunk de 0×3
-    y = da.from_array(y_np, chunks=(2, 1))   # chunk de 2 filas, 1 columna
+    x_np = np.empty((0, 3))  # matriz de 0 filas y 3 columnas
+    y_np = np.array([[1, 2], [3, 4]])  # matriz de 2×2 normal
+    x = da.from_array(x_np, chunks=(0, 3))  # chunk de 0×3
+    y = da.from_array(y_np, chunks=(2, 1))  # chunk de 2 filas, 1 columna
     result = kron(x, y)
     expected = np.kron(x_np, y_np)
     assert_eq(result, expected)
 
-@pytest.mark.parametrize("shape_x, chunks_x, shape_y, chunks_y, dtype", [
-    # Parámetros de test para escenarios más “reales”:
-    # 1) Matrices grandes pero un solo bloque (todo en memoria)
-    ((100, 50),  (100, 50),  (20, 10),  (20, 10),  int),
-    # 2) Matrices medianas con múltiples bloques
-    ((30, 40),   (10, 20),   (15, 10),  (5, 5),    float),
-    # 3) Vectores 1D con chunks mixtos (fuerza el fallback de NumPy)
-    ((5,),       (2,),       (7,),      (3,),      int),
-    # 4) Promoción de dtype: mezcla float e int
-    ((10, 10),   (3, 7),     (8, 6),    (4, 2),    float),
-])
+
+@pytest.mark.parametrize(
+    "shape_x, chunks_x, shape_y, chunks_y, dtype",
+    [
+        # Parámetros de test para escenarios más “reales”:
+        # 1) Matrices grandes pero un solo bloque (todo en memoria)
+        ((100, 50), (100, 50), (20, 10), (20, 10), int),
+        # 2) Matrices medianas con múltiples bloques
+        ((30, 40), (10, 20), (15, 10), (5, 5), float),
+        # 3) Vectores 1D con chunks mixtos (fuerza el fallback de NumPy)
+        ((5,), (2,), (7,), (3,), int),
+        # 4) Promoción de dtype: mezcla float e int
+        ((10, 10), (3, 7), (8, 6), (4, 2), float),
+    ],
+)
 def test_kron_various(shape_x, chunks_x, shape_y, chunks_y, dtype):
     """
     Parametrized test for various shapes, chunkings, and dtypes.
@@ -71,6 +81,7 @@ def test_kron_various(shape_x, chunks_x, shape_y, chunks_y, dtype):
     # Comprueba que resultado Dask == resultado NumPy, incluyendo chunking
     assert_eq(result, expected)
 
+
 def test_kron_random_property():
     """
     Smoke test with random small shapes and values.
@@ -84,10 +95,10 @@ def test_kron_random_property():
         shape_x = (nx, ny)
         shape_y = (mx, my)
         # Define chunks que dividen cada dimensión en dos (al menos 1)
-        chunks_x = (max(1, nx//2), max(1, ny//2))
-        chunks_y = (max(1, mx//2), max(1, my//2))
+        chunks_x = (max(1, nx // 2), max(1, ny // 2))
+        chunks_y = (max(1, mx // 2), max(1, my // 2))
 
-        x_np = rng.standard_normal(shape_x)   # datos float aleatorios
+        x_np = rng.standard_normal(shape_x)  # datos float aleatorios
         y_np = rng.standard_normal(shape_y)
 
         x = da.from_array(x_np, chunks=chunks_x)
@@ -95,6 +106,7 @@ def test_kron_random_property():
 
         # La propiedad central: kron(x,y) debe coincidir con np.kron
         assert_eq(kron(x, y), np.kron(x_np, y_np))
+
 
 def test_kron_medium_reduction_compute():
     """
@@ -107,7 +119,7 @@ def test_kron_medium_reduction_compute():
     """
     # Creamos arrays de 1.000.000 de elementos (200×50 y 50×20)
     x_np = np.ones((200, 50), dtype=float)
-    y_np = np.ones(( 50, 20), dtype=float)
+    y_np = np.ones((50, 20), dtype=float)
 
     # Convertimos a Dask Array con chunks pequeños que quepan en memoria
     x = da.from_array(x_np, chunks=(50, 25))


### PR DESCRIPTION
Adds dask/array/kron.py with the kron function using blockwise for 2D arrays.
Supports fallback to NumPy for 1D, empty, or ND>2 cases.
Includes comprehensive unit tests in tests/test_kron.py (basic, random, and reduction cases).

Implementa producto de Kronecker distribuido (kron) para Dask Array

- Añade dask/array/kron.py con la función kron usando blockwise para arrays 2D.
- Soporta fallback a NumPy para casos 1D, vacíos o ND>2.
- Incluye pruebas unitarias variadas en tests/test_kron.py (básicos, aleatorios y reducción).

- [x]Closes #3657
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

