### PR TITLE
TST: Fix test_enforce_columns on Python 3.14

### DIFF
--- a/dask/dataframe/io/tests/test_csv.py
+++ b/dask/dataframe/io/tests/test_csv.py
@@ -346,9 +346,9 @@ def test_enforce_columns(reader, blocks):
     blocks = [blocks[0], [blocks[1][0].replace(b"a", b"A"), blocks[1][1]]]
     head = reader(BytesIO(blocks[0][0]), header=0)
     header = blocks[0][0].split(b"\n")[0] + b"\n"
+    dfs = text_blocks_to_pandas(reader, blocks, header, head, {}, enforce=True)
     with pytest.raises(ValueError):
-        dfs = text_blocks_to_pandas(reader, blocks, header, head, {}, enforce=True)
-        dask.compute(*dfs, scheduler="sync")
+        dask.compute(dfs, scheduler="sync")
 
 
 #############################


### PR DESCRIPTION
Formerly, the `ValueError` would be raised by `DataFrame.__len__` from the tuple unpacking into the function arguments. In Python 3.14, as of https://github.com/python/cpython/commit/5a23994a3dbee43a0b08f5920032f60f38b63071 the `__len__` method is not called and the `ValueError` is not raised.

In any case, I don't believe the point of the test is to check `__len__` due to tuple unpacking, but just general column consistency checks. It is thus sufficient to call `dask.compute` on the `DataFrame` as a whole, which will run a column consistency check in all cases.

- [n/a] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
