### PR TITLE
Fix Zarr write chunking warning logic

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3852,31 +3852,46 @@ def _write_dask_to_existing_zarr(
             for s, c, r in zip(z.shape, dask_write_chunks, index)
         )
 
-    for ax, (dw, zw) in enumerate(
-        zip(dask_write_chunks, zarr_write_chunks, strict=True)
+    for ax, (dw, zw, shape_ax) in enumerate(
+        zip(dask_write_chunks, zarr_write_chunks, z.shape, strict=True)
     ):
         if len(dw) >= 1:
             nominal_dask_chunk_size = dw[0]
             if not nominal_dask_chunk_size % zw == 0:
-                safe_chunk_size = np.prod(zarr_write_chunks) * max(1, z.dtype.itemsize)
-                msg = (
-                    f"The input Dask array will be rechunked along axis {ax} with chunk size "
-                    f"{nominal_dask_chunk_size}, but a chunk size divisible by {zw} is "
-                    f"required for Dask to write safely to the Zarr array {z}. "
-                    "To avoid risk of data loss when writing to this Zarr array, set the "
-                    '"array.chunk-size" configuration parameter to at least the size in'
-                    " bytes of a single on-disk "
-                    f"chunk (or shard) of the Zarr array, which in this case is "
-                    f"{safe_chunk_size} bytes. "
-                    f'E.g., dask.config.set({{"array.chunk-size": {safe_chunk_size}}})'
-                )
+                write_size = sum(dw)
+                has_misaligned_chunks = False
+                if len(dw) > 1:
+                    for chunk_size in dw[:-1]:
+                        if chunk_size < zw or (
+                            chunk_size > zw and chunk_size % zw != 0
+                        ):
+                            has_misaligned_chunks = True
+                            break
+                elif (
+                    len(dw) == 1
+                    and nominal_dask_chunk_size > zw
+                    and write_size < shape_ax
+                ):
+                    has_misaligned_chunks = True
 
-                warnings.warn(
-                    msg,
-                    PerformanceWarning,
-                    stacklevel=3,
-                )
-                break
+                if has_misaligned_chunks:
+                    safe_chunk_size = np.prod(zarr_write_chunks) * max(
+                        1, z.dtype.itemsize
+                    )
+                    msg = (
+                        f"The input Dask array has been rechunked along axis {ax} with chunk size {nominal_dask_chunk_size}, "
+                        f"which does not align with the Zarr array's chunk size of {zw}. This can cause race conditions or data loss. "
+                        "To avoid this issue, increase the 'array.chunk-size' configuration to at least "
+                        f"{safe_chunk_size} bytes (the size of one Zarr chunk), "
+                        f"and/or manually rechunk the array to align with boundaries of size {zarr_write_chunks}."
+                    )
+
+                    warnings.warn(
+                        msg,
+                        PerformanceWarning,
+                        stacklevel=3,
+                    )
+                    break
 
     arr = arr.rechunk(dask_write_chunks)
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -5250,9 +5250,51 @@ def test_zarr_risky_shards_warns():
     with dask.config.set({"array.chunk-size": 1}):
         with pytest.raises(
             PerformanceWarning,
-            match="The input Dask array will be rechunked along axis",
+            match="The Dask array will be rechunked along axis",
         ):
             arr.to_zarr(z)
+
+
+def test_zarr_valid_shard_without_evenly_dividing_array():
+    """
+    Test that we don't warn when shard shape doesn't evenly divide array shape.
+    """
+    zarr = pytest.importorskip("zarr", minversion="3.0.0")
+
+    shape = (65, 65, 65)
+    zarr_chunk_shape = (16, 16, 16)
+    zarr_shard_shape = (32, 32, 32)
+
+    arr = da.ones(shape, chunks=(32, 32, 32))
+
+    z = zarr.create_array(
+        store={},
+        shape=shape,
+        chunks=zarr_chunk_shape,
+        shards=zarr_shard_shape,
+        dtype=arr.dtype,
+    )
+
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", PerformanceWarning)
+        result = arr.to_zarr(z, compute=False)
+        result.compute()
+
+    assert_eq(z[...], arr.compute())
+
+
+def test_zarr_multiple_writes_to_one_chunk():
+    """
+    Test that we warn when multiple writes would be made similtaneously to a single zarr chunk.
+    """
+    zarr = pytest.importorskip("zarr")
+    b = da.arange(4).rechunk(1)
+    z_small = zarr.zeros(4, chunks=2)
+    with dask.config.set({"array.chunk-size": 1}):
+        with pytest.warns(PerformanceWarning, match="do not align"):
+            b.to_zarr(z_small)
 
 
 def test_zarr_nocompute():
@@ -5287,8 +5329,7 @@ def test_zarr_regions():
     assert_eq(a2, expected)
     assert a2.chunks == a.chunks
 
-    with pytest.warns(PerformanceWarning):
-        a[3:, 3:].to_zarr(z, region=(slice(2, 3), slice(1, 2)))
+    a[3:, 3:].to_zarr(z, region=(slice(2, 3), slice(1, 2)))
 
     a2 = da.from_zarr(z)
     expected = [[0, 1, 0, 0], [4, 5, 3, 0], [0, 15, 7, 0], [0, 0, 11, 0]]


### PR DESCRIPTION
- [x] #12263
- [X] Tests added / passed
  - Passes existing zarr writing tests, with a minor change to `test_zarr_regions` where that test was assuming the faulty behavior
  - Adds `test_zarr_multiple_writes_to_one_chunk`
  - Adds `test_zarr_valid_shard_without_evenly_dividing_array`
- [X] Passes `pre-commit run --all-files`

The zarr writing code introduced by PR #12153 added a performance warning in cases where writing is unsafe. However, its logic for determining when a write would be unsafe isn't precise enough, and it raises the warning whenever the Zarr chunk size doesn't evenly divide into the array size. This is an issue because the last Zarr chunk is allowed to be smaller than the rest.

I haven't changed it here, but perhaps this should also be more than a performance warning? It seems like non-deterministic write behavior because of a race-condition is exception-worthy behavior.