### PR TITLE
Doc: document Zarr compression options for to_zarr

### DIFF
--- a/docs/source/array-creation.rst
+++ b/docs/source/array-creation.rst
@@ -483,9 +483,7 @@ For example, using ``numcodecs`` to configure Blosc compression:
    ... )
 
 The available compressors and compression settings depend on the Zarr
-backend being used. See the Zarr documentation on compressors for details:
-
-https://zarr.readthedocs.io/en/stable/user-guide/arrays.html#compressors
+backend being used. See the [Zarr documentation on compressors](https://zarr.readthedocs.io/en/stable/user-guide/arrays.html#compressors) for details:
 
 
 


### PR DESCRIPTION
Added a short example showing how to pass compression settings (e.g. Blosc with a
specific compression level) via ``storage_options`` when writing Dask arrays to Zarr.

- [x] Closes #9298
- [x] Tests not required (documentation-only change)
- [ ] Passes `pre-commit run --all-files` (not run locally)
