### PR TITLE
Fix wrong dtype when using masked_array with Python float

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5167,7 +5167,9 @@ def elemwise(op, *args, out=None, where=True, dtype=None, name=None, **kwargs):
         # to match.
         vals = [
             (
-                np.empty((1,) * max(1, a.ndim), dtype=a.dtype)
+                np.zeros_like(
+                    meta_from_array(a), shape=(1,) * max(1, a.ndim), dtype=a.dtype
+                )
                 if not is_scalar_for_elemwise(a)
                 else a
             )


### PR DESCRIPTION
Fixes #12154

**Problem**

Arithmetic between a `dask.array.ma.masked_array` (float32) and a Python `float` reports the result dtype as `float32`, but `.compute()` returns `float64`. The metadata is inconsistent with the actual result:

```python
masked_array = dask.array.ma.masked_array([1.0], dtype=np.float32)
arr = masked_array * float(1.5)
arr.dtype          # float32  (wrong prediction)
arr.compute().dtype  # float64  (actual result)
```

This doesn't happen with regular (non-masked) dask arrays because numpy's type promotion rules differ between `np.ndarray` and `np.ma.MaskedArray`:

```python
(np.array([1.0], dtype=np.float32) * 1.5).dtype       # float32
(np.ma.array([1.0], dtype=np.float32) * 1.5).dtype     # float64
```

**Root cause**

The dtype inference in `elemwise` uses `np.empty(...)` to create placeholder arrays for computing the output dtype. This always produces a regular `ndarray`, even when the actual dask array holds masked array chunks. Since masked arrays have different type promotion, the inferred dtype can disagree with the computed result.

**Fix**

Replace `np.empty(...)` with `np.zeros_like(meta_from_array(a), ...)`, which preserves the array type (masked vs regular) and produces correct dtype predictions. This is consistent with how `apply_infer_dtype` already constructs its placeholders elsewhere in the same file.