### PR TITLE
Fix ``xfail`` condition for ``pyarrow`` ``large_string`` issue

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -17,7 +17,7 @@ from packaging.version import Version
 import dask
 import dask.dataframe as dd
 import dask.multiprocessing
-from dask.dataframe._compat import PANDAS_GE_202, PANDAS_GE_300, PYARROW_GE_2101
+from dask.dataframe._compat import PANDAS_GE_202, PANDAS_GE_300
 from dask.dataframe.io.parquet.core import get_engine
 from dask.dataframe.utils import assert_eq, pyarrow_strings_enabled
 from dask.utils import natural_sort_key
@@ -2669,7 +2669,7 @@ def test_arrow_to_pandas(tmpdir, engine):
 
 
 PYARROW_LARGE_STRING_XFAIL = pytest.mark.xfail(
-    condition=PANDAS_GE_300 and not PYARROW_GE_2101,
+    condition=PANDAS_GE_300,
     reason="https://github.com/apache/arrow/issues/47177",
     strict=True,
 )


### PR DESCRIPTION
Closes https://github.com/dask/dask/issues/12030

@TomAugspurger I'm basing this on your comment here https://github.com/apache/arrow/issues/47177#issuecomment-3113297383 about this issue existing for older `pyarrow` versions but only showing up here with the recent pyarrow-related changed in `pandas`. Let me know if you think this should be something different 