### PR TITLE
fix: csc scalar declaration in `_array_like_safe`

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -5361,11 +5361,16 @@ def test_dask_array_holds_scipy_sparse_containers(container):
 @pytest.mark.parametrize(
     "container", [pytest.param("array", marks=skip_if_no_sparray()), "matrix"]
 )
-def test_dask_array_setitem_singleton_sparse(container):
+@pytest.mark.parametrize("format", ["csr", "csc"])
+def test_dask_array_setitem_singleton_sparse(container, format):
     pytest.importorskip("scipy.sparse")
     import scipy.sparse
 
-    cls = scipy.sparse.csr_matrix if container == "matrix" else scipy.sparse.csr_array
+    cls = (
+        getattr(scipy.sparse, f"{format}_matrix")
+        if container == "matrix"
+        else getattr(scipy.sparse, f"{format}_array")
+    )
 
     x = cls(scipy.sparse.eye(100))
     x_dask = da.from_array(x)

--- a/dask/array/utils.py
+++ b/dask/array/utils.py
@@ -460,7 +460,7 @@ def _array_like_safe(np_func, da_func, a, like, **kwargs):
         # e.g. scipy.sparse.csr_matrix
         kwargs.pop("order", None)
         if np.isscalar(a):
-            a = np.array([a])
+            a = np.array([[a]])
         return type(like)(a, **kwargs)
 
     # Unknown namespace with no __array_function__ support.


### PR DESCRIPTION
- [x] Small bug I noticed: `scipy.sparse.csc_matrix(numpy.array([0]))` throws an error complaining about the dimension of the input.
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
