### PR TITLE
Add uv.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ hdfs-initialized-indicator
 .env
 .history
 env.yaml
+uv.lock


### PR DESCRIPTION
I've been using `uv` more and more recently. I used it while working on the docs updates in #12093. It kept creating and updating a lock file that we don't want to commit in here. 

Usually I would add things like this to my global gitignore, but there are some projects where we explicitly do want to include the `uv.lock`. So it should probably go in the gitignore here.