### PR TITLE
Pandas4Warning: Copy-on-Write is always enabled with pandas >= 3.0

### DIFF
--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -10,9 +10,6 @@ import dask.dataframe as dd
 from dask.dataframe._compat import PANDAS_GE_220, PANDAS_GE_300
 from dask.dataframe.utils import assert_eq
 
-if PANDAS_GE_300:
-    from pandas.errors import Pandas4Warning
-
 
 def resample(df, freq, how="mean", **kwargs):
     return getattr(df.resample(freq, **kwargs), how)()
@@ -236,6 +233,8 @@ def test_rule_deprecated():
     ds = dd.from_pandas(s, npartitions=2)
 
     if PANDAS_GE_300:
+        from pandas.errors import Pandas4Warning
+
         ctx = pytest.warns(Pandas4Warning, match="'d' is deprecated")
     else:
         ctx = contextlib.nullcontext()


### PR DESCRIPTION
Prevent
 
> Pandas4Warning: The 'mode.copy_on_write' option is deprecated. Copy-on-Write
> can no longer be disabled (it is always enabled with pandas >= 3.0), and
> setting the option has no impact. This option will be removed in pandas 4.0.

in the test suite.

pyproject.toml informs that this warning should cause a hard error in pytest. This is not the case, for some reason. I'm tackling this issue in a downstream PR.