### PR TITLE
Clean up obsolete PANDAS_GE markers

### DIFF
--- a/dask/_pandas_compat.py
+++ b/dask/_pandas_compat.py
@@ -20,10 +20,8 @@ import pandas as pd
 import pandas.testing as tm
 
 PANDAS_VERSION = Version(pd.__version__)
-PANDAS_GE_201 = PANDAS_VERSION.release >= (2, 0, 1)
 PANDAS_GE_202 = PANDAS_VERSION.release >= (2, 0, 2)
 PANDAS_GE_210 = PANDAS_VERSION.release >= (2, 1, 0)
-PANDAS_GE_211 = PANDAS_VERSION.release >= (2, 1, 1)
 PANDAS_GE_220 = PANDAS_VERSION.release >= (2, 2, 0)
 PANDAS_GE_230 = PANDAS_VERSION.release >= (2, 3, 0)
 PANDAS_GE_300 = PANDAS_VERSION.major >= 3
@@ -142,20 +140,6 @@ def check_apply_dataframe_deprecation():
                 "ignore",
                 message="Returning a DataFrame",
                 category=FutureWarning,
-            )
-            yield
-    else:
-        yield
-
-
-@contextlib.contextmanager
-def check_reductions_runtime_warning():
-    if not PANDAS_GE_201:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message="invalid value encountered in double_scalars|Degrees of freedom <= 0 for slice",
-                category=RuntimeWarning,
             )
             yield
     else:

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -9,10 +9,8 @@ import_optional_dependency("numpy")
 from packaging.version import Version
 
 from dask._pandas_compat import (
-    PANDAS_GE_201,
     PANDAS_GE_202,
     PANDAS_GE_210,
-    PANDAS_GE_211,
     PANDAS_GE_220,
     PANDAS_GE_230,
     PANDAS_GE_300,
@@ -24,7 +22,6 @@ from dask._pandas_compat import (
     check_convert_dtype_deprecation,
     check_groupby_axis_deprecation,
     check_observed_deprecation,
-    check_reductions_runtime_warning,
     is_any_real_numeric_dtype,
     is_string_dtype,
     makeDataFrame,
@@ -59,10 +56,8 @@ else:
 
 __all__ = [
     "PANDAS_VERSION",
-    "PANDAS_GE_201",
     "PANDAS_GE_202",
     "PANDAS_GE_210",
-    "PANDAS_GE_211",
     "PANDAS_GE_220",
     "PANDAS_GE_230",
     "PANDAS_GE_300",
@@ -79,7 +74,6 @@ __all__ = [
     "check_observed_deprecation",
     "check_convert_dtype_deprecation",
     "check_apply_dataframe_deprecation",
-    "check_reductions_runtime_warning",
     "is_any_real_numeric_dtype",
     "is_string_dtype",
     "IndexingError",

--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -36,7 +36,12 @@ from dask.array import Array
 from dask.base import DaskMethodsMixin, is_dask_collection, named_schedulers
 from dask.core import flatten
 from dask.dataframe import methods
-from dask.dataframe._compat import PANDAS_GE_210, PANDAS_GE_220, PANDAS_VERSION
+from dask.dataframe._compat import (
+    PANDAS_GE_210,
+    PANDAS_GE_220,
+    PANDAS_GE_300,
+    PANDAS_VERSION,
+)
 from dask.dataframe.accessor import CachedAccessor
 from dask.dataframe.core import (
     _concat,
@@ -103,7 +108,6 @@ from dask.dataframe.dask_expr._shuffle import (
 )
 from dask.dataframe.dask_expr._str_accessor import StringAccessor
 from dask.dataframe.dask_expr._util import (
-    PANDAS_GE_300,
     _BackendData,
     _convert_to_list,
     _get_shuffle_preferring_order,

--- a/dask/dataframe/dask_expr/_groupby.py
+++ b/dask/dataframe/dask_expr/_groupby.py
@@ -12,6 +12,7 @@ from pandas.core.apply import reconstruct_func, validate_func_kwargs
 from dask import is_dask_collection
 from dask._task_spec import Task
 from dask.core import flatten
+from dask.dataframe._compat import PANDAS_GE_300
 from dask.dataframe.core import (
     _concat,
     apply_and_enforce,
@@ -41,11 +42,7 @@ from dask.dataframe.dask_expr._expr import (
 )
 from dask.dataframe.dask_expr._reductions import ApplyConcatApply, Chunk, Reduction
 from dask.dataframe.dask_expr._shuffle import RearrangeByColumn
-from dask.dataframe.dask_expr._util import (
-    PANDAS_GE_300,
-    _convert_to_list,
-    get_specified_shuffle,
-)
+from dask.dataframe.dask_expr._util import _convert_to_list, get_specified_shuffle
 from dask.dataframe.dispatch import concat, make_meta, meta_nonempty
 from dask.dataframe.groupby import (
     GROUP_KEYS_DEFAULT,
@@ -1553,9 +1550,7 @@ class GroupBy:
 
         self.obj = obj[projection] if projection is not None else obj
         self.sort = sort
-        self.observed = (
-            observed if observed is not None else False if not PANDAS_GE_300 else True
-        )
+        self.observed = observed if observed is not None else PANDAS_GE_300
         self.dropna = dropna
         self.group_keys = group_keys
         self.by = (

--- a/dask/dataframe/dask_expr/_util.py
+++ b/dask/dataframe/dask_expr/_util.py
@@ -6,7 +6,6 @@ from collections.abc import Hashable
 from typing import Any, Literal, TypeVar, cast
 
 import pandas as pd
-from packaging.version import Version
 
 from dask import config, is_dask_collection
 from dask.dataframe._compat import is_string_dtype
@@ -16,9 +15,6 @@ from dask.utils import get_default_shuffle_method
 
 K = TypeVar("K", bound=Hashable)
 V = TypeVar("V")
-
-PANDAS_VERSION = Version(pd.__version__)
-PANDAS_GE_300 = PANDAS_VERSION.major >= 3
 
 
 def _calc_maybe_new_divisions(df, periods, freq):

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -3664,7 +3664,7 @@ def test_inplace_operators():
     "idx",
     [
         np.arange(100),
-        sorted(np.random.random(size=100)),
+        np.sort(np.random.random(size=100)),
         pd.date_range("20150101", periods=100),
     ],
 )

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2252,6 +2252,12 @@ def test_groupby_shift_with_freq(shuffle_method):
     )
 
 
+@pytest.mark.filterwarnings("ignore:`meta` is not specified")
+# These warnings appear only on pandas >=2.1,<3.0
+@pytest.mark.filterwarnings(r"ignore:.*(DataFrame|Series)GroupBy\.sum:FutureWarning")
+@pytest.mark.filterwarnings(r"ignore:.*DataFrame\.sum with axis=None:FutureWarning")
+@pytest.mark.filterwarnings(r"ignore:.*DataFrameGroupBy\.apply:DeprecationWarning")
+@pytest.mark.filterwarnings(r"ignore:.*DataFrameGroupBy\.apply:FutureWarning")
 @pytest.mark.parametrize(
     "transformation", [lambda x: x.sum(), np.sum, "sum", pd.Series.rank]
 )
@@ -2266,18 +2272,17 @@ def test_groupby_transform_funcs(transformation):
     )
     ddf = dd.from_pandas(pdf, 3)
 
-    with pytest.warns(UserWarning):
-        # DataFrame
-        assert_eq(
-            pdf.groupby("A").transform(transformation),
-            ddf.groupby("A").transform(transformation),
-        )
+    # DataFrame
+    assert_eq(
+        pdf.groupby("A").transform(transformation),
+        ddf.groupby("A").transform(transformation),
+    )
 
-        # Series
-        assert_eq(
-            pdf.groupby("A")["B"].transform(transformation),
-            ddf.groupby("A")["B"].transform(transformation),
-        )
+    # Series
+    assert_eq(
+        pdf.groupby("A")["B"].transform(transformation),
+        ddf.groupby("A")["B"].transform(transformation),
+    )
 
 
 @pytest.mark.parametrize("npartitions", list(range(1, 10)))


### PR DESCRIPTION
- Remove unused markers `PANDAS_GE_201` and `PANDAS_GE_211`
- Clean up duplicated marker `PANDAS_GE_300`
- Suppress warnings on `test_groupby_transform_funcs` in pandas >=2.1,<3.0