### PR TITLE
CI: update actions location

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -79,7 +79,7 @@ jobs:
           && github.event_name != 'pull_request'
           && github.repository == 'dask/dask'
           && steps.run_tests.outcome == 'failure'
-        uses: xarray-contrib/issue-from-pytest-log@v1.3.0
+        uses: scientific-python/issue-from-pytest-log-action@v1.3.0
         with:
           log-path: output-log.jsonl
           issue-title: ⚠️ Upstream CI failed ⚠️


### PR DESCRIPTION
We have upstreamed the action during the scipy sprints. While the old link redirects, it can also be updated.