### PR TITLE
Adjust pyarrow version skip in test_parquet

### DIFF
--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -179,7 +179,7 @@ def test_parquet(engine):
     pytest.importorskip("requests", minversion="2.21.0")
     dd = pytest.importorskip("dask.dataframe")
     pa = pytest.importorskip(engine)
-    if Version(pa.__version__) == Version("22.0.0"):
+    if Version(pa.__version__) >= Version("22.0.0"):
         pytest.skip(reason="https://github.com/apache/arrow/issues/47981")
 
     df = dd.read_parquet(


### PR DESCRIPTION
We install pyarrow nigthly in our upstream-dev test, which has a higher version number than what the version check matched. I've adjusted the test to skip pyarrow>=22.0.0.

Closes https://github.com/dask/dask/issues/12123