### PR TITLE
Ignore deprecationwarning on np.fix

### DIFF
--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2595,6 +2595,7 @@ def test_astype_gh9316():
     assert result_a.flags.f_contiguous == result_b.flags.f_contiguous
 
 
+@pytest.mark.filterwarnings("ignore:numpy.fix")
 def test_arithmetic():
     x = np.arange(5).astype("f4") + 2
     y = np.arange(5).astype("i8") + 2


### PR DESCRIPTION
`np.fix` is deprecated in favor of `truncate` in numpy dev, which caused this CI failure: https://github.com/dask/dask/actions/runs/21265711665/job/61204253570#step:6:37038

Closes #12245 

This PR ignores that warning. We want to keep testing `fix` until it's removed, but we don't care that it's deprecated.