### PR TITLE
Fix IndexError when printing DataFrames with empty partitions

### DIFF
--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -327,6 +327,17 @@ def process_val_weights(vals_and_weights, npartitions, dtype_info):
     vals = np.array(vals)
     weights = np.array(weights)
 
+    # Guard against empty data (prevents IndexError during repr)
+    # This can occur when operations like merge, filter, or drop_duplicates
+    # result in empty partitions. Return unknown divisions to maintain
+    # consistent behavior with other cases where divisions cannot be determined.
+    if len(vals) == 0 or len(weights) == 0:
+        try:
+            return np.array([None] * (npartitions + 1), dtype=dtype)
+        except Exception:
+            # dtype does not support None value so allow it to change
+            return np.array([None] * (npartitions + 1), dtype=np.float64)
+
     # We want to create exactly `npartition` number of groups of `vals` that
     # are approximately the same weight and non-empty if possible.  We use a
     # simple approach (more accurate algorithms exist):


### PR DESCRIPTION
Fixes #12257

Problem
print(df) crashes with IndexError: index 0 is out of bounds when DataFrame operations produce empty partitions.

Solution
Added guard clause in process_val_weights to handle empty data gracefully. Returns unknown divisions instead of crashing, consistent with Dask's existing behavior.

Changes
Added early-return check for empty vals or 
weights
 arrays in 
dask/dataframe/partitionquantiles.py
