### PR TITLE
pre-commit black hook: use implicit defaults

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,9 +11,6 @@ repos:
     rev: 25.11.0
     hooks:
       - id: black
-        language_version: python3
-        args:
-          - --target-version=py310
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:


### PR DESCRIPTION
The black [`--target-version`](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#t-target-version) option does not seem useful nowadays, since black can infer the target version automatically:
> By default, Black will infer target versions from the project metadata in `pyproject.toml`, specifically the `[project.requires-python]` field. If this does not yield conclusive results, Black will use per-file auto-detection.

The pre-commit [`language_version`](https://pre-commit.com/#top_level-default_language_version) option currently [specifies Python 3, which goes without saying nowadays](https://black.readthedocs.io/en/stable/integrations/source_version_control.html):
> ```
>         # It is recommended to specify the latest version of Python
>         # supported by your project here, or alternatively use
>         # pre-commit's default_language_version, see
>         # https://pre-commit.com/#top_level-default_language_version
> ```

This is a follow-up to the decision taken in https://github.com/dask/dask/pull/12126#pullrequestreview-3464661665.