### PR TITLE
Build llms.txt files in Sphinx documentation

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -7,6 +7,7 @@ sphinx-remove-toctrees
 sphinx_autosummary_accessors
 sphinx-tabs
 sphinx-design
+sphinx-llm
 jupyter_sphinx
 nbconvert
 toolz

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,6 +52,7 @@ extensions = [
     "jupyter_sphinx",
     "sphinx_copybutton",
     "sphinx_design",
+    "sphinx_llm.txt",
 ]
 
 copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "


### PR DESCRIPTION
Adds documentation support for [llms.txt](https://llmstxt.org/) via the `sphinx-llm` extension that I wrote.

In addition to building HTML pages, a markdown version of the documentation is also built for consumption by LLMs. This reduces the amount of context window space LLMs need to use by removing HTML/CSS/JavaScript markup in favour of more streamlined markdown.

- For each documentation page a markdown version is built using the [sphinx-markdown-builder](https://pypi.org/project/sphinx-markdown-builder/) (you can append `.md` to any documentation URL to view this)
- An `llms.txt` file file is generated which acts as a sitemap for LLMs to use to discover pages
- An `llms-full.txt` file is generated with the entire docs contained in a single markdown file to allow loading all of the Dask docs into context with a single HTTP request (which for Dask would use 1.1M input tokens 🙀)

### Build preview highlights
| Page | HTML | Markdown |
| --- | --- | --- |
| llms.txt | NA | [Markdown](https://dask--12192.org.readthedocs.build/en/12192/llms.txt) |
| 10 minutes to dask | [HTML](https://dask--12192.org.readthedocs.build/en/12192/10-minutes-to-dask.html) |  [Markdown](https://dask--12192.org.readthedocs.build/en/12192/10-minutes-to-dask.html.md) |
| API docs example (`dask.array.angle`) | [HTML](https://dask--12192.org.readthedocs.build/en/12192/generated/dask.array.angle.html#dask.array.angle) | [Markdown](https://dask--12192.org.readthedocs.build/en/12192/generated/dask.array.angle.html.md) |