### PR TITLE
DOC: Add dask.tokenize to API docs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -33,6 +33,15 @@ These more general Dask functions are described below:
    persist
    visualize
 
+.. currentmodule:: dask.tokenize
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   tokenize
+   TokenizationError
+
 These functions work with any scheduler.  More advanced operations are
 available when using the newer scheduler and starting a
 :obj:`dask.distributed.Client` (which, despite its name, runs nicely on a


### PR DESCRIPTION
Adds `dask.tokenize` (and `TokenizationError`) to the API reference via autosummary so it’s included in `generated/` and linkable via intersphinx.

Closes dask/dask#11954.
