### PR TITLE
Fix pyarrow string dtype in str.split expand meta

### DIFF
--- a/dask/dataframe/dask_expr/_str_accessor.py
+++ b/dask/dataframe/dask_expr/_str_accessor.py
@@ -182,11 +182,8 @@ class SplitMap(FunctionMap):
     @functools.cached_property
     def _meta(self):
         delimiter = " " if self.pat is None else self.pat
-        meta = meta_nonempty(self.frame._meta)
-        meta = self.frame._meta._constructor(
-            [delimiter.join(["a"] * (self.n + 1))],
-            index=meta.iloc[:1].index,
-        )
+        meta = meta_nonempty(self.frame._meta).iloc[:1].copy()
+        meta.iloc[0] = delimiter.join(["a"] * (self.n + 1))
         return make_meta(
             getattr(meta.str, self.attr)(n=self.n, expand=self.expand, pat=self.pat)
         )

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -310,6 +310,17 @@ def test_str_accessor_split_expand(method):
         )
 
 
+def test_str_accessor_split_expand_preserves_pyarrow_string_dtype():
+    pytest.importorskip("pyarrow")
+    s = pd.Series(["a,b", "c,d"], dtype="string[pyarrow]")
+    ds = dd.from_pandas(s, npartitions=1)
+
+    result = ds.str.split(",", n=1, expand=True)
+    expected = s.str.split(",", n=1, expand=True)
+
+    assert result.dtypes.equals(expected.dtypes)
+
+
 @pytest.mark.xfail(reason="Need to pad columns")
 def test_str_accessor_split_expand_more_columns():
     s = pd.Series(["a b c d", "aa", "aaa bbb ccc dddd"])


### PR DESCRIPTION
- [x] Closes #11884
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

