### PR TITLE
Add support for how='cross' in dask.dataframe.merge

### DIFF
--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -2877,7 +2877,7 @@ class DataFrame(FrameBase):
         Parameters
         ----------
         right: dask.dataframe.DataFrame
-        how : {'left', 'right', 'outer', 'inner', 'leftsemi'}, default: 'inner'
+        how : {'left', 'right', 'outer', 'inner', 'cross', 'leftsemi'}, default: 'inner'
             How to handle the operation of the two objects:
 
             - left: use calling frame's index (or column if on is specified)
@@ -2888,6 +2888,8 @@ class DataFrame(FrameBase):
             - inner: form intersection of calling frame's index (or column if
               on is specified) with other frame's index, preserving the order
               of the calling's one
+            - cross: creates the cartesian product from both frames, preserves
+              the order of the left keys.
             - leftsemi: Choose all rows in left where the join keys can be found
               in right. Won't duplicate rows if the keys are duplicated in right.
               Drops all columns from right.
@@ -5573,6 +5575,36 @@ def merge(
     for o in [on, left_on, right_on]:
         if isinstance(o, FrameBase):
             raise NotImplementedError()
+
+    if how == "cross":
+        if on is not None or left_on is not None or right_on is not None:
+            raise ValueError(
+                "Can not pass on, left_on, or right_on to merge with how='cross'."
+            )
+        if left_index or right_index:
+            raise ValueError(
+                "Can not pass left_index=True or right_index=True "
+                "to merge with how='cross'."
+            )
+        # Implement cross join by adding a temporary constant column to both
+        # sides and performing an inner join on it, mirroring what pandas does
+        # internally.
+        cross_col = "__dask_cross_col__"
+        left = left.assign(**{cross_col: 1})
+        right = right.assign(**{cross_col: 1})
+        result = merge(
+            left,
+            right,
+            how="inner",
+            on=cross_col,
+            suffixes=suffixes,
+            indicator=indicator,
+            shuffle_method=shuffle_method,
+            npartitions=npartitions,
+            broadcast=broadcast,
+        )
+        return result.drop(columns=[cross_col])
+
     if not on and not left_on and not right_on and not left_index and not right_index:
         on = [c for c in left.columns if c in right.columns]
         if not on:

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -828,9 +828,53 @@ def test_merge_how_raises():
     )
 
     with pytest.raises(
-        ValueError, match="dask.dataframe.merge does not support how='cross'"
+        ValueError, match="dask.dataframe.merge does not support how='invalid'"
     ):
-        dd.merge(left, right, how="cross")
+        dd.merge(left, right, how="invalid")
+
+
+@pytest.mark.parametrize("npartitions_left", [1, 2, 5])
+@pytest.mark.parametrize("npartitions_right", [1, 2, 5])
+def test_merge_cross(npartitions_left, npartitions_right):
+    left = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    right = pd.DataFrame({"c": [10, 20], "d": ["p", "q"]})
+
+    ddf_left = dd.from_pandas(left, npartitions=npartitions_left)
+    ddf_right = dd.from_pandas(right, npartitions=npartitions_right)
+
+    expected = pd.merge(left, right, how="cross")
+    result = dd.merge(ddf_left, ddf_right, how="cross")
+
+    assert_eq(result, expected, check_index=False)
+
+
+def test_merge_cross_with_suffixes():
+    left = pd.DataFrame({"a": [1, 2], "val": [10, 20]})
+    right = pd.DataFrame({"b": [3, 4], "val": [30, 40]})
+
+    ddf_left = dd.from_pandas(left, npartitions=1)
+    ddf_right = dd.from_pandas(right, npartitions=1)
+
+    expected = pd.merge(left, right, how="cross", suffixes=("_l", "_r"))
+    result = dd.merge(ddf_left, ddf_right, how="cross", suffixes=("_l", "_r"))
+
+    assert_eq(result, expected, check_index=False)
+
+
+def test_merge_cross_rejects_on():
+    left = pd.DataFrame({"a": [1, 2]})
+    right = pd.DataFrame({"a": [3, 4]})
+    ddf_left = dd.from_pandas(left, npartitions=1)
+    ddf_right = dd.from_pandas(right, npartitions=1)
+
+    with pytest.raises(ValueError, match="Can not pass on"):
+        dd.merge(ddf_left, ddf_right, how="cross", on="a")
+
+    with pytest.raises(ValueError, match="Can not pass on"):
+        dd.merge(ddf_left, ddf_right, how="cross", left_on="a", right_on="a")
+
+    with pytest.raises(ValueError, match="Can not pass left_index"):
+        dd.merge(ddf_left, ddf_right, how="cross", left_index=True)
 
 
 @pytest.mark.parametrize("parts", [(3, 3), (3, 1), (1, 3)])

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -835,7 +835,7 @@ def test_merge_how_raises():
 
 @pytest.mark.parametrize("npartitions_left", [1, 2, 5])
 @pytest.mark.parametrize("npartitions_right", [1, 2, 5])
-def test_merge_cross(npartitions_left, npartitions_right):
+def test_merge_cross(npartitions_left, npartitions_right, shuffle_method):
     left = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
     right = pd.DataFrame({"c": [10, 20], "d": ["p", "q"]})
 
@@ -848,7 +848,7 @@ def test_merge_cross(npartitions_left, npartitions_right):
     assert_eq(result, expected, check_index=False)
 
 
-def test_merge_cross_with_suffixes():
+def test_merge_cross_with_suffixes(shuffle_method):
     left = pd.DataFrame({"a": [1, 2], "val": [10, 20]})
     right = pd.DataFrame({"b": [3, 4], "val": [30, 40]})
 
@@ -875,6 +875,9 @@ def test_merge_cross_rejects_on():
 
     with pytest.raises(ValueError, match="Can not pass left_index"):
         dd.merge(ddf_left, ddf_right, how="cross", left_index=True)
+
+    with pytest.raises(ValueError, match="Can not pass left_index"):
+        dd.merge(ddf_left, ddf_right, how="cross", right_index=True)
 
 
 @pytest.mark.parametrize("parts", [(3, 3), (3, 1), (1, 3)])


### PR DESCRIPTION
Fixes #11957

The docs mention `how='cross'` as a supported option for `dask.dataframe.merge`, but actually using it throws a `ValueError`. This adds cross join support.

The implementation works by adding a temporary constant key column to both sides, doing an inner merge on it, and dropping the temp column afterward. This is essentially the same approach pandas uses internally for cross joins, and it lets us reuse all of dask's existing merge/shuffle infrastructure without needing a separate code path.

Also validates that you can't pass `on`/`left_on`/`right_on`/`left_index`/`right_index` with `how='cross'` (same as pandas).

Test plan:
- Added parametrized tests for different partition combinations (1x1, 1x2, 2x5, etc.)
- Added test for suffix handling with overlapping column names
- Added tests for proper validation of incompatible args
- Updated existing `test_merge_how_raises` to test an actually unsupported join type