### PR TITLE
Fix mixed HLG/Expr handling in ``_ExprSequence._simplify_down``

### DIFF
--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -1238,27 +1238,30 @@ class _ExprSequence(Expr):
 
         issue_warning = False
         hlgs = []
-        for op in self.operands:
-            if isinstance(op, (HLGExpr, HLGFinalizeCompute)):
-                hlgs.append(op)
-            elif isinstance(op, dict):
-                hlgs.append(
-                    HLGExpr(
-                        dsk=HighLevelGraph.from_collections(
-                            str(id(op)), op, dependencies=()
+        if any(
+            isinstance(op, (HLGExpr, HLGFinalizeCompute, dict)) for op in self.operands
+        ):
+            for op in self.operands:
+                if isinstance(op, (HLGExpr, HLGFinalizeCompute)):
+                    hlgs.append(op)
+                elif isinstance(op, dict):
+                    hlgs.append(
+                        HLGExpr(
+                            dsk=HighLevelGraph.from_collections(
+                                str(id(op)), op, dependencies=()
+                            )
                         )
                     )
-                )
-            elif hlgs:
-                issue_warning = True
-                opt = op.optimize()
-                hlgs.append(
-                    HLGExpr(
-                        dsk=HighLevelGraph.from_collections(
-                            opt._name, opt.__dask_graph__(), dependencies=()
+                else:
+                    issue_warning = True
+                    opt = op.optimize()
+                    hlgs.append(
+                        HLGExpr(
+                            dsk=HighLevelGraph.from_collections(
+                                opt._name, opt.__dask_graph__(), dependencies=()
+                            )
                         )
                     )
-                )
         if issue_warning:
             warnings.warn(
                 "Computing mixed collections that are backed by "

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -470,6 +470,17 @@ def test_compute_array_dataframe():
 
 
 @pytest.mark.skipif("not dd")
+def test_compute_delayed_dataframe():
+    pdf = pd.DataFrame({"a": [1, 2, 3]})
+    df = dd.from_pandas(pdf, npartitions=1)
+    dl = delayed(lambda x: None)(pdf)
+    with pytest.warns(UserWarning, match="mixed.*materialize"):
+        df_out, dl_out = compute(df, dl)
+    assert dl_out is None
+    dd.utils.assert_eq(df_out, pdf)
+
+
+@pytest.mark.skipif("not dd")
 def test_compute_dataframe_valid_unicode_in_bytes():
     df = pd.DataFrame(data=np.random.random((3, 1)), columns=["ö".encode()])
     dd.from_pandas(df, npartitions=4)


### PR DESCRIPTION
The current logic in `_ExprSequence._simplify_down` only works when the non-`Expr` objects come before proper `Expr` objects in the sequence. This PR implements a simple fix and adds test coverage.

Note that the user in https://github.com/dask/distributed/issues/9117 will still get a warning when they mix the Delayed object with a DataFrame expression. However, their reproducer should work with the change in this PR.

- [x] Closes https://github.com/dask/distributed/issues/9117
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
