### PR TITLE
DEP: bump minimal requirement on toolz (0.10.0 -> 0.12.0)

### DIFF
--- a/continuous_integration/environment-mindeps-array.yaml
+++ b/continuous_integration/environment-mindeps-array.yaml
@@ -11,7 +11,7 @@ dependencies:
   - partd=1.2.0
   - fsspec=2021.09.0
   - importlib-metadata=4.13.0
-  - toolz=0.10.0
+  - toolz=0.12.0
   # optional dependencies pulled in by pip install dask[array]
   - numpy=1.21
   # test dependencies

--- a/continuous_integration/environment-mindeps-dataframe.yaml
+++ b/continuous_integration/environment-mindeps-dataframe.yaml
@@ -11,7 +11,7 @@ dependencies:
   - partd=1.2.0
   - fsspec=2021.09.0
   - importlib-metadata=4.13.0
-  - toolz=0.10.0
+  - toolz=0.12.0
   # optional dependencies pulled in by pip install dask[dataframe]
   - numpy=1.21
   - pandas=1.3

--- a/continuous_integration/environment-mindeps-distributed.yaml
+++ b/continuous_integration/environment-mindeps-distributed.yaml
@@ -11,7 +11,7 @@ dependencies:
   - partd=1.2.0
   - fsspec=2021.09.0
   - importlib-metadata=4.13.0
-  - toolz=0.10.0
+  - toolz=0.12.0
   # optional dependencies pulled in by pip install dask[distributed]
   - pip
   - pip:

--- a/continuous_integration/environment-mindeps-non-optional.yaml
+++ b/continuous_integration/environment-mindeps-non-optional.yaml
@@ -11,7 +11,7 @@ dependencies:
   - partd=1.2.0
   - fsspec=2021.09.0
   - importlib-metadata=4.13.0
-  - toolz=0.10.0
+  - toolz=0.12.0
   # test dependencies
   - pre-commit
   - pytest

--- a/continuous_integration/environment-mindeps-optional.yaml
+++ b/continuous_integration/environment-mindeps-optional.yaml
@@ -11,7 +11,7 @@ dependencies:
   - partd=1.2.0
   - fsspec=2021.09.0
   - importlib-metadata=4.13.0
-  - toolz=0.10.0
+  - toolz=0.12.0
   # optional dependencies pulled in by pip install dask[array,dataframe]
   - numpy=1.21
   - pandas=1.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "packaging >= 20.0",
     "partd >= 1.2.0",
     "pyyaml >= 5.3.1",
-    "toolz >= 0.10.0",
+    "toolz >= 0.12.0",
     # importlib.metadata has the following bugs fixed in 3.10.9 and 3.11.1
     # https://github.com/python/cpython/issues/99130
     # https://github.com/python/cpython/issues/98706


### PR DESCRIPTION
- [x] Closes #12162
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`
