### PR TITLE
Skip groupby cov test for pandas 3.x

### DIFF
--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3193,7 +3193,6 @@ def test_cov_corr_stable():
 def test_cov_corr_mixed(numeric_only):
     size = 1000
     d = {
-        "dates": pd.date_range("2015-01-01", periods=size, freq="1min"),
         "unique_id": np.arange(0, size),
         "ints": np.random.randint(0, size, size=size),
         "floats": np.random.randn(size),
@@ -3205,6 +3204,11 @@ def test_cov_corr_mixed(numeric_only):
         "categorical_binary": np.random.choice(["a", "b"], size=size),
         "categorical_nans": np.random.choice(["a", "b", "c"], size=size),
     }
+
+    if not PANDAS_GE_300:
+        # pandas 3.x doesn't support cov of datetime
+        d["dates"] = pd.date_range("2015-01-01", periods=size, freq="1min")
+
     df = pd.DataFrame(d)
     df["hardbools"] = df["bools"] == 1
     df["categorical_nans"] = df["categorical_nans"].replace("c", np.nan)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3184,7 +3184,7 @@ def test_groupby_numeric_only_false_cov_corr(func):
     if not PANDAS_GE_300:
         # pandas 3.x doesn't support cov of datetime
         # https://github.com/pandas-dev/pandas/pull/60898
-        df["timedelta"] = (pd.to_timedelta([1, 2, 3, 4, 5, 6, 7, 8]),)
+        df["timedelta"] = pd.to_timedelta([1, 2, 3, 4, 5, 6, 7, 8])
 
     ddf = dd.from_pandas(df, npartitions=2)
     dd_result = getattr(ddf.groupby("A"), func)(numeric_only=False)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3173,19 +3173,19 @@ def test_groupby_numeric_only_true(func):
 @pytest.mark.parametrize("func", ["cov", "corr"])
 def test_groupby_numeric_only_false_cov_corr(func):
 
-    if PANDAS_GE_300 and func == "cov":
-        # pandas 3.x doesn't support cov of datetime
-        # https://github.com/pandas-dev/pandas/pull/60898
-        pytest.skip("pandas 3.x doesn't support cov of datetime")
-
     df = pd.DataFrame(
         {
             "float": [1.0, 2.0, 3.0, 4.0, 5, 6.0, 7.0, 8.0],
             "int": [1, 2, 3, 4, 5, 6, 7, 8],
-            "timedelta": pd.to_timedelta([1, 2, 3, 4, 5, 6, 7, 8]),
             "A": 1,
         }
     )
+
+    if not PANDAS_GE_300:
+        # pandas 3.x doesn't support cov of datetime
+        # https://github.com/pandas-dev/pandas/pull/60898
+        df["timedelta"] = (pd.to_timedelta([1, 2, 3, 4, 5, 6, 7, 8]),)
+
     ddf = dd.from_pandas(df, npartitions=2)
     dd_result = getattr(ddf.groupby("A"), func)(numeric_only=False)
     pd_result = getattr(df.groupby("A"), func)(numeric_only=False)

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -3172,6 +3172,12 @@ def test_groupby_numeric_only_true(func):
 
 @pytest.mark.parametrize("func", ["cov", "corr"])
 def test_groupby_numeric_only_false_cov_corr(func):
+
+    if PANDAS_GE_300 and func == "cov":
+        # pandas 3.x doesn't support cov of datetime
+        # https://github.com/pandas-dev/pandas/pull/60898
+        pytest.skip("pandas 3.x doesn't support cov of datetime")
+
     df = pd.DataFrame(
         {
             "float": [1.0, 2.0, 3.0, 4.0, 5, 6.0, 7.0, 8.0],

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -289,7 +289,6 @@ def test_to_hdf_distributed(c):
         ),
     ],
 )
-@pytest.mark.xfail_with_pyarrow_strings
 def test_to_hdf_scheduler_distributed(npartitions, c):
     pytest.importorskip("numpy")
     pytest.importorskip("pandas")


### PR DESCRIPTION
This should fix the failures in the upstream nightly tests seen at https://github.com/dask/dask/actions/runs/15459654118/job/43518210766#step:11:35897.

https://github.com/pandas-dev/pandas/pull/60898 changed the behavior of `.cov` on datetime / timedelta to raise an error.

cc @jrbourbeau 