### PR TITLE
 Make module name logic more resilient in ``Dispatch``

### DIFF
--- a/continuous_integration/environment-3.12.yaml
+++ b/continuous_integration/environment-3.12.yaml
@@ -76,6 +76,4 @@ dependencies:
   - matplotlib  # visualize test
   - pip
   - pip:
-    # TODO: Revert before merging
-    - git+https://github.com/jrbourbeau/distributed.git@_always_use_pickle_for
-    # - git+https://github.com/dask/distributed
+    - git+https://github.com/dask/distributed

--- a/continuous_integration/environment-3.12.yaml
+++ b/continuous_integration/environment-3.12.yaml
@@ -76,4 +76,6 @@ dependencies:
   - matplotlib  # visualize test
   - pip
   - pip:
-    - git+https://github.com/dask/distributed
+    # TODO: Revert before merging
+    - git+https://github.com/jrbourbeau/distributed.git@_always_use_pickle_for
+    # - git+https://github.com/dask/distributed

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -747,7 +747,10 @@ class Dispatch:
             return lk[cls]
         for cls2 in cls.__mro__:
             # Is a lazy registration function present?
-            toplevel, _, _ = cls2.__module__.partition(".")
+            try:
+                toplevel, _, _ = cls2.__module__.partition(".")
+            except Exception:
+                continue
             try:
                 register = self._lazy[toplevel]
             except KeyError:


### PR DESCRIPTION
We have some CI failures due to not being able to serialize a DataFrame when using the nightly dev version of `pandas` ([example CI buid](https://github.com/dask/dask/actions/runs/15146625201/job/42583787280)):

```
FAILED dask/dataframe/dask_expr/io/tests/test_distributed.py::test_parquet_distributed[arrow] - TypeError: ('Could not serialize object of type _ExprSequence', 'ExprSequence(FusedParquetIO(eabfedf))')
FAILED dask/dataframe/dask_expr/io/tests/test_distributed.py::test_pickle_size[arrow] - TypeError: self.info cannot be converted to a Python object for pickling
FAILED dask/dataframe/dask_expr/io/tests/test_parquet.py::test_ensure_plan_computed_during_optimization[arrow] - TypeError: ('Could not serialize object of type _ExprSequence', "ExprSequence(5 * TreeReduce(Chunk(frame=Filter(frame=Index(frame=FusedParquetIO(d74a48c)), predicate=FusedParquetIO(d74a48c)['a'] == 1), kind=<class 'dask.dataframe.dask_expr._reductions.Len'>, chunk=<bound method Reduction.chunk of <class 'dask.dataframe.dask_expr._reductions.Len'>>, chunk_kwargs={}), kind=Len, split_every=8))")
```

A Cython function is getting introduced somewhere it wasn't before and our logic for getting the module name to dispatch custom serializers isn't working for that function. This PR makes our `Dispatch` logic more resilient to not being able to parse out a module name. 