### PR TITLE
Add explicit output dtype inference function argument to element-wise operators 

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4885,7 +4885,16 @@ def broadcast_shapes(*shapes):
     return tuple(reversed(out))
 
 
-def elemwise(op, *args, out=None, where=True, dtype=None, name=None, **kwargs):
+def elemwise(
+    op,
+    *args,
+    out=None,
+    where=True,
+    dtype=None,
+    dtype_infer_op=None,
+    name=None,
+    **kwargs,
+):
     """Apply an elementwise ufunc-like function blockwise across arguments.
 
     Like numpy ufuncs, broadcasting rules are respected.
@@ -4910,6 +4919,8 @@ def elemwise(op, *args, out=None, where=True, dtype=None, name=None, **kwargs):
         for more information.
     dtype : dtype, optional
         If provided, overrides the output array dtype.
+    dtype_infer_op: callable, optional
+        If provided, it's used to infer the output array dtype instead of op function unless explicit dtype is provided.
     name : str, optional
         A unique key name to use when building the backing dask graph. If not
         provided, one will be automatically generated based on the input
@@ -4973,7 +4984,11 @@ def elemwise(op, *args, out=None, where=True, dtype=None, name=None, **kwargs):
             for a in args
         ]
         try:
-            dtype = apply_infer_dtype(op, vals, {}, "elemwise", suggest_dtype=False)
+            if dtype_infer_op is None:
+                dtype_infer_op = op
+            dtype = apply_infer_dtype(
+                dtype_infer_op, vals, {}, "elemwise", suggest_dtype=False
+            )
         except Exception:
             return NotImplemented
         need_enforce_dtype = any(

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -2063,9 +2063,17 @@ def variadic_choose(a, *choices):
     return np.choose(a, choices)
 
 
+def variadic_choose_clip(a, *choices):
+    """
+    Default mode 'raise' might raise an error during dtype inference.
+    https://github.com/dask/dask/issues/11980
+    """
+    return np.choose(a, choices, mode="clip")
+
+
 @derived_from(np)
 def choose(a, choices):
-    return elemwise(variadic_choose, a, *choices)
+    return elemwise(variadic_choose, a, *choices, dtype_infer_op=variadic_choose_clip)
 
 
 def _isnonzero_vec(v):

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1713,6 +1713,16 @@ def test_choose():
     assert_eq(index_dask.choose([-d, d]), index_numpy.choose([-x, x]))
 
 
+def test_choose_single_array_choices():
+    indices = np.array([0, 0, 0, 0])
+    choices = (np.array([10.0, 20.0, 30.0, 40.0]),)
+
+    d_indices = da.from_array(indices)
+    d_choices = da.from_array(choices)
+
+    assert_eq(da.choose(d_indices, d_choices), np.choose(indices, choices))
+
+
 def test_piecewise():
     rng = np.random.default_rng(1337)
 


### PR DESCRIPTION
- [x] Closes https://github.com/dask/dask/issues/11980
- [x] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
