### PR TITLE
Quadratic definition time in xarray.DataArray.to_zarr(compute=False)

### DIFF
--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -793,7 +793,9 @@ class Task(GraphNode):
     ) -> Task:
         subs_filtered = {
             # subs can be as large as the whole graph; do not iterate over it!
-            k: v for k in (self.dependencies & subs.keys()) if (v := subs[k]) != k
+            k: v
+            for k in (self.dependencies & subs.keys())
+            if (v := subs[k]) != k
         }
         extras = _extra_args(type(self))  # type: ignore[arg-type]
         extra_kwargs = {
@@ -882,7 +884,9 @@ class NestedContainer(Task, Iterable):
     ) -> NestedContainer:
         subs_filtered = {
             # subs can be as large as the whole graph; do not iterate over it!
-            k: v for k in (self.dependencies & subs.keys()) if (v := subs[k]) != k
+            k: v
+            for k in (self.dependencies & subs.keys())
+            if (v := subs[k]) != k
         }
         if not subs_filtered:
             return self
@@ -965,7 +969,9 @@ class Dict(NestedContainer, Mapping):
     ) -> Dict:
         subs_filtered = {
             # subs can be as large as the whole graph; do not iterate over it!
-            k: v for k in (self.dependencies & subs.keys()) if (v := subs[k]) != k
+            k: v
+            for k in (self.dependencies & subs.keys())
+            if (v := subs[k]) != k
         }
         if not subs_filtered:
             return self


### PR DESCRIPTION
Closes #12298

Reduce the time it takes for `xarray.DataArray.to_zarr(..., compute=False)` to return a delayed object from O(n^2) to O(n), where n is the total number of tasks in the graph.

In my production environment, this reduces the time it takes to store the metadata of an array backed by a ~70k tasks graph from 3 minutes to 2 seconds.

Read #12298 for full explanation and analysis.

No unit test since, AFAIK, there are no microbenchmarks available?