### PR TITLE
Fix warning in test_ufunc_where_no_out

### DIFF
--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -557,7 +557,7 @@ def test_ufunc_where_no_out():
     d_left = da.from_array(left, chunks=2)
     d_right = da.from_array(right, chunks=2)
 
-    expected = np.add(left, right, where=where)
+    expected = np.add(left, right, where=where, out=None)
     result = da.add(d_left, d_right, where=d_where)
 
     # If no `out` is provided, numpy leaves elements that don't match `where`


### PR DESCRIPTION
With numpy dev, this test errors with a warning:

```
>       expected = np.add(left, right, where=where)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       UserWarning: 'where' used without 'out', expect unitialized memory in output. If this is intentional, use out=None.

```

This should resolve the last issue in https://github.com/dask/dask/issues/12076