### PR TITLE
MAINT: Address NumPy DeprecationWarning

### DIFF
--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -374,7 +374,7 @@ def process_val_weights(vals_and_weights, npartitions, dtype_info):
         left = np.searchsorted(q_weights, q_target, side="left")
         right = np.searchsorted(q_weights, q_target, side="right") - 1
         # stay inbounds
-        np.maximum(right, 0, right)
+        np.maximum(right, 0, out=right)
         lower = np.minimum(left, right)
         trimmed = trimmed_vals[lower]
 


### PR DESCRIPTION
The way the current code is written throws a `DeprecationWarning` with NumPy nightly:
```python
>           np.maximum(right, 0, right)
E           DeprecationWarning: Passing more than 2 positional arguments to np.maximum and np.minimum is deprecated. If you meant to use the third argument as an output, use the `out` keyword argument instead. If you hoped to work with more than 2 inputs, combine them into a single array and get the extrema for the relevant axis.
```

Spotted in the [Narwhals CI](https://github.com/narwhals-dev/narwhals/actions/runs/17190932127/job/48766454518?pr=3030)

This fix should be backwards and forwards compatible