### PR TITLE
Update map_meta test

### DIFF
--- a/dask/dataframe/dask_expr/tests/test_collection.py
+++ b/dask/dataframe/dask_expr/tests/test_collection.py
@@ -954,6 +954,7 @@ def test_map_meta(pdf, df):
 
     pdf.index.name = "a"
     df = from_pandas(pdf, npartitions=10)
+    expected = pdf.x.map(lambda x: x + 1)
     result = df.x.map(lambda x: x + 1, meta=("x", "int64"))
     assert_eq(result, expected)
 


### PR DESCRIPTION
With pandas 3.x, the behavior of this test changed, probably related to copy-on-write, so that mutating

```
expected = pdf.x.map(lambda x: x + 1)
pdf.index.name = "a"
```

no longer mutated `expected.index.name`.

This updates the test to recompute `expected` after modifying the index.

Closes https://github.com/dask/dask/issues/12225
Closes https://github.com/dask/dask/issues/12203