### PR TITLE
Disable the GIL on 3.14t Windows CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,8 +106,9 @@ jobs:
       - name: Disable msgpack C extension on free-threading
         if: ${{ matrix.environment == '3.14t' }}
         run: |
-          mamba uninstall -y msgpack-python
-          MSGPACK_PUREPYTHON=1 pip install msgpack --no-binary msgpack --no-cache -v
+          conda uninstall -y -v --force msgpack-python
+          MSGPACK_PUREPYTHON=1 pip install msgpack --no-binary msgpack --no-cache --force-reinstall -v
+          python -Werror -c 'import msgpack'
 
       - name: Reconfigure pytest-timeout
         # No SIGALRM available on Windows

--- a/continuous_integration/environment-3.14t.yaml
+++ b/continuous_integration/environment-3.14t.yaml
@@ -32,7 +32,7 @@ dependencies:
   - boto3
   - botocore
   # - moto<5  # Not available for 3.14t on Windows
-  - s3fs>=2021.9.0
+  # - s3fs>=2026.1.0  # Not available for 3.14t
   # other optional dependencies
   - mimesis
   # - numba  # Not available for 3.14t


### PR DESCRIPTION
For some reason, the previous msgpack hack worked fine on Linux, but did not uninstall msgpack on Windows. This caused the GIL to remain acquired for the whole 3.14t CI.