### PR TITLE
pandas 3.x compatibility

### DIFF
--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -26,6 +26,7 @@ PANDAS_GE_300 = PANDAS_VERSION.major >= 3
 
 PYARROW_VERSION = Version(pa.__version__)
 PYARROW_GE_1500 = PYARROW_VERSION.release >= (15, 0, 0)
+PYARROW_GE_2101 = PYARROW_VERSION.release >= (21, 0, 1)
 
 import pandas.testing as tm
 

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -581,6 +581,37 @@ def group_split_pandas(df, c, k, ignore_index=False):
     return ShuffleGroupResult(zip(range(k), parts))
 
 
+def _union_categoricals_wrapper(
+    dfs: list[pd.CategoricalIndex] | list[pd.Series], **kwargs
+) -> pd.Categorical:
+    """
+    A wrapper around pandas' union_categoricals that handles some dtype issues.
+
+    union_categoricals requires that the dtype of each array's categories match.
+    So you can't union ``Categorical(['a', 'b'])`` and ``Categorical([1, 2])``
+    since the dtype (str vs. int) doesn't match.
+
+    *Somewhere* in Dask, we're possibly creating an empty ``Categorical``
+    with a dtype of ``object``. In pandas 2.x, we could union that with string
+    categories since they both used object dtype. But pandas 3.x uses string
+    dtype for categories.
+
+    This wrapper handles that by creating a new ``Categorical`` with the
+    correct dtype.
+    """
+    categories_dtypes = {cat.dtype.categories.dtype.name for cat in dfs}
+    if "object" in categories_dtypes and "str" in categories_dtypes:
+        # TODO: don't drop name?
+        dfs = [
+            type(cat)(pd.Categorical(pd.Index([], dtype="str")), name=cat.name)
+            if cat.dtype.categories.dtype.name == "object" and len(cat) == 0
+            else cat
+            for cat in dfs
+        ]
+
+    return union_categoricals(dfs, **kwargs)
+
+
 @concat_dispatch.register((pd.DataFrame, pd.Series, pd.Index))
 def concat_pandas(
     dfs,
@@ -603,7 +634,8 @@ def concat_pandas(
                 if not isinstance(dfs[i], pd.CategoricalIndex):
                     dfs[i] = dfs[i].astype("category")
             return pd.CategoricalIndex(
-                union_categoricals(dfs, ignore_order=ignore_order), name=dfs[0].name
+                _union_categoricals_wrapper(dfs, ignore_order=ignore_order),
+                name=dfs[0].name,
             )
         elif isinstance(dfs[0], pd.MultiIndex):
             first, rest = dfs[0], dfs[1:]
@@ -698,7 +730,7 @@ def concat_pandas(
                             codes, sample.cat.categories, sample.cat.ordered
                         )
                         parts.append(data)
-                out[col] = union_categoricals(parts, ignore_order=ignore_order)
+                out[col] = _union_categoricals_wrapper(parts, ignore_order=ignore_order)
                 # Pandas resets index type on assignment if frame is empty
                 # https://github.com/pandas-dev/pandas/issues/17101
                 if not len(temp_ind):

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 
 import numpy as np
 import pandas as pd
-import pyarrow.compute
+import pyarrow as pa
 from pandas.api.types import is_scalar, union_categoricals
 
 from dask.array import Array
@@ -198,9 +198,7 @@ def _(x, index=None):
 
     for k, v in out.items():
         if isinstance(v.array, pd.arrays.ArrowExtensionArray):
-            values = pyarrow.compute.take(
-                pyarrow.array(v.array), pyarrow.array([], type="int32")
-            )
+            values = pa.chunked_array([v.array]).combine_chunks()
             out[k] = v._constructor(
                 pd.array(values, dtype=v.array.dtype), index=v.index, name=v.name
             )

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -601,11 +601,12 @@ def _union_categoricals_wrapper(
     """
     categories_dtypes = {cat.dtype.categories.dtype.name for cat in dfs}
     if "object" in categories_dtypes and "str" in categories_dtypes:
-        # TODO: don't drop name?
         dfs = [
-            type(cat)(pd.Categorical(pd.Index([], dtype="str")), name=cat.name)
-            if cat.dtype.categories.dtype.name == "object" and len(cat) == 0
-            else cat
+            (
+                type(cat)(pd.Categorical(pd.Index([], dtype="str")), name=cat.name)
+                if cat.dtype.categories.dtype.name == "object" and len(cat) == 0
+                else cat
+            )
             for cat in dfs
         ]
 

--- a/dask/dataframe/dask_expr/io/tests/test_from_pandas.py
+++ b/dask/dataframe/dask_expr/io/tests/test_from_pandas.py
@@ -5,6 +5,7 @@ import copy
 import pytest
 
 import dask
+from dask.dataframe._compat import PANDAS_GE_300
 from dask.dataframe.dask_expr import from_pandas, repartition
 from dask.dataframe.dask_expr.tests._util import _backend_library
 from dask.dataframe.utils import assert_eq, pyarrow_strings_enabled
@@ -126,12 +127,18 @@ def test_from_pandas_string_option():
     assert df.compute().index.dtype == dtype
     assert_eq(df, pdf)
 
+    if PANDAS_GE_300:
+        dtype = "string"
+    else:
+        dtype = "object"
+
     with dask.config.set({"dataframe.convert-string": False}):
         df = from_pandas(pdf, npartitions=2)
-        assert df.dtypes["y"] == "object"
-        assert df.index.dtype == "object"
-        assert df.compute().dtypes["y"] == "object"
-        assert df.compute().index.dtype == "object"
+
+        assert df.dtypes["y"] == dtype
+        assert df.index.dtype == dtype
+        assert df.compute().dtypes["y"] == dtype
+        assert df.compute().index.dtype == dtype
         assert_eq(df, pdf)
 
 

--- a/dask/dataframe/dask_expr/tests/test_shuffle.py
+++ b/dask/dataframe/dask_expr/tests/test_shuffle.py
@@ -538,6 +538,11 @@ def test_set_index_head_nlargest(df, pdf):
     # df.set_index([df.x, df.y]).head(3)
 
 
+# def test_set_index_map_strings():
+#     ddf = from_pandas(pd.DataFrame({"x": ["a", "b", "c"], "y": [1, 2, 3]}), npartitions=2)
+#     result = ddf.set_index(ddf["x"].map(str.upper, meta="str"))
+
+
 @pytest.mark.skipif(
     not pyarrow_strings_enabled() or not PANDAS_GE_220,
     reason="doesn't work without arrow",
@@ -584,10 +589,11 @@ def test_index_nulls(null_value):
     )
     ddf = from_pandas(df, npartitions=2)
     with pytest.raises(NotImplementedError, match="presence of nulls"):
-        with pytest.warns(UserWarning):
-            ddf.set_index(
-                ddf["non_numeric"].map({"foo": "foo", "bar": null_value})
-            ).compute()
+        ddf.set_index(
+            ddf["non_numeric"].map(
+                {"foo": "foo", "bar": null_value}, meta=ddf["non_numeric"]._meta
+            )
+        ).compute()
 
 
 @pytest.mark.parametrize("freq", ["16h", "-16h"])

--- a/dask/dataframe/dask_expr/tests/test_shuffle.py
+++ b/dask/dataframe/dask_expr/tests/test_shuffle.py
@@ -538,11 +538,6 @@ def test_set_index_head_nlargest(df, pdf):
     # df.set_index([df.x, df.y]).head(3)
 
 
-# def test_set_index_map_strings():
-#     ddf = from_pandas(pd.DataFrame({"x": ["a", "b", "c"], "y": [1, 2, 3]}), npartitions=2)
-#     result = ddf.set_index(ddf["x"].map(str.upper, meta="str"))
-
-
 @pytest.mark.skipif(
     not pyarrow_strings_enabled() or not PANDAS_GE_220,
     reason="doesn't work without arrow",

--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -721,7 +721,7 @@ class ArrowDatasetEngine(Engine):
                     "Appended columns not the same.\n"
                     "Previous: {} | New: {}".format(names, list(df.columns))
                 )
-            elif (pd.Series(dtypes).loc[names] != df[names].dtypes).any():
+            elif pd.Series(dtypes).loc[names].tolist() != df[names].dtypes.tolist():
                 # TODO Coerce values for compatible but different dtypes
                 raise ValueError(
                     "Appended dtypes differ.\n{}".format(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1272,7 +1272,11 @@ def test_pyarrow_schema_mismatch_error(tmpdir):
     msg = str(rec.value)
     assert "Failed to convert partition to expected pyarrow schema" in msg
     assert "y: double" in str(rec.value)
-    assert "y: string" in str(rec.value)
+
+    if PANDAS_GE_300:
+        assert "y: large_string" in str(rec.value)
+    else:
+        assert "y: string" in str(rec.value)
 
 
 @PYARROW_MARK
@@ -2691,8 +2695,8 @@ def test_partitioned_column_overlap(tmpdir, engine, write_cols):
         assert_eq(result, expect, check_index=False)
     else:
         # For now, partial overlap between partition columns and
-        # real columns is not allowed for pyarrow
-        with pytest.raises(ValueError):
+        # real columns is not allowed for
+        with pytest.raises((ValueError, pa.ArrowTypeError)):
             dd.read_parquet(path, engine=engine)
 
 

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2669,7 +2669,7 @@ def test_arrow_to_pandas(tmpdir, engine):
 
 
 PYARROW_LARGE_STRING_XFAIL = pytest.mark.xfail(
-    condition=not PYARROW_GE_2101,
+    condition=PANDAS_GE_300 and not PYARROW_GE_2101,
     reason="https://github.com/apache/arrow/issues/47177",
     strict=True,
 )

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -511,12 +511,17 @@ def test_to_sql(npartitions, parallel):
         result = read_sql_table("test", uri, "age")
         assert_eq(df_by_age, result)
 
+    if PANDAS_GE_300:
+        string_dtype = "str"
+    else:
+        string_dtype = "object"
+
     # Index column can't have "object" dtype if no partitions are provided
     with tmp_db_uri() as uri:
         ddf.set_index("name").to_sql("test", uri)
         with pytest.raises(
             TypeError,
-            match='Provided index column is of type "object".  If divisions is not provided the index column type must be numeric or datetime.',  # noqa: E501
+            match=f'Provided index column is of type "{string_dtype}".  If divisions is not provided the index column type must be numeric or datetime.',  # noqa: E501
         ):
             read_sql_table("test", uri, "name")
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3567,10 +3567,11 @@ def test_index_nulls(null_value):
     # an object column with only some nulls fails
     ddf = dd.from_pandas(df, npartitions=2)
     with pytest.raises(NotImplementedError, match="presence of nulls"):
-        with pytest.warns(UserWarning, match="meta"):
-            ddf.set_index(
-                ddf["non_numeric"].map({"foo": "foo", "bar": null_value})
-            ).compute()
+        ddf.set_index(
+            ddf["non_numeric"].map(
+                {"foo": "foo", "bar": null_value}, meta=ddf["non_numeric"]._meta
+            )
+        ).compute()
 
 
 def test_set_index_with_index():

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -4055,7 +4055,11 @@ def test_values():
         ctx = pytest.warns(UserWarning, match="object dtype")
     with ctx:
         result = ddf.x.values
-    assert_eq(df.x.values, result)
+
+    if not PANDAS_GE_300:
+        # Dask currently lacks an extension type.
+        # https://github.com/dask/dask/issues/5001
+        assert_eq(df.x.values, result)
     assert_eq(df.y.values, ddf.y.values)
     assert_eq(df.index.values, ddf.index.values)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -1452,7 +1452,8 @@ def test_dataframe_quantile(method, expected, numeric_only):
         numeric_only_kwarg = {"numeric_only": numeric_only}
 
     if numeric_only is False or numeric_only is None:
-        with pytest.raises(TypeError):
+        # TypeError for pandas<3, ArrowNotImplementedError for pandas>=3
+        with pytest.raises((TypeError, ArrowNotImplementedError)):
             df.quantile(**numeric_only_kwarg)
         with pytest.raises(
             (TypeError, ArrowNotImplementedError, ValueError),

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -117,7 +117,7 @@ def test_ufunc(pandas_input, ufunc):
         assert_eq(dafunc(dask_input), npfunc(pandas_input))
 
     # Index
-    if pandas_input.index.dtype in [object, str]:
+    if pandas_input.index.dtype.name in ["object", "str"]:
         return
     if ufunc in ("logical_not", "signbit", "isnan", "isinf", "isfinite"):
         return

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -55,6 +55,10 @@ def test_make_meta():
             df_pointer = df[col].values.__array_interface__["data"][0]
         assert meta_pointer != df_pointer
 
+        meta_index_pointer = meta.index.values.__array_interface__["data"][0]
+        df_index_pointer = df.index.values.__array_interface__["data"][0]
+        assert meta_index_pointer != df_index_pointer
+
     # Pandas series
     meta = make_meta(df.a)
     assert len(meta) == 0

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -246,7 +246,10 @@ def test_meta_duplicated():
     df = pd.DataFrame(columns=["A", "A", "B"])
     res = meta_nonempty(df)
 
-    o = dd.utils._object
+    if PANDAS_GE_300:
+        o = dd.utils._object
+    else:
+        o = "foo"
 
     exp = pd.DataFrame(
         [[o, o, o], [o, o, o]],

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -246,8 +246,10 @@ def test_meta_duplicated():
     df = pd.DataFrame(columns=["A", "A", "B"])
     res = meta_nonempty(df)
 
+    o = dd.utils._object
+
     exp = pd.DataFrame(
-        [["foo", "foo", "foo"], ["foo", "foo", "foo"]],
+        [[o, o, o], [o, o, o]],
         index=meta_nonempty(df.index),
         columns=["A", "A", "B"],
     )

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -8,7 +8,7 @@ import traceback
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from contextlib import contextmanager
 from numbers import Number
-from typing import TypeVar, overload
+from typing import Any, TypeVar, overload
 
 import numpy as np
 import pandas as pd
@@ -17,7 +17,7 @@ from pandas.api.types import is_dtype_equal
 import dask
 from dask.base import is_dask_collection
 from dask.core import get_deps
-from dask.dataframe._compat import tm  # noqa: F401
+from dask.dataframe._compat import PANDAS_GE_300, tm  # noqa: F401
 from dask.dataframe.dispatch import (  # noqa : F401
     is_categorical_dtype_dispatch,
     make_meta,
@@ -267,7 +267,7 @@ def _empty_series(name, dtype, index=None):
     return pd.Series([], dtype=dtype, name=name, index=index)
 
 
-_simple_fake_mapping = {
+_simple_fake_mapping: dict[str, Any] = {
     "b": np.bool_(True),
     "V": np.void(b" "),
     "M": np.datetime64("1970-01-01"),
@@ -275,8 +275,12 @@ _simple_fake_mapping = {
     "S": np.str_("foo"),
     "a": np.str_("foo"),
     "U": np.str_("foo"),
-    "O": "foo",
 }
+
+if PANDAS_GE_300:
+    _simple_fake_mapping["O"] = object()
+else:
+    _simple_fake_mapping["O"] = "foo"
 
 
 def _scalar_from_dtype(dtype):

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -277,8 +277,10 @@ _simple_fake_mapping: dict[str, Any] = {
     "U": np.str_("foo"),
 }
 
+_object = object()
+
 if PANDAS_GE_300:
-    _simple_fake_mapping["O"] = object()
+    _simple_fake_mapping["O"] = _object
 else:
     _simple_fake_mapping["O"] = "foo"
 

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -478,7 +478,9 @@ def test_compute_dataframe_valid_unicode_in_bytes():
 @pytest.mark.skipif("not dd")
 def test_compute_dataframe_invalid_unicode():
     # see https://github.com/dask/dask/issues/2713
-    df = pd.DataFrame(data=np.random.random((3, 1)), columns=["\ud83d"])
+    df = pd.DataFrame(
+        data=np.random.random((3, 1)), columns=pd.Index(["\ud83d"], dtype="object")
+    )
     dd.from_pandas(df, npartitions=4)
 
 

--- a/dask/tests/test_tokenize.py
+++ b/dask/tests/test_tokenize.py
@@ -581,6 +581,11 @@ def test_tokenize_pandas():
     assert check_tokenize(a) == check_tokenize(b)
 
 
+def test_tokenize_pandas_fragmented_index():
+    s = pd.concat([pd.Series(1, index=["a", "b"]), pd.Series(2, index=["c", "d"])])
+    check_tokenize(s)
+
+
 @pytest.mark.skipif("not pd")
 def test_tokenize_pandas_invalid_unicode():
     # see https://github.com/dask/dask/issues/2713

--- a/dask/tests/test_tokenize.py
+++ b/dask/tests/test_tokenize.py
@@ -22,6 +22,7 @@ from tlz import compose, curry, partial
 import dask
 from dask._compatibility import PY_VERSION
 from dask.core import flatten, literal
+from dask.dataframe._compat import PANDAS_GE_300
 from dask.tokenize import TokenizationError, normalize_token, tokenize
 from dask.utils import tmpfile
 from dask.utils_test import import_or_none
@@ -78,6 +79,13 @@ def check_tokenize(*args, **kwargs):
         # Skip: different interpreter determinism
 
     return before
+
+
+@pytest.mark.skipif(not PANDAS_GE_300, reason="requires pandas>=3.0.0")
+def test_tokenize_arrow_string_array_numpy_semantics():
+    arr = pd.Series(["a", "b", "c"], dtype="category").cat.categories.array
+    # assert isinstance(arr, pd.core.arrays.string_arrow.ArrowStringArray)  # TODO: public API
+    check_tokenize(arr)
 
 
 def test_check_tokenize():

--- a/dask/tests/test_tokenize.py
+++ b/dask/tests/test_tokenize.py
@@ -570,8 +570,14 @@ def test_tokenize_pandas():
     a = pd.DataFrame({"x": [1, 2, 3], "y": ["a", "b", "a"]})
     b = pd.DataFrame({"x": [1, 2, 3], "y": ["a", "b", "a"]})
     a["z"] = a.y.astype("category")
+
+    # tokenize is currently sensitive to fragmentation of the pyarrow Array
+    # backing the columns. Create a new one to work around this.
+    a.columns = pd.Index(["x", "y", "z"])
     assert check_tokenize(a) != check_tokenize(b)
     b["z"] = a.y.astype("category")
+
+    b.columns = pd.Index(["x", "y", "z"])
     assert check_tokenize(a) == check_tokenize(b)
 
 

--- a/dask/tests/test_tokenize.py
+++ b/dask/tests/test_tokenize.py
@@ -581,6 +581,7 @@ def test_tokenize_pandas():
     assert check_tokenize(a) == check_tokenize(b)
 
 
+@pytest.mark.skipif("not pd")
 def test_tokenize_pandas_fragmented_index():
     s = pd.concat([pd.Series(1, index=["a", "b"]), pd.Series(2, index=["c", "d"])])
     check_tokenize(s)

--- a/dask/tests/test_tokenize.py
+++ b/dask/tests/test_tokenize.py
@@ -22,7 +22,6 @@ from tlz import compose, curry, partial
 import dask
 from dask._compatibility import PY_VERSION
 from dask.core import flatten, literal
-from dask.dataframe._compat import PANDAS_GE_300
 from dask.tokenize import TokenizationError, normalize_token, tokenize
 from dask.utils import tmpfile
 from dask.utils_test import import_or_none
@@ -79,13 +78,6 @@ def check_tokenize(*args, **kwargs):
         # Skip: different interpreter determinism
 
     return before
-
-
-@pytest.mark.skipif(not PANDAS_GE_300, reason="requires pandas>=3.0.0")
-def test_tokenize_arrow_string_array_numpy_semantics():
-    arr = pd.Series(["a", "b", "c"], dtype="category").cat.categories.array
-    # assert isinstance(arr, pd.core.arrays.string_arrow.ArrowStringArray)  # TODO: public API
-    check_tokenize(arr)
 
 
 def test_check_tokenize():
@@ -587,8 +579,13 @@ def test_tokenize_pandas():
 def test_tokenize_pandas_invalid_unicode():
     # see https://github.com/dask/dask/issues/2713
     df = pd.DataFrame(
-        {"x\ud83d": [1, 2, 3], "y\ud83d": ["4", "asd\ud83d", None]}, index=[1, 2, 3]
+        {
+            "x": [1, 2, 3],
+            "y": pd.Series(["4", "asd\ud83d", None], dtype="object"),
+        },
+        index=[1, 2, 3],
     )
+    df.columns = pd.Index(["x\ud83d", "y\ud83d"], dtype="object")
     check_tokenize(df)
 
 

--- a/dask/tokenize.py
+++ b/dask/tokenize.py
@@ -387,17 +387,11 @@ def register_pyarrow():
 
     @normalize_token.register(pa.ChunkedArray)
     def normalize_chunked_array(arr):
-        # So, pyarrow chooses to consolidate chunks
-        # when pickling. To get deterministic tokenization, we need to
-        # do the same thing...
-        # I really don't want to do that this. This is a potentially
-        # expensive operation.
-        return ("pa.ChunkedArray", normalize_token(arr.combine_chunks()))
-        # return (
-        #     "pa.ChunkedArray",
-        #     normalize_token(arr.type),
-        #     normalize_token(arr.chunks),
-        # )
+        return (
+            "pa.ChunkedArray",
+            normalize_token(arr.type),
+            normalize_token(arr.chunks),
+        )
 
     @normalize_token.register(pa.Array)
     def normalize_array(arr):

--- a/dask/tokenize.py
+++ b/dask/tokenize.py
@@ -387,11 +387,17 @@ def register_pyarrow():
 
     @normalize_token.register(pa.ChunkedArray)
     def normalize_chunked_array(arr):
-        return (
-            "pa.ChunkedArray",
-            normalize_token(arr.type),
-            normalize_token(arr.chunks),
-        )
+        # So, pyarrow chooses to consolidate chunks
+        # when pickling. To get deterministic tokenization, we need to
+        # do the same thing...
+        # I really don't want to do that this. This is a potentially
+        # expensive operation.
+        return ("pa.ChunkedArray", normalize_token(arr.combine_chunks()))
+        # return (
+        #     "pa.ChunkedArray",
+        #     normalize_token(arr.type),
+        #     normalize_token(arr.chunks),
+        # )
 
     @normalize_token.register(pa.Array)
     def normalize_chunked_array(arr):

--- a/dask/tokenize.py
+++ b/dask/tokenize.py
@@ -400,7 +400,7 @@ def register_pyarrow():
         # )
 
     @normalize_token.register(pa.Array)
-    def normalize_chunked_array(arr):
+    def normalize_array(arr):
         buffers = arr.buffers()
         # pyarrow does something clever when (de)serializing an array that has
         # an empty validity map: The buffers for the deserialized array will
@@ -419,7 +419,7 @@ def register_pyarrow():
         )
 
     @normalize_token.register(pa.Buffer)
-    def normalize_chunked_array(buf):
+    def normalize_buffer(buf):
         return ("pa.Buffer", hash_buffer_hex(buf))
 
 

--- a/dask/tokenize.py
+++ b/dask/tokenize.py
@@ -285,6 +285,15 @@ def register_pandas():
     @normalize_token.register(pd.Index)
     def normalize_index(ind):
         values = ind.array
+
+        if isinstance(values, pd.arrays.ArrowExtensionArray):
+            import pyarrow as pa
+
+            # these are sensitive to fragmentation of the backing Arrow array.
+            # Because common operations like DataFrame.getitem and DataFrame.setitem
+            # result in fragmented Arrow arrays, we'll consolidate them here.
+            values = pa.chunked_array([values._pa_array]).combine_chunks()
+
         return type(ind), ind.name, normalize_token(values)
 
     @normalize_token.register(pd.MultiIndex)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,6 @@ python_version = "3.10"
 platform = "linux"
 # platform = win32
 # platform = darwin
-plugins = ["numpy.typing.mypy_plugin"]
 disallow_untyped_decorators = true
 ignore_missing_imports = true
 no_implicit_optional = true


### PR DESCRIPTION
This adds compatibility for pandas 3.x. I'll leave comments inline.

Leaving it in draft until I have everything passing. The remaining failures are related to

- [ ] tokenization
- [ ] shuffle / divisions for string columsn
- [ ] parquet IO

Closes #12022 