### PR TITLE
tweak setuptools-scm and pins to allow upstream installs with distributed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dataframe = [
     "pandas >= 2.0",
     "pyarrow>=14.0.1",
 ]
-distributed = ["distributed == 2025.11.0"]
+distributed = ["distributed >=2025.11.0,<2025.11.1"]
 diagnostics = [
     "bokeh >= 3.1.0",
     "jinja2 >= 2.10.3",
@@ -144,6 +144,7 @@ ignore = [
 
 [tool.setuptools_scm]
 version_file = "dask/_version.py"
+version_scheme = "post-release"
 
 [tool.pytest.ini_options]
 markers = [


### PR DESCRIPTION
You need the version-scheme change in addition to the pinning change so that it does not get resolved to 2025.11.1.dev.... which would then not allow it to work.

Paired PR for distributed: https://github.com/dask/distributed/pull/9155

- [x] Closes https://github.com/dask/dask/issues/12167
- [NA] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
