### PR TITLE
Remove mention of obsolete default value for 'boundary' parameter.

### DIFF
--- a/dask/array/overlap.py
+++ b/dask/array/overlap.py
@@ -542,7 +542,6 @@ def map_overlap(
         or any constant value like 0 or np.nan.
         If a list then each element must be a str, tuple or dict defining the
         boundary for the corresponding array in `args`.
-        The default value is 'reflect'.
     trim: bool, keyword only
         Whether or not to trim ``depth`` elements from each block after
         calling the map function.


### PR DESCRIPTION
Dear maintainers,

This is a minor update to the docstring of [dask.array.overlap.map_overlap](https://docs.dask.org/en/latest/generated/dask.array.overlap.map_overlap.html). From the function signature, the default value for `boundary` is `None` (is it worth mentioning that `'none'` is equivalent to `None`?).

I looked at the Git Blame, and I guess the update of this parameter description fell in the cracks when #8397 and #8743 happened.

Best,
Marianne