### PR TITLE
Preliminary Python 3.14t support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         # Note: after adding/removing builds here, update
         # codecov.yml to match.
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        environment: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        environment: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
         extra: [null]
         array-expr: ["false"]
         exclude:
@@ -42,6 +42,8 @@ jobs:
             environment: "3.12"
           - os: "macos-latest"
             environment: "3.13"
+          - os: "macos-latest"
+            environment: "3.14t"
         include:
           # Minimum dependencies
           - os: "ubuntu-latest"
@@ -99,6 +101,13 @@ jobs:
           export DASK_DATAFRAME__CONVERT_STRING="False"
           echo "DASK_DATAFRAME__CONVERT_STRING: $DASK_DATAFRAME__CONVERT_STRING"
           echo "DASK_DATAFRAME__CONVERT_STRING=$DASK_DATAFRAME__CONVERT_STRING" >> $GITHUB_ENV
+
+      # FIXME https://github.com/msgpack/msgpack-python/issues/613
+      - name: Disable msgpack C extension on free-threading
+        if: ${{ matrix.environment == '3.14t' }}
+        run: |
+          mamba uninstall -y msgpack-python
+          MSGPACK_PUREPYTHON=1 pip install msgpack --no-binary msgpack --no-cache -v
 
       - name: Reconfigure pytest-timeout
         # No SIGALRM available on Windows

--- a/continuous_integration/environment-3.14t.yaml
+++ b/continuous_integration/environment-3.14t.yaml
@@ -1,0 +1,88 @@
+name: test-environment
+channels:
+  - conda-forge
+dependencies:
+  # required dependencies
+  - python-freethreading=3.14
+  - packaging
+  - pyyaml
+  - click
+  - cloudpickle
+  - partd
+  - fsspec
+  - toolz
+  # test dependencies
+  - pre-commit
+  - pytest
+  - pytest-cov
+  - pytest-mock
+  - pytest-rerunfailures
+  - pytest-timeout
+  - pytest-xdist
+  - coverage
+  # key optional dependencies
+  - numpy
+  # - pandas >=3  # Needed for free-threading  # FIXME race conditions in 3.0.0rc1
+  # - pyarrow
+  # conda variant of distributed depends on cytoolz, which is not available
+  # on conda yet.
+  # Manually install distributed dependencies from conda below.
+  # - distributed  # Overridden by git tip below; used to pull in dependencies
+  # optional s3 I/O
+  - boto3
+  - botocore
+  # - moto<5  # Not available for 3.14t on Windows
+  - s3fs>=2021.9.0
+  # other optional dependencies
+  - mimesis
+  # - numba  # Not available for 3.14t
+  - flask
+  # - h5py  # Not available for 3.14t
+  # - pytables  # Not available for 3.14t
+  # - zarr  # Not available for 3.14t
+  # - pyspark  # Huge package; limit where it is tested
+  # - tiledb-py  # Not available for 3.14t
+  # - tiledb  # Not available for 3.14t
+  # - xarray  # Requires pandas
+  # - sqlalchemy  # Not available for 3.14t
+  - jsonschema
+  # - bokeh  # Requires pandas
+  - httpretty
+  - aiohttp
+  # - crick  # No Python 3.14 build yet
+  # - cytoolz  # conda package for 3.14t not yet available; installed via pip below
+  - ipython
+  - ipycytoscape
+  - ipywidgets
+  # - ipykernel  # Not available for 3.14t
+  - lz4
+  - psutil
+  - requests
+  - scikit-image
+  - scikit-learn
+  - scipy
+  - python-snappy
+  # - sparse  # Not available for 3.14t
+  - cachey
+  - python-graphviz
+  # - python-cityhash  # Not available for 3.14t
+  - python-xxhash
+  - mmh3
+  - jinja2
+
+  # FIXME pull in distributed dependencies from conda (see above)
+  - locket
+  # FIXME https://github.com/msgpack/msgpack-python/issues/613
+  # Install placeholder to prevent distributed below from compiling the C extension from
+  # sources. tests.yml will replace this with a pure-python variant.
+  - msgpack-python
+  - sortedcontainers
+  - tblib
+  - tornado
+  - urllib3
+  - zict
+
+  - pip
+  - pip:
+    - cytoolz  # conda package for 3.14t not yet available
+    - git+https://github.com/dask/distributed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: Free Threading :: 1 - Unstable",
     "Topic :: Scientific/Engineering",
     "Topic :: System :: Distributed Computing",
 ]


### PR DESCRIPTION
- Run test suite on 3.14t, without pandas for now. While pandas 3 in theory supports free-threading, there are many race conditions left in 3.0.0rc1. [EDIT] support for pandas >=3.0.1 added in #12284
- msgpack, which is a key dependency of `distributed`, currently needs a very ugly hack. This is being tracked upstream (https://github.com/msgpack/msgpack-python/issues/613). As I was forced to install it in pure-python mode, I would advise against running benchmarks until the C extension becomes available.
- Many other optional dependencies are still missing and will be added as they become available.
- Added pypi classifier `Programming Language :: Python :: Free Threading :: 1 - Unstable`. Technically it's known broken for dask.dataframe and `2 - Beta` for everything else. I will bump the flag to `2 - Beta` once pandas fixes the race conditions upstream and we can reintroduce it to the CI environment. Also probably a good idea to wait for a hack-free msgpack before we indicate a good user experience.

This PR incorporates and is blocked by https://github.com/dask/dask/pull/12224. This PR only adds the last commit https://github.com/dask/dask/pull/12223/commits/208891b2348000d78e4e7bbd4bfb5161a9fd63aa.
