### PR TITLE
Prevent builtins.any from being shadowed in dask.array.reductions

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1564,7 +1564,7 @@ def quantile(
     and then calling ``numpy.quantile`` function across the remaining dimensions
     """
     if axis is None:
-        if any(n_blocks > 1 for n_blocks in a.numblocks):
+        if builtins.any(n_blocks > 1 for n_blocks in a.numblocks):
             raise NotImplementedError(
                 "The da.quantile function only works along an axis.  "
                 "The full algorithm is difficult to do in parallel"
@@ -1715,7 +1715,7 @@ def nanquantile(
     and then calling ``numpy.nanquantile`` function across the remaining dimensions
     """
     if axis is None:
-        if any(n_blocks > 1 for n_blocks in a.numblocks):
+        if builtins.any(n_blocks > 1 for n_blocks in a.numblocks):
             raise NotImplementedError(
                 "The da.nanquantile function only works along an axis.  "
                 "The full algorithm is difficult to do in parallel"

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -967,14 +967,8 @@ def test_quantile(rechunk, q, axis):
 
 
 @pytest.mark.parametrize(
-    "func",
-    [
-        da.quantile,
-        da.percentile,
-        da.nanquantile,
-        da.nanpercentile
-    ]
-    )
+    "func", [da.quantile, da.percentile, da.nanquantile, da.nanpercentile]
+)
 def test_quantile_func_family_with_axis_none(func):
     # Check that these functions raise a
     # NotImplementedError when axis=None

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -966,6 +966,23 @@ def test_quantile(rechunk, q, axis):
     )
 
 
+@pytest.mark.parametrize(
+    "func",
+    [
+        da.quantile,
+        da.percentile,
+        da.nanquantile,
+        da.nanpercentile
+    ]
+    )
+def test_quantile_func_family_with_axis_none(func):
+    # Check that these functions raise a
+    # NotImplementedError when axis=None
+    darr = da.ones((3, 3), chunks=(2, 2))
+    with pytest.raises(NotImplementedError):
+        func(darr, 0.5, axis=None)
+
+
 def test_nanquantile_all_nan():
     shape = 10, 15, 20, 15
     arr = np.random.randn(*shape)


### PR DESCRIPTION
Fixes https://github.com/dask/dask/issues/11986.

As @TomAugspurger commented, the shadowing of `builtins.any` in `dask.array.reductions` leads to an error when calling
- `da.quantile`
- `da.percentile`
- `da.nanquantile`
- `da.nanpercentile`

together with `..., axis=None`.

This PR explicitly calls `builtins.any` where required and adds a minimal test checking that the functions above yield a `NotImplementedError` in the case of axis=None.

- [x] Closes https://github.com/dask/dask/issues/11986
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
