### PR TITLE
Tweak MacOS CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,17 +25,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-latest", "ubuntu-latest", "macos-14"]
+        os: ["windows-latest", "ubuntu-latest", "macos-latest"]
         environment: ["3.10", "3.11", "3.12", "3.13"]
         extra: [null]
         array-expr: ["false"]
-        exclude:
-          - os: "macos-14"
-            environment: "3.10"
-          - os: "macos-14"
-            environment: "3.11"
-          - os: "macos-14"
-            environment: "3.13"
         include:
           # Minimum dependencies
           - os: "ubuntu-latest"


### PR DESCRIPTION
- Bump MacOS CI runners from macos 14 to macos 15
- Historically, Mac runners were used very parsimoniously due to their slowness and scarce availability. This dates back to the era of mac intel. Neither are an issue today with modern ARM runners. Remove a bunch of skips.