### PR TITLE
Fix: avoid using methods.concat on empty lists

### DIFF
--- a/dask/dataframe/dask_expr/_concat.py
+++ b/dask/dataframe/dask_expr/_concat.py
@@ -58,20 +58,24 @@ class Concat(Expr):
     @functools.cached_property
     def _meta(self):
         # ignore DataFrame without columns to avoid dtype upcasting
-        return make_meta(
-            methods.concat(
-                [
-                    meta_nonempty(df._meta)
-                    for df in self._frames
-                    if df.ndim < 2 or len(df._meta.columns) > 0
-                ],
-                join=self.join,
-                filter_warning=False,
-                axis=self.axis,
-                ignore_order=self.ignore_order,
-                **self._kwargs,
+        filtered = [
+            meta_nonempty(df._meta)
+            for df in self._frames
+            if df.ndim < 2 or len(df._meta.columns) > 0
+        ]
+        if len(filtered) == 0:
+            return make_meta(meta_nonempty(self._frames[0]._meta))
+        else:
+            return make_meta(
+                methods.concat(
+                    filtered,
+                    join=self.join,
+                    filter_warning=False,
+                    axis=self.axis,
+                    ignore_order=self.ignore_order,
+                    **self._kwargs,
+                )
             )
-        )
 
     def _divisions(self):
         dfs = self._frames

--- a/dask/dataframe/dask_expr/tests/test_concat.py
+++ b/dask/dataframe/dask_expr/tests/test_concat.py
@@ -86,6 +86,12 @@ def test_concat_one_no_columns(df, pdf):
     assert_eq(result, expected)
 
 
+def test_concat_multiple_no_columns(df, pdf):
+    result = concat([df[[]], df[[]]])
+    expected = pd.concat([pdf[[]], pdf[[]]])
+    assert_eq(result, expected)
+
+
 def test_concat_simplify(pdf, df):
     pdf2 = pdf.copy()
     pdf2["z"] = 1


### PR DESCRIPTION
- [x] Closes #12063 
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
