### PR TITLE
cupy compatibility for percentile

### DIFF
--- a/dask/array/backends.py
+++ b/dask/array/backends.py
@@ -138,6 +138,7 @@ def register_cupy():
     percentile_lookup.register(cupy.ndarray, percentile)
     numel_lookup.register(cupy.ndarray, _numel_arraylike)
     nannumel_lookup.register(cupy.ndarray, _nannumel)
+    empty_lookup.register(cupy.ndarray, cupy.empty)
 
     @to_numpy_dispatch.register(cupy.ndarray)
     def cupy_to_numpy(data, **kwargs):

--- a/dask/array/tests/test_cupy_percentile.py
+++ b/dask/array/tests/test_cupy_percentile.py
@@ -10,6 +10,10 @@ from dask.array.utils import assert_eq, same_keys
 
 cupy = pytest.importorskip("cupy")
 
+import dask.array.backends
+
+dask.array.backends.register_cupy()
+
 
 def test_percentile():
     d = da.from_array(cupy.ones((16,)), chunks=(4,))
@@ -60,7 +64,7 @@ def test_percentiles_with_scaler_percentile(q):
     result = da.percentile(d, q, method="midpoint")
     assert type(result._meta) == cupy.ndarray
     assert_eq(result, result)  # Check that _meta and computed arrays match types
-    assert_eq(result, np.array([1], dtype=d.dtype), check_type=False)
+    assert_eq(result, np.array(1, dtype=d.dtype), check_type=False)
 
 
 def test_percentiles_with_unknown_chunk_sizes():


### PR DESCRIPTION
After #12088, a few tests in `dask/array/tests/test_cupy_percentile.py` were failing.

- cupy doesn't currently support `np.concatenate((list_of_int, cupy_ndarray))`
- pieces of the code allocated numpy ndarrays, instead of ndarrays of the same type of the input

Fixes https://github.com/rapidsai/dask-upstream-testing/issues/81. I've tested the changes locally with cupy.