### PR TITLE
Clean up setuptools-specific configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,6 @@ cupy = "dask.array.cupy_entry_point:CupyBackendEntrypoint"
 dask = "dask.__main__:main"
 
 [tool.setuptools]
-include-package-data = true
-zip-safe = false
 license-files = [
     "LICENSE.txt",
     "dask/array/NUMPY_LICENSE.txt",


### PR DESCRIPTION
* `include-package-data` is True by default
* `zip-safe` is obsolete, only relevant for `pkg_resources`, `easy_install` and `setup.py install` in the context of eggs (deprecated)

https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#setuptools-specific-configuration

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
