### PR TITLE
Update ``np.accumulate`` workaround comment

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1223,8 +1223,9 @@ def cumreduction(
         use_dtype = "dtype" in func_params
     except ValueError:
         try:
-            # Workaround for https://github.com/numpy/numpy/issues/30095
+            # Workaround for numpy<=2.3.4
             # np.ufunc.accumulate doesn't have a signature, but it does accept dtype
+            # See https://github.com/numpy/numpy/issues/30095
             if isinstance(func.__self__, np.ufunc) and func.__name__ == "accumulate":
                 use_dtype = True
         except AttributeError:


### PR DESCRIPTION
Even though https://github.com/numpy/numpy/pull/30104 is merged we still need to maintain our workaround for https://github.com/numpy/numpy/issues/30095 until our minimum numpy version is higher than `2.3.4`.

This PR updates the comment in the workaround to make it clear when the workaround can be removed by some future maintainer.