### PR TITLE
Fall-back to textual repr in case ``jinja2`` is not installed

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1655,7 +1655,7 @@ class Array(DaskMethodsMixin):
             nbytes = "unknown"
             cbytes = "unknown"
 
-        ARRAY_TEMPLATE.render(
+        return ARRAY_TEMPLATE.render(
             array=self,
             grid=grid,
             nbytes=nbytes,

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -96,10 +96,11 @@ from dask.utils import (
 )
 from dask.widgets import get_template
 
-try:
-    ARRAY_TEMPLATE = get_template("array.html.j2")
-except ImportError:
-    ARRAY_TEMPLATE = None
+
+@lru_cache(maxsize=1)
+def _array_template():
+    return get_template("array.html.j2")
+
 
 T_IntOrNaN = Union[int, float]  # Should be Union[int, Literal[np.nan]]
 
@@ -1650,7 +1651,7 @@ class Array(DaskMethodsMixin):
             nbytes = "unknown"
             cbytes = "unknown"
 
-        return ARRAY_TEMPLATE.render(
+        return _array_template().render(
             array=self,
             grid=grid,
             nbytes=nbytes,


### PR DESCRIPTION
- [X] Tests added / passed
- [X] Passes `pre-commit run --all-files`

Improve the error message when trying to render a `dask.array` as HTML in a Jupyter Notebook without having `jinja2` installed.

The following produces an error if the `jinja2` soft dependency is not installed:

```python
import dask.array
arr = dask.array.zeros((32, 32))
arr._repr_html_()
```

However, the error is pretty cryptic and could be easily improved by lazy_loading the underlying `ARRAY_TEMPLATE` - which is what this PR does.

## Before

![image](https://github.com/user-attachments/assets/16dab158-9e98-41fb-a828-8de3aa6d071e)


## After

![image](https://github.com/user-attachments/assets/de6eb65a-8e16-42af-96fa-b4af011fbc73)


Related issue in xarray: https://github.com/pydata/xarray/issues/10384