### PR TITLE
Test array expr on Python 3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,10 +43,10 @@ jobs:
             environment: "mindeps-optional"
           # Experimental setups
           - os: "ubuntu-latest"
-            environment: "3.12"
+            environment: "3.14"
             extra: "pandas-nightly"
           - os: "ubuntu-latest"
-            environment: "3.12"
+            environment: "3.14"
             array-expr: "true"
 
     env:


### PR DESCRIPTION
Issues around pickling in Python 3.14 were recently fixed (#12206).

There are unit tests that verify that all Expr's are pickleable.
This PR ensures that the specific Expr's used by dask.array are tested for serialization under 3.14 too, and not just those for dask.dataframe.

Closes #12043