### PR TITLE
Replace pre-commit hook with ruff rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,8 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: end-of-file-fixer
-      - id: debug-statements
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.2
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ line-length = 120
 # We specify additional rules with extend-select.
 extend-select = [
     "B",
+    "T10",
     "TID",
     "PLR",
     "UP",


### PR DESCRIPTION
flake8-debugger rule is equivalent to debug-statements pre-commit hook.