### PR TITLE
DOC: fix broken sphinx cross-reference warnings in docstrings

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4336,7 +4336,7 @@ def unify_chunks(*args, **kwargs):
     Unify chunks across a sequence of arrays
 
     This utility function is used within other common operations like
-    :func:`dask.array.core.map_blocks` and :func:`dask.array.core.blockwise`.
+    :func:`dask.array.map_blocks` and :func:`dask.array.blockwise`.
     It is not commonly used by end-users directly.
 
     Parameters
@@ -4371,7 +4371,7 @@ def unify_chunks(*args, **kwargs):
 
     See Also
     --------
-    common_blockdim
+    dask.array.core.common_blockdim
     """
     if not args:
         return {}, []
@@ -4502,7 +4502,7 @@ def block(arrays, allow_unknown_chunksizes=False):
     hstack : Stack arrays in sequence horizontally (column wise).
     vstack : Stack arrays in sequence vertically (row wise).
     dstack : Stack arrays in sequence depth wise (along third dimension).
-    vsplit : Split array into a list of multiple sub-arrays vertically.
+    numpy.vsplit : Split array into a list of multiple sub-arrays vertically.
 
     Notes
     -----

--- a/dask/array/rechunk.py
+++ b/dask/array/rechunk.py
@@ -165,10 +165,10 @@ def old_to_new(old_chunks, new_chunks):
     Notes
     -----
     This function expects that the arguments have been pre-processed by
-    :func:`dask.array.core.normalize_chunks`. In particular any ``nan`` values should
-    have been replaced (and are so by :func:`dask.array.core.normalize_chunks`)
+    ``dask.array.core.normalize_chunks``. In particular any ``nan`` values should
+    have been replaced (and are so by ``dask.array.core.normalize_chunks``)
     by the canonical ``np.nan``. It also expects that the arguments have been validated
-    with `_validate_rechunk` and rechunking is thus possible.
+    with ``_validate_rechunk`` and rechunking is thus possible.
 
     Examples
     --------

--- a/docs/source/array.rst
+++ b/docs/source/array.rst
@@ -69,7 +69,7 @@ New duck array chunk types (types below Dask on
 not registered will be deferred to in binary operations and NumPy
 ufuncs/functions (that is, Dask will return ``NotImplemented``). Note, however,
 that *any* ndarray-like type can be inserted into a Dask Array using
-:func:`~dask.array.Array.from_array`.
+:func:`~dask.array.from_array`.
 
 Common Uses
 -----------

--- a/docs/source/high-level-graphs.rst
+++ b/docs/source/high-level-graphs.rst
@@ -136,7 +136,7 @@ While the DataFrame points to the output layers on which it depends directly:
 HighLevelGraphs
 ---------------
 
-The :obj:`HighLevelGraph` object is a ``Mapping`` object composed of other
+The :obj:`dask.highlevelgraph.HighLevelGraph` object is a ``Mapping`` object composed of other
 sub-``Mappings``, along with a high-level dependency mapping between them:
 
 .. code-block:: python


### PR DESCRIPTION
Fixes #9121

## Summary

This PR addresses several sphinx "reference target not found" warnings that occur when building dask documentation with `-n` (nitpicky mode).

### Changes

**`dask/array/core.py`**
- `unify_chunks` docstring: replaced `:func:\`dask.array.core.map_blocks\`` and `:func:\`dask.array.core.blockwise\`` with the correct public API paths `:func:\`dask.array.map_blocks\`` and `:func:\`dask.array.blockwise\`` (both are exported from `dask.array`)
- `unify_chunks` docstring: qualified bare `common_blockdim` in the See Also section to `dask.array.core.common_blockdim` so sphinx can resolve it
- `block` docstring: qualified bare `vsplit` in the See Also section to `numpy.vsplit`, since `vsplit` is not part of the `dask.array` public API

**`dask/array/rechunk.py`**
- `old_to_new` docstring: replaced `:func:\`dask.array.core.normalize_chunks\`` with inline code literals (double backticks), since `normalize_chunks` is an internal helper not included in the sphinx-documented public API

**`docs/source/array.rst`**
- Fixed `:func:\`~dask.array.Array.from_array\`` to `:func:\`~dask.array.from_array\`` — `from_array` is a module-level function, not a method of the `Array` class

**`docs/source/high-level-graphs.rst`**
- Qualified bare `:obj:\`HighLevelGraph\`` to `:obj:\`dask.highlevelgraph.HighLevelGraph\`` so sphinx can resolve the reference