### PR TITLE
Disable the GIL in 3.14t CI

### DIFF
--- a/continuous_integration/environment-3.14t.yaml
+++ b/continuous_integration/environment-3.14t.yaml
@@ -61,7 +61,7 @@ dependencies:
   - scikit-image
   - scikit-learn
   - scipy
-  - python-snappy
+  # - python-snappy  # dependency cramjam does not release the GIL
   # - sparse  # Not available for 3.14t
   - cachey
   - python-graphviz


### PR DESCRIPTION
Importing snappy causes the GIL to be acquired permanently, which invalidates much of the 3.14t test case.

This is revealed by a RuntimeWarning when importing snappy.

Downstream of this I'm working on a separate PR to tighten which warnings are ignored and which are treated as errors.