### PR TITLE
Relax `test_serialization`

### DIFF
--- a/dask/dataframe/dask_expr/tests/test_collection.py
+++ b/dask/dataframe/dask_expr/tests/test_collection.py
@@ -1390,7 +1390,7 @@ def test_column_getattr(df):
 def test_serialization(pdf, df):
     before = pickle.dumps(df)
 
-    assert len(before) < 350 + len(pickle.dumps(pdf))
+    assert len(before) < 500 + len(pickle.dumps(pdf))
 
     part = df.partitions[0].compute()
     assert (


### PR DESCRIPTION
This is failing 
- on python 3.10/pandas 2.1.4, by adding 426 bytes on top of the plain pandas pickle size of 2316 bytes
- on 3.14/pandas 3 nightly, by adding 450 bytes on top of the plain pandas pickle size of 2416 bytes