### PR TITLE
fix: Concat expr _simplify_up raise IndexError when optimized column set is empty

### DIFF
--- a/dask/dataframe/dask_expr/_concat.py
+++ b/dask/dataframe/dask_expr/_concat.py
@@ -250,6 +250,10 @@ class Concat(Expr):
 
             columns = determine_column_projection(self, parent, dependents)
             columns = _convert_to_list(columns)
+
+            if len(columns) == 0:
+                return
+
             columns_frame = [
                 [col for col in get_columns_or_name(frame) if col in columns]
                 for frame in self._frames


### PR DESCRIPTION
1. I met reproducible exception "IndexError: list index out of range" when I excuted codes below:

- codes
```python
import pandas as pd
import numpy as np
import dask.dataframe as dd
import dask

df1 = pd.DataFrame(np.random.randint(50, 100, (50, 5)), columns=['A', 'B', 'C', 'D', 'E'])
df2 = pd.DataFrame(np.random.randint(50, 100, (2, 5)), columns=['A', 'B', 'C', 'D', 'E'])

ddf1 = dd.from_pandas(
    df1,
    npartitions=5,
    sort=False
)

ddf2 = dd.from_pandas(
    df2,
    npartitions=1 ,
    sort=False
)

ddf = dd.concat([ddf1,ddf2])

ddf['x'] = 1
ddf['x'] = ddf.x.cumsum()
ddf = ddf.set_index('x', npartitions=10)
print(ddf.compute())
```

- traceback
```python
File "/home/skpy/pyTest/.venv/lib/python3.11/site-packages/dask/_expr.py", line 404, in simplify_once
  out = child._simplify_up(expr, dependents)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/skpy/pyTest/.venv/lib/python3.11/site-packages/dask/dataframe/dask_expr/_concat.py", line 299, in _simplify_up
  if result.columns == _convert_to_list(parent.operand("columns")):
     ^^^^^^^^^^^^^^
File "/home/skpy/pyTest/.venv/lib/python3.11/site-packages/dask/dataframe/dask_expr/_expr.py", line 452, in columns
  return list(self._meta.columns)
              ^^^^^^^^^^
File "/usr/local/lib/python3.11/functools.py", line 1001, in __get__
  val = self.func(instance)
        ^^^^^^^^^^^^^^^^^^^
File "/home/skpy/pyTest/.venv/lib/python3.11/site-packages/dask/dataframe/dask_expr/_concat.py", line 67, in _meta
  return make_meta(meta_nonempty(self._frames[0]._meta))
                                 ~~~~~~~~~~~~^^^
IndexError: list index out of range
```

2. After debugging, I think it's because when the parent expr of concat expr is Projection and the calculated projection column set is empty, a Concat(frames=[],) will be calculated and accessing the _meta of this object will cause the above error.

```python
299 B->	            if result.columns == _convert_to_list(parent.operand("columns")):
300  	                if result.ndim == parent.ndim:
301  	                    return result
302  	                elif result.ndim < parent.ndim:
303  	                    return ToFrame(result)
304
305  	            return type(parent)(result, *parent.operands[1:])
(Pdb) result
Concat(frames=[], )
(Pdb) self
Concat(frames=[df, df], )
(Pdb) parent
(Concat(frames=[df, df], ))[[]]
(Pdb)
```

3. This problem was solved by directly returning when the calculated projection columns were empty.