### PR TITLE
Set the integer size in `test_merge_groupby_to_frame`

### DIFF
--- a/dask/dataframe/dask_expr/tests/test_partitioning_knowledge.py
+++ b/dask/dataframe/dask_expr/tests/test_partitioning_knowledge.py
@@ -211,13 +211,19 @@ def test_avoid_shuffle_on_top_of_lowered_shuffle():
 
 def test_merge_groupby_to_frame():
     pdf = pd.DataFrame(
-        {"a": np.random.randint(1, 5, (10,)), "b": np.random.randint(1, 5, (10,))}
+        {
+            "a": np.random.randint(1, 5, (10,), dtype=np.int64),
+            "b": np.random.randint(1, 5, (10,), dtype=np.int64),
+        }
     )
 
     df = from_pandas(pdf, npartitions=4)
 
     pdf2 = pd.DataFrame(
-        {"a": np.random.randint(1, 5, (10,)), "c": np.random.randint(1, 5, (10,))}
+        {
+            "a": np.random.randint(1, 5, (10,), dtype=np.int64),
+            "c": np.random.randint(1, 5, (10,), dtype=np.int64),
+        }
     )
 
     df2 = from_pandas(pdf2, npartitions=3)


### PR DESCRIPTION
Spotted in https://github.com/dask/dask/pull/12243, on our windows CI this test was failing now that pandas 3 is out.

Most likely, pandas 3.x changed something to use / preserve the native integer size on some operation. I haven't had a chance to debug it so for now I've changed the test to explicitly set int64. If someone needs the native dtype to work we can look into it then.