### PR TITLE
Fix ``upstream`` CI installation

### DIFF
--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -19,12 +19,12 @@ if [[ ${UPSTREAM_DEV} ]]; then
     python -m pip install \
         --upgrade \
         locket \
-        git+https://github.com/dask/s3fs \
-        git+https://github.com/intake/filesystem_spec \
+        git+https://github.com/fsspec/s3fs \
         git+https://github.com/dask/partd \
         git+https://github.com/dask/zict \
         git+https://github.com/dask/distributed \
         git+https://github.com/zarr-developers/zarr-python
+    python -m pip install --upgrade git+https://github.com/fsspec/filesystem_spec
     # TODO: Add nightly `h5py` back once https://github.com/h5py/h5py/issues/2563 is resolved
     # mamba uninstall --force numpy pandas scipy numexpr numba sparse scikit-image h5py numbagg
     mamba uninstall --force numpy pandas scipy numexpr numba sparse scikit-image numbagg

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -24,17 +24,18 @@ if [[ ${UPSTREAM_DEV} ]]; then
         git+https://github.com/dask/zict \
         git+https://github.com/dask/distributed \
         git+https://github.com/zarr-developers/zarr-python
+    # NOTE: Dev version of `fsspec` needs to be installed after the dev version of
+    # `s3fs` to avoid dependency conflicts
     python -m pip install --upgrade git+https://github.com/fsspec/filesystem_spec
-    # TODO: Add nightly `h5py` back once https://github.com/h5py/h5py/issues/2563 is resolved
     # TODO: Add nightly `scikit-image` back once it's available
     mamba uninstall --force numpy pandas scipy numexpr numba sparse scikit-image numbagg
     python -m pip install --no-deps --pre --retries 10 \
         -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
         numpy \
         pandas \
-        scipy
+        scipy \
+        h5py
         # scikit-image
-        # h5py
 
     # Used when automatically opening an issue when the `upstream` CI build fails
     mamba install pytest-reportlog

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -26,14 +26,14 @@ if [[ ${UPSTREAM_DEV} ]]; then
         git+https://github.com/zarr-developers/zarr-python
     python -m pip install --upgrade git+https://github.com/fsspec/filesystem_spec
     # TODO: Add nightly `h5py` back once https://github.com/h5py/h5py/issues/2563 is resolved
-    # mamba uninstall --force numpy pandas scipy numexpr numba sparse scikit-image h5py numbagg
+    # TODO: Add nightly `scikit-image` back once it's available
     mamba uninstall --force numpy pandas scipy numexpr numba sparse scikit-image numbagg
     python -m pip install --no-deps --pre --retries 10 \
         -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
         numpy \
         pandas \
-        scipy \
-        scikit-image
+        scipy
+        # scikit-image
         # h5py
 
     # Used when automatically opening an issue when the `upstream` CI build fails


### PR DESCRIPTION
Right now things in the upstream build are failing. This PR fixes that by:

- Installing s3fs and fsspec separately to avoid conflicts (xref https://github.com/fsspec/s3fs/issues/969)
- Temporarily ignoring the nightly version of `scikit-image`, which isn't available (xref https://github.com/scikit-image/scikit-image/issues/7805)
- Adds `h5py` back to the upstream environment (not related, but made this change while touching this file anyways) 