### PR TITLE
Disable some Mac builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,16 @@ jobs:
         environment: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         extra: [null]
         array-expr: ["false"]
+        exclude:
+          # MacOS CI does not have many hosts available; run it on 3.14 only
+          - os: "macos-latest"
+            environment: "3.10"
+          - os: "macos-latest"
+            environment: "3.11"
+          - os: "macos-latest"
+            environment: "3.12"
+          - os: "macos-latest"
+            environment: "3.13"
         include:
           # Minimum dependencies
           - os: "ubuntu-latest"

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,7 +9,7 @@ codecov:
   # This number is informed by the number of builds defined by the matrix in
   # .github/workflows/tests.yml.
   notify:
-    after_n_builds: 22
+    after_n_builds: 18
 
 coverage:
   precision: 2


### PR DESCRIPTION
- Partially reverts #12200, as there is in fact scarcity of macos-latest runners (is this an org-specific thing?)
- Aligns dask/dask to dask/distributed