### PR TITLE
FIX: Stabilize test_filter_nonpartition_columns

### DIFF
--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -2538,6 +2538,10 @@ def test_filter_nonpartition_columns(
             "random": np.random.choice(["cat", "dog"], size=16),
         }
     )
+    df_write["random"] = df_write["random"].astype(
+        pd.CategoricalDtype(categories=["cat", "dog"])
+    )
+
     ddf_write = dd.from_pandas(df_write, npartitions=4)
     ddf_write.to_parquet(
         tmpdir, write_index=False, partition_on=["id"], engine=write_engine


### PR DESCRIPTION
- [x] Closes #12128 
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

This PR fixes a flaky (unstable) test `test_filter_nonpartition_columns` that was occasionally failing in CI.