### PR TITLE
Apply ruff/Pylint Error rules (PLE)

### DIFF
--- a/dask/local.py
+++ b/dask/local.py
@@ -344,7 +344,7 @@ def default_get_id():
 
 
 def default_pack_exception(e, dumps):
-    raise
+    raise e
 
 
 def reraise(exc, tb=None):


### PR DESCRIPTION
PLE0704 Bare `raise` statement is not inside an exception handler

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
