### PR TITLE
Suppress warning: Consolidated metadata is not part of Zarr 3

### DIFF
--- a/dask/array/tests/test_xarray.py
+++ b/dask/array/tests/test_xarray.py
@@ -89,6 +89,10 @@ def test_positional_indexer_multiple_variables():
     assert len({k for k in graph if "shuffle-sorter" in k}) == 2
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Consolidated metadata is currently not part in the "
+    "Zarr format 3 specification"
+)
 @pytest.mark.parametrize("compute", [True, False])
 def test_xarray_blockwise_fusion_store(compute):
     pytest.importorskip("zarr")

--- a/dask/tests/test_sizeof.py
+++ b/dask/tests/test_sizeof.py
@@ -5,7 +5,6 @@ import sys
 from array import array
 
 import pytest
-from packaging.version import Version
 
 from dask.multiprocessing import get_context
 from dask.sizeof import sizeof
@@ -275,20 +274,17 @@ def test_xarray():
     assert sizeof(dataset.indexes) >= sizeof(ind)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Consolidated metadata is currently not part in the "
+    "Zarr format 3 specification"
+)
 def test_xarray_not_in_memory():
     xr = pytest.importorskip("xarray")
-    zarr = pytest.importorskip("zarr")
     np = pytest.importorskip("numpy")
     pytest.importorskip("zarr")
 
     ind = np.arange(-66, 67, 1).astype(float)
     arr = np.random.random((len(ind),))
-
-    # TODO: remove this conditional after consolidated metadata lands in v3
-    if Version(zarr.__version__) > Version("3.0.0.a0") and Version(
-        zarr.__version__
-    ) < Version("3.0.0"):
-        pytest.xfail("consolidated metadata and xarray support is not complete")
 
     with tmpdir() as path:
         xr.DataArray(


### PR DESCRIPTION
Ignore a Zarr warning, which previously was flowing to the end of the console log.

Downstream of this I'm working on a separate PR to tighten which warnings are ignored and which are treated as errors.