### PR TITLE
Avoid unconditional pyarrow dependency in dataframe.backends

### DIFF
--- a/dask/_pandas_compat.py
+++ b/dask/_pandas_compat.py
@@ -1,0 +1,179 @@
+# Compatibility specifically for pandas. Note that this file is at
+# dask._pandas_compat, rather than under dask.dataframe. That's to avoid
+# importing all of dask.dataframe (which depends on pyarrow) when registering
+# *pandas* objects with our dispatch system, which might be used by
+# non-dask.dataframe users of Dask (e.g. xarray).
+
+from __future__ import annotations
+
+import contextlib
+import string
+import warnings
+
+from packaging.version import Version
+
+from dask._compatibility import import_optional_dependency
+
+import_optional_dependency("pandas")
+import numpy as np
+import pandas as pd
+import pandas.testing as tm
+
+PANDAS_VERSION = Version(pd.__version__)
+PANDAS_GE_201 = PANDAS_VERSION.release >= (2, 0, 1)
+PANDAS_GE_202 = PANDAS_VERSION.release >= (2, 0, 2)
+PANDAS_GE_210 = PANDAS_VERSION.release >= (2, 1, 0)
+PANDAS_GE_211 = PANDAS_VERSION.release >= (2, 1, 1)
+PANDAS_GE_220 = PANDAS_VERSION.release >= (2, 2, 0)
+PANDAS_GE_230 = PANDAS_VERSION.release >= (2, 3, 0)
+PANDAS_GE_300 = PANDAS_VERSION.major >= 3
+
+
+def assert_categorical_equal(left, right, *args, **kwargs):
+    tm.assert_extension_array_equal(left, right, *args, **kwargs)
+    assert isinstance(
+        left.dtype, pd.CategoricalDtype
+    ), f"{left} is not categorical dtype"
+    assert isinstance(
+        right.dtype, pd.CategoricalDtype
+    ), f"{right} is not categorical dtype"
+
+
+def assert_numpy_array_equal(left, right):
+    left_na = pd.isna(left)
+    right_na = pd.isna(right)
+    np.testing.assert_array_equal(left_na, right_na)
+
+    left_valid = left[~left_na]
+    right_valid = right[~right_na]
+    np.testing.assert_array_equal(left_valid, right_valid)
+
+
+def makeDataFrame():
+    data = np.random.randn(30, 4)
+    index = list(string.ascii_letters)[:30]
+    return pd.DataFrame(data, index=index, columns=list("ABCD"))
+
+
+def makeTimeDataFrame():
+    data = makeDataFrame()
+    data.index = makeDateIndex()
+    return data
+
+
+def makeTimeSeries():
+    return makeTimeDataFrame()["A"]
+
+
+def makeDateIndex(k=30, freq="B"):
+    return pd.date_range("2000", periods=k, freq=freq)
+
+
+def makeTimedeltaIndex(k=30, freq="D"):
+    return pd.timedelta_range("1 day", periods=k, freq=freq)
+
+
+def makeMissingDataframe():
+    df = makeDataFrame()
+    data = df.values
+    data = np.where(data > 1, np.nan, data)
+    return pd.DataFrame(data, index=df.index, columns=df.columns)
+
+
+def makeMixedDataFrame():
+    df = pd.DataFrame(
+        {
+            "A": [0.0, 1, 2, 3, 4],
+            "B": [0.0, 1, 0, 1, 0],
+            "C": [f"foo{i}" for i in range(5)],
+            "D": pd.date_range("2009-01-01", periods=5),
+        }
+    )
+    return df
+
+
+@contextlib.contextmanager
+def check_groupby_axis_deprecation():
+    if PANDAS_GE_210:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                ".*Call without passing 'axis' instead|.*Operate on the un-grouped DataFrame instead",
+                FutureWarning,
+            )
+            yield
+    else:
+        yield
+
+
+@contextlib.contextmanager
+def check_observed_deprecation():
+    if PANDAS_GE_210:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="The default of observed=False",
+                category=FutureWarning,
+            )
+            yield
+    else:
+        yield
+
+
+@contextlib.contextmanager
+def check_convert_dtype_deprecation():
+    if PANDAS_GE_210:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="the convert_dtype parameter",
+                category=FutureWarning,
+            )
+            yield
+    else:
+        yield
+
+
+@contextlib.contextmanager
+def check_apply_dataframe_deprecation():
+    if PANDAS_GE_210:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="Returning a DataFrame",
+                category=FutureWarning,
+            )
+            yield
+    else:
+        yield
+
+
+@contextlib.contextmanager
+def check_reductions_runtime_warning():
+    if not PANDAS_GE_201:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message="invalid value encountered in double_scalars|Degrees of freedom <= 0 for slice",
+                category=RuntimeWarning,
+            )
+            yield
+    else:
+        yield
+
+
+IndexingError = pd.errors.IndexingError
+
+
+def is_any_real_numeric_dtype(arr_or_dtype) -> bool:
+    return pd.api.types.is_any_real_numeric_dtype(arr_or_dtype)
+
+
+def is_string_dtype(arr_or_dtype) -> bool:
+    # is_string_dtype did not recognize pyarrow strings before 2.0
+    # Can remove once 2.0 is minimum version for us
+    if hasattr(arr_or_dtype, "dtype"):
+        dtype = arr_or_dtype.dtype
+    else:
+        dtype = arr_or_dtype
+    return pd.api.types.is_string_dtype(dtype)

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -1,181 +1,93 @@
 from __future__ import annotations
 
-import contextlib
-import string
-import warnings
-
 from dask._compatibility import import_optional_dependency
 
 import_optional_dependency("pandas")
 import_optional_dependency("numpy")
-import_optional_dependency("pyarrow")
+# import_optional_dependency("pyarrow")
 
-import numpy as np
-import pandas as pd
-import pyarrow as pa
 from packaging.version import Version
 
-PANDAS_VERSION = Version(pd.__version__)
-PANDAS_GE_201 = PANDAS_VERSION.release >= (2, 0, 1)
-PANDAS_GE_202 = PANDAS_VERSION.release >= (2, 0, 2)
-PANDAS_GE_210 = PANDAS_VERSION.release >= (2, 1, 0)
-PANDAS_GE_211 = PANDAS_VERSION.release >= (2, 1, 1)
-PANDAS_GE_220 = PANDAS_VERSION.release >= (2, 2, 0)
-PANDAS_GE_230 = PANDAS_VERSION.release >= (2, 3, 0)
-PANDAS_GE_300 = PANDAS_VERSION.major >= 3
+from dask._pandas_compat import (
+    PANDAS_GE_201,
+    PANDAS_GE_202,
+    PANDAS_GE_210,
+    PANDAS_GE_211,
+    PANDAS_GE_220,
+    PANDAS_GE_230,
+    PANDAS_GE_300,
+    PANDAS_VERSION,
+    IndexingError,
+    assert_categorical_equal,
+    assert_numpy_array_equal,
+    check_apply_dataframe_deprecation,
+    check_convert_dtype_deprecation,
+    check_groupby_axis_deprecation,
+    check_observed_deprecation,
+    check_reductions_runtime_warning,
+    is_any_real_numeric_dtype,
+    is_string_dtype,
+    makeDataFrame,
+    makeDateIndex,
+    makeMissingDataframe,
+    makeMixedDataFrame,
+    makeTimeDataFrame,
+    makeTimedeltaIndex,
+    makeTimeSeries,
+    tm,
+)
 
-PYARROW_VERSION = Version(pa.__version__)
-PYARROW_GE_1500 = PYARROW_VERSION.release >= (15, 0, 0)
-PYARROW_GE_2101 = PYARROW_VERSION.release >= (21, 0, 1)
-
-import pandas.testing as tm
-
-
-def assert_categorical_equal(left, right, *args, **kwargs):
-    tm.assert_extension_array_equal(left, right, *args, **kwargs)
-    assert isinstance(
-        left.dtype, pd.CategoricalDtype
-    ), f"{left} is not categorical dtype"
-    assert isinstance(
-        right.dtype, pd.CategoricalDtype
-    ), f"{right} is not categorical dtype"
-
-
-def assert_numpy_array_equal(left, right):
-    left_na = pd.isna(left)
-    right_na = pd.isna(right)
-    np.testing.assert_array_equal(left_na, right_na)
-
-    left_valid = left[~left_na]
-    right_valid = right[~right_na]
-    np.testing.assert_array_equal(left_valid, right_valid)
+# re-export all the things we need from dask._pandas_compat
 
 
-def makeDataFrame():
-    data = np.random.randn(30, 4)
-    index = list(string.ascii_letters)[:30]
-    return pd.DataFrame(data, index=index, columns=list("ABCD"))
+try:
+    import pyarrow as pa
+except ImportError:
+    HAS_PYARROW = False
+else:
+    HAS_PYARROW = True
 
 
-def makeTimeDataFrame():
-    data = makeDataFrame()
-    data.index = makeDateIndex()
-    return data
+if HAS_PYARROW:
+    PYARROW_VERSION: Version | None = Version(pa.__version__)
+    # we know that Version should be non-None when PYARROW_VERSION is True.
+    PYARROW_GE_1500: bool | None = PYARROW_VERSION.release >= (15, 0, 0)  # type: ignore[union-attr]
+    PYARROW_GE_2101: bool | None = PYARROW_VERSION.release >= (21, 0, 1)  # type: ignore[union-attr]
+else:
+    PYARROW_VERSION = None
+    PYARROW_GE_1500 = None
+    PYARROW_GE_2101 = None
 
 
-def makeTimeSeries():
-    return makeTimeDataFrame()["A"]
-
-
-def makeDateIndex(k=30, freq="B"):
-    return pd.date_range("2000", periods=k, freq=freq)
-
-
-def makeTimedeltaIndex(k=30, freq="D"):
-    return pd.timedelta_range("1 day", periods=k, freq=freq)
-
-
-def makeMissingDataframe():
-    df = makeDataFrame()
-    data = df.values
-    data = np.where(data > 1, np.nan, data)
-    return pd.DataFrame(data, index=df.index, columns=df.columns)
-
-
-def makeMixedDataFrame():
-    df = pd.DataFrame(
-        {
-            "A": [0.0, 1, 2, 3, 4],
-            "B": [0.0, 1, 0, 1, 0],
-            "C": [f"foo{i}" for i in range(5)],
-            "D": pd.date_range("2009-01-01", periods=5),
-        }
-    )
-    return df
-
-
-@contextlib.contextmanager
-def check_groupby_axis_deprecation():
-    if PANDAS_GE_210:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                ".*Call without passing 'axis' instead|.*Operate on the un-grouped DataFrame instead",
-                FutureWarning,
-            )
-            yield
-    else:
-        yield
-
-
-@contextlib.contextmanager
-def check_observed_deprecation():
-    if PANDAS_GE_210:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message="The default of observed=False",
-                category=FutureWarning,
-            )
-            yield
-    else:
-        yield
-
-
-@contextlib.contextmanager
-def check_convert_dtype_deprecation():
-    if PANDAS_GE_210:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message="the convert_dtype parameter",
-                category=FutureWarning,
-            )
-            yield
-    else:
-        yield
-
-
-@contextlib.contextmanager
-def check_apply_dataframe_deprecation():
-    if PANDAS_GE_210:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message="Returning a DataFrame",
-                category=FutureWarning,
-            )
-            yield
-    else:
-        yield
-
-
-@contextlib.contextmanager
-def check_reductions_runtime_warning():
-    if not PANDAS_GE_201:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message="invalid value encountered in double_scalars|Degrees of freedom <= 0 for slice",
-                category=RuntimeWarning,
-            )
-            yield
-    else:
-        yield
-
-
-IndexingError = pd.errors.IndexingError
-
-
-def is_any_real_numeric_dtype(arr_or_dtype) -> bool:
-    return pd.api.types.is_any_real_numeric_dtype(arr_or_dtype)
-
-
-def is_string_dtype(arr_or_dtype) -> bool:
-    # is_string_dtype did not recognize pyarrow strings before 2.0
-    # Can remove once 2.0 is minimum version for us
-    if hasattr(arr_or_dtype, "dtype"):
-        dtype = arr_or_dtype.dtype
-    else:
-        dtype = arr_or_dtype
-    return pd.api.types.is_string_dtype(dtype)
+__all__ = [
+    "PANDAS_VERSION",
+    "PANDAS_GE_201",
+    "PANDAS_GE_202",
+    "PANDAS_GE_210",
+    "PANDAS_GE_211",
+    "PANDAS_GE_220",
+    "PANDAS_GE_230",
+    "PANDAS_GE_300",
+    "assert_categorical_equal",
+    "assert_numpy_array_equal",
+    "makeDataFrame",
+    "makeTimeDataFrame",
+    "makeTimeSeries",
+    "makeDateIndex",
+    "makeTimedeltaIndex",
+    "makeMissingDataframe",
+    "makeMixedDataFrame",
+    "check_groupby_axis_deprecation",
+    "check_observed_deprecation",
+    "check_convert_dtype_deprecation",
+    "check_apply_dataframe_deprecation",
+    "check_reductions_runtime_warning",
+    "is_any_real_numeric_dtype",
+    "is_string_dtype",
+    "IndexingError",
+    "HAS_PYARROW",
+    "PYARROW_VERSION",
+    "PYARROW_GE_1500",
+    "PYARROW_GE_2101",
+    "tm",
+]

--- a/dask/tokenize.py
+++ b/dask/tokenize.py
@@ -278,7 +278,8 @@ def _normalize_dataclass(obj):
 def register_pandas():
     import pandas as pd
 
-    from dask.dataframe._compat import PANDAS_GE_210
+    # use dask._pandas_compat to avoid importing dask.dataframe here
+    from dask._pandas_compat import PANDAS_GE_210
 
     @normalize_token.register(pd.RangeIndex)
     def normalize_range_index(x):


### PR DESCRIPTION
This avoids importing pyarrow unconditionally in dataframe.backends, which is reachable in some dask.array workloads (notably, those using xarray, which use pandas.Index classes, tokenization of which requires importing this module; however that class of users doesn't depend on dask[dataframe] and so may not have the pyarrow dependency.

To accomplish this, we need to reorganize the root of the dask.dataframe package a bit. I've moved some uses of pandas in dask.dataframe._compat to dask._pandas_compat, which is outside of the dask.dataframe subpackage.

This lets users of just pandas, but not dask.dataframe, (like tokenization registration for pandas objects) import from dask._pandas_compat, while avoiding all of dask.dataframe.

Closes https://github.com/dask/dask/issues/12072

---

At the moment, I've only tested this manually using the reproducer from #12072. I don't have a unit test yet. I started with

```python
@pytest.mark.filterwarnings("ignore:Passing an object to dask.array")
def test_tokenize_without_pyarrow(monkeypatch: pytest.MonkeyPatch) -> None:
    # https://github.com/dask/dask/issues/12072
    packages = list(sys.modules)
    for package in packages:
        if package.startswith(("pyarrow", "dask")):
            monkeypatch.delitem(sys.modules, package)

    monkeypatch.setitem(sys.modules, "pyarrow", None)

    y = xr.DataArray(
        data=da.zeros((1)),
        dims=('y',),
        coords={'y': np.arange(1)},
        name='foo'
    ).to_dataset()
    y['foo'] = y.foo.dims, y.foo.data + 1
    dask.optimize(y)
```

which reproduces the issues. However, the trick of messing with `sys.modules` to force re-importing modules / import errors doesn't play nicely with dask's import-time tokenization registration.