### PR TITLE
Pin to sphinx<9 until it's supported in sphinx-autosummary-accessors

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,5 +1,7 @@
 numpydoc
-sphinx>=8.0.0
+# Pin to sphinx<9 until it's supported in sphinx-autosummary-accessors
+# https://github.com/xarray-contrib/sphinx-autosummary-accessors/issues/165
+sphinx>=8.0.0,<9.0.0 
 dask-sphinx-theme>=4.0.0
 sphinx-click
 sphinx-copybutton


### PR DESCRIPTION
Docs builds are failing in recent PRs. Looks like `sphinx` 9 isn't supported in `sphinx-autosummary-accessors` yet (xref https://github.com/xarray-contrib/sphinx-autosummary-accessors/issues/165)

For now pinning to `sphinx<9`