### PR TITLE
Docs: mention that describe() uses approximate algorithms (#10416)

### DIFF
--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -142,6 +142,13 @@ DataFrame
     DataFrame.visualize
     DataFrame.where
 
+	.. note::
+
+   The ``describe()`` method in Dask uses **approximate algorithms**
+   to speed up computations on large datasets.
+   Therefore, results may slightly differ from exact pandas outputs.
+
+	
 Series
 ~~~~~~
 


### PR DESCRIPTION
This PR updates the DataFrame API docs to clarify that
the `describe()` method in Dask uses approximate algorithms
for large datasets, which may lead to slight differences
from Pandas results.
