### PR TITLE
Run test suite with xarray but without zarr

### DIFF
--- a/dask/array/tests/test_xarray.py
+++ b/dask/array/tests/test_xarray.py
@@ -91,6 +91,8 @@ def test_positional_indexer_multiple_variables():
 
 @pytest.mark.parametrize("compute", [True, False])
 def test_xarray_blockwise_fusion_store(compute):
+    pytest.importorskip("zarr")
+
     def custom_scheduler_get(dsk, keys, expected, **kwargs):
         dsk = dsk.__dask_graph__()
         assert (


### PR DESCRIPTION
This was prompted by ongoing work on 3.14t support.
xarray is available on 3.14t, but zarr is not at the moment of writing.

(To be more precise, zarr's dependency `numcodecs` has no conda-forge package nor pip wheels. When compiled from sources, it does not release the GIL after import).