### PR TITLE
Ruff supersedes absolufy-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,6 @@ repos:
     hooks:
       - id: end-of-file-fixer
       - id: debug-statements
-  - repo: https://github.com/MarcoGorelli/absolufy-imports
-    rev: v0.3.1
-    hooks:
-      - id: absolufy-imports
-        name: absolufy-imports
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.2
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ line-length = 120
 # We specify additional rules with extend-select.
 extend-select = [
     "B",
+    "TID",
     "PLR",
     "UP",
 ]


### PR DESCRIPTION
From https://github.com/MarcoGorelli/absolufy-imports:
> This repository was archived by the owner on Jul 3, 2024. It is now read-only. 

> This tool has been superseded by Ruff https://docs.astral.sh/ruff/rules/relative-imports/. Please use that instead.
> 
> R.I.P. `absolufy-imports`