### PR TITLE
avoid instantiating a potentially very large arange in `take`

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -601,10 +601,12 @@ def take(outname, inname, chunks, index, axis=0):
 
     if not np.isnan(chunks[axis]).any():
         from dask.array._shuffle import _shuffle
-        from dask.array.utils import arange_safe, asarray_safe
+        from dask.array.utils import asarray_safe
 
-        arange = arange_safe(np.sum(chunks[axis]), like=index)
-        if len(index) == len(arange) and np.abs(index - arange).sum() == 0:
+        # verify if this is a full arange (the equivalent of `slice(None)`)
+        full_length = np.sum(chunks[axis])
+        is_sequential = np.all(np.diff(index) == 1)
+        if len(index) == full_length and is_sequential and index[0] == 0:
             # TODO: This should be a real no-op, but the call stack is
             # too deep to do this efficiently for now
             chunk_tuples = product(*(range(len(c)) for i, c in enumerate(chunks)))

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -604,7 +604,7 @@ def take(outname, inname, chunks, index, axis=0):
         from dask.array.utils import asarray_safe
 
         # verify if this is a full arange (the equivalent of `slice(None)`)
-        full_length = np.sum(chunks[axis])
+        full_length = sum(chunks[axis])
         is_sequential = np.all(np.diff(index) == 1)
         if len(index) == full_length and is_sequential and index[0] == 0:
             # TODO: This should be a real no-op, but the call stack is
@@ -616,7 +616,7 @@ def take(outname, inname, chunks, index, axis=0):
             }
             return tuple(chunks), graph
 
-        average_chunk_size = int(sum(chunks[axis]) / len(chunks[axis]))
+        average_chunk_size = int(full_length / len(chunks[axis]))
 
         indexer = []
         index = asarray_safe(index, like=index)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1598,6 +1598,16 @@ def test_take():
     assert same_keys(da.take(a, [3, 4, 5], axis=-1), da.take(a, [3, 4, 5], axis=-1))
 
 
+def test_take_large():
+    a = da.arange(1_000_000_000_000, chunks=(200_000_000,))
+    x = np.arange(20)
+
+    assert_eq(da.take(a, x, axis=0), x)
+
+    x = np.arange(50, 300)
+    assert_eq(da.take(a, x, axis=0), x)
+
+
 def test_take_dask_from_numpy():
     x = np.arange(5).astype("f8")
     y = da.from_array(np.array([1, 2, 3, 3, 2, 1]), chunks=3)


### PR DESCRIPTION
- [x] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

If I understand correctly, in https://github.com/dask/dask/blob/a7e05043816c6243d9b69e6bec09d61cb078b957/dask/array/slicing.py#L606-L607 we create a `arange` array the size of the input array to check for a potential no-op (i.e. `index` is equivalent to `slice(None)`).

However, if we try to index along a very large dimension this will try to allocate a similarly large array, and will run out of client memory.

To avoid that, I think we can achieve the same thing using `np.diff`, which allows checking if the numbers are sorted and sequential, and then we just need to check the length of `index` and its first element.