### PR TITLE
Add input validation on `dask.dataframe.read_sql_query()`

### DIFF
--- a/dask/dataframe/io/sql.py
+++ b/dask/dataframe/io/sql.py
@@ -84,6 +84,9 @@ def read_sql_query(
     """
     import sqlalchemy as sa
 
+    if isinstance(sql, str):
+        raise ValueError("`sql` must be a SQLAlchemy Selectable, not a string")
+
     if not isinstance(con, str):
         raise TypeError(
             "'con' must be of type str, not "

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -446,9 +446,11 @@ def test_query_with_meta(db):
     # Don't check dtype for windows https://github.com/dask/dask/issues/8620
     assert_eq(out, df[["name", "age"]], check_dtype=sys.platform != "win32")
 
+
 def test_read_sql_query_string_raises_error(db):
     with pytest.raises(ValueError):
         read_sql_query("SELECT * FROM test", db, npartitions=2, index_col="number")
+
 
 def test_no_character_index_without_divisions(db):
     # attempt to read the sql table with a character index and no divisions

--- a/dask/dataframe/io/tests/test_sql.py
+++ b/dask/dataframe/io/tests/test_sql.py
@@ -446,6 +446,9 @@ def test_query_with_meta(db):
     # Don't check dtype for windows https://github.com/dask/dask/issues/8620
     assert_eq(out, df[["name", "age"]], check_dtype=sys.platform != "win32")
 
+def test_read_sql_query_string_raises_error(db):
+    with pytest.raises(ValueError):
+        read_sql_query("SELECT * FROM test", db, npartitions=2, index_col="number")
 
 def test_no_character_index_without_divisions(db):
     # attempt to read the sql table with a character index and no divisions


### PR DESCRIPTION
To avoid unexpected errors when accidentally passing a string query to `dask.dataframe.read_sql_query()` this PR adds some input validation. To stay as flexible as possible I decided to check for "is not string", the common footgun, instead of "is SQLAlchemy Selectable", but happy to discuss this.

Closes #12028