### PR TITLE
Support to hdf5 parallel writing with to_hdf5 with HDF5 VDS

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3400,7 +3400,7 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
                     multiplier_remaining = True
 
         for k, v in result.items():
-            chunks[k] = v if v else 0
+            chunks[k] = v or 0
         return tuple(chunks)
 
     else:
@@ -5445,7 +5445,7 @@ def chunks_from_arrays(arrays):
 
     def shape(x):
         try:
-            return x.shape if x.shape else (1,)
+            return x.shape or (1,)
         except AttributeError:
             return (1,)
 
@@ -5701,7 +5701,7 @@ def concatenate_axes(arrays, axes):
     return concatenate3(transposelist(arrays, axes, extradims=extradims))
 
 
-def to_hdf5(filename, *args, chunks=True, **kwargs):
+def to_hdf5(filename, *args, chunks=True, distributed=False, **kwargs):
     """Store arrays in HDF5 file
 
     This saves several dask arrays into several datapaths in an HDF5 file.
@@ -5737,6 +5737,8 @@ def to_hdf5(filename, *args, chunks=True, **kwargs):
     da.store
     h5py.File.create_dataset
     """
+
+    print(args)
     if len(args) == 1 and isinstance(args[0], dict):
         data = args[0]
     elif len(args) == 2 and isinstance(args[0], str) and isinstance(args[1], Array):
@@ -5746,18 +5748,167 @@ def to_hdf5(filename, *args, chunks=True, **kwargs):
 
     import h5py
 
-    with h5py.File(filename, mode="a") as f:
-        dsets = [
-            f.require_dataset(
-                dp,
-                shape=x.shape,
-                dtype=x.dtype,
-                chunks=tuple(c[0] for c in x.chunks) if chunks is True else chunks,
-                **kwargs,
+    if distributed:
+        to_hdf5_distributed(filename, data)
+    else:
+        with h5py.File(filename, mode="a") as f:
+            dsets = [
+                f.require_dataset(
+                    dp,
+                    shape=x.shape,
+                    dtype=x.dtype,
+                    chunks=tuple(c[0] for c in x.chunks) if chunks is True else chunks,
+                    **kwargs,
+                )
+                for dp, x in data.items()
+            ]
+            store(list(data.values()), dsets)
+
+
+def to_hdf5_distributed(fname: str, sources) -> None:
+    """
+    Store arrays in HDF5 file (using HDF5 VDS)
+
+    Parameters
+    ----------
+    fname : str
+        The name of the final file where the data will be stored.
+    sources : dict[str, dask.array]
+        Dict mapping the datasets in final file to final files
+
+    Notes
+    -----
+    This method creates files for each chunk, then links the
+    files using HDF5 VDS. The chunk file is named as
+    `.{filename}-{chunk_position}.h5`.
+    """
+
+    import pathlib
+
+    import h5py
+
+    import dask.delayed
+
+    def chunk_fname(
+        fname: str | pathlib.Path, dataset: str, chunkid: tuple[int, ...] = ()
+    ):
+        """
+        Create the filename for a chunk.
+
+        Parameters
+        ----------
+        fname : str | pathlib.Path
+            The name of the final file where the data will be stored.
+        dataset : str
+            The name of the dataset in the hdf5 where the data will be stored.
+        chunkid : tuple[int, ...]
+            Chunk position to create the file.
+
+        Returns
+        -------
+        str
+            Filename for the chunk of position block_id.
+        """
+
+        path = pathlib.Path(fname).expanduser().resolve()
+        parents, name, suffix = path.parents[0], path.stem, path.suffix
+        chunk_str = "-".join(map(str, chunkid))
+
+        # Hidden name for the chunk files
+        new_name = "." + name + "-" + dataset + f"-{chunk_str}" + suffix
+
+        return parents / new_name
+
+    def save_chunk(
+        chunk: np.ndarray,
+        fname: str,
+        dataset: str,
+        block_id: tuple[int, ...],
+    ) -> None:
+        """
+        Save one chunk to a individual hdf5 file.
+
+        Parameters
+        ----------
+        chunk : np.ndarray
+            Chunk to be stored.
+        fname : str
+            The name of the final file where the data will be stored.
+        dataset : str
+            The name of the dataset in the hdf5 where the data will be stored.
+        block_id : tuple[int, ...]
+            Chunk position, used to merge into a VDS.
+        """
+
+        filename = chunk_fname(fname, dataset, block_id)
+
+        with h5py.File(filename, "w") as f:
+            f.create_dataset(dataset, data=chunk, chunks=chunk.shape)
+
+    def create_vds(
+        fname: str | pathlib.Path,
+        dataset: str,
+        chunk_shape: tuple[int, ...],
+        data_shape: tuple[int, ...],
+        nb_chunks_per_dim: tuple[int, ...],
+        data_dtype: np.dtype,
+    ) -> None:
+        """
+        Creates a VDS aggregating all chunk files.
+
+        Parameters
+        ----------
+        fname : str | pathlib.Path
+            The name of the final file where the data will be stored.
+        dataset : str
+            The name of the dataset in the hdf5 where the data will be stored.
+        chunk_shape : tuple[int,...]
+            Shape of the chunks, used to map the chunks into the VDS.4
+        data_shape : tuple[int,...]
+            Shape of the data.
+        nb_chunks_per_dim : tuple[int,...]
+            Number of chunks for each dimension
+        data_dtype : np.dtype
+            The numpy dtype of the data.
+        """
+
+        layout = h5py.VirtualLayout(shape=data_shape, dtype=data_dtype)
+
+        for block_id in np.ndindex(nb_chunks_per_dim):
+            name = chunk_fname(fname, dataset, block_id)
+            vsource = h5py.VirtualSource(name, dataset, shape=chunk_shape)
+
+            selection = tuple(
+                slice(idx * size, (idx + 1) * size)
+                for idx, size in zip(block_id, chunk_shape)
             )
-            for dp, x in data.items()
-        ]
-        store(list(data.values()), dsets)
+
+            layout[selection] = vsource
+
+        with h5py.File(fname, "a", libver="latest") as f:
+            ds = f.create_virtual_dataset(dataset, layout, fillvalue=-1)
+            ds.attrs["chunks"] = chunk_shape
+
+    full_path = pathlib.Path(fname).expanduser().resolve()
+
+    writing_tasks = []
+    for dataset, arr in sources.items():
+        delayed_grid = arr.to_delayed()
+
+        for block_id in np.ndindex(delayed_grid.shape):
+            chunk = delayed_grid[block_id]
+
+            writing_tasks.append(
+                dask.delayed(save_chunk)(
+                    chunk, fname=str(full_path), dataset=dataset, block_id=block_id
+                )
+            )
+
+        create_vds(
+            full_path, dataset, arr.chunksize, arr.shape, arr.numblocks, arr.dtype
+        )
+
+    dask.compute(*writing_tasks)
 
 
 def interleave_none(a, b):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5808,7 +5808,7 @@ def to_hdf5_distributed(fname: str, sources) -> None:
             Filename for the chunk of position block_id.
         """
 
-        path = pathlib.Path(fname).expanduser().resolve()
+        path = pathlib.Path(fname)
         parents, name, suffix = path.parents[0], path.stem, path.suffix
         chunk_str = "-".join(map(str, chunkid))
 
@@ -5887,7 +5887,7 @@ def to_hdf5_distributed(fname: str, sources) -> None:
             ds = f.create_virtual_dataset(dataset, layout, fillvalue=-1)
             ds.attrs["chunks"] = chunk_shape
 
-    full_path = pathlib.Path(fname).expanduser().resolve()
+    full_path = pathlib.Path(fname)
 
     writing_tasks = []
     for dataset, arr in sources.items():

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5701,7 +5701,7 @@ def concatenate_axes(arrays, axes):
     return concatenate3(transposelist(arrays, axes, extradims=extradims))
 
 
-def to_hdf5(filename, *args, chunks=True, distributed=False, **kwargs):
+def to_hdf5(filename, *args, chunks=True, use_vds=False, **kwargs):
     """Store arrays in HDF5 file
 
     This saves several dask arrays into several datapaths in an HDF5 file.
@@ -5746,8 +5746,8 @@ def to_hdf5(filename, *args, chunks=True, distributed=False, **kwargs):
 
     import h5py
 
-    if distributed:
-        to_hdf5_distributed(filename, data)
+    if use_vds:
+        to_hdf5_vds(filename, data, **kwargs)
     else:
         with h5py.File(filename, mode="a") as f:
             dsets = [
@@ -5763,7 +5763,7 @@ def to_hdf5(filename, *args, chunks=True, distributed=False, **kwargs):
             store(list(data.values()), dsets)
 
 
-def to_hdf5_distributed(fname: str, sources) -> None:
+def to_hdf5_vds(fname: str, sources, **kwargs) -> None:
     """
     Store arrays in HDF5 file (using HDF5 VDS)
 
@@ -5822,6 +5822,7 @@ def to_hdf5_distributed(fname: str, sources) -> None:
         fname: str,
         dataset: str,
         block_id: tuple[int, ...],
+        **kwargs
     ) -> None:
         """
         Save one chunk to a individual hdf5 file.
@@ -5841,7 +5842,7 @@ def to_hdf5_distributed(fname: str, sources) -> None:
         filename = chunk_fname(fname, dataset, block_id)
 
         with h5py.File(filename, "w") as f:
-            f.create_dataset(dataset, data=chunk, chunks=chunk.shape)
+            f.create_dataset(dataset, data=chunk, chunks=chunk.shape, **kwargs)
 
     def create_vds(
         fname: str | pathlib.Path,
@@ -5898,7 +5899,7 @@ def to_hdf5_distributed(fname: str, sources) -> None:
 
             writing_tasks.append(
                 dask.delayed(save_chunk)(
-                    chunk, fname=str(full_path), dataset=dataset, block_id=block_id
+                    chunk, fname=str(full_path), dataset=dataset, block_id=block_id, **kwargs
                 )
             )
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5871,7 +5871,7 @@ def to_hdf5_vds(fname: str, sources, **kwargs) -> None:
 
         for block_id in np.ndindex(nb_chunks_per_dim):
             name = chunk_fname(fname, dataset, block_id)
-            vsource = h5py.VirtualSource(name, dataset, shape=chunk_shape)
+            vsource = h5py.VirtualSource(name.name, dataset, shape=chunk_shape)
 
             selection = tuple(
                 slice(idx * size, (idx + 1) * size)

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5737,8 +5737,6 @@ def to_hdf5(filename, *args, chunks=True, distributed=False, **kwargs):
     da.store
     h5py.File.create_dataset
     """
-
-    print(args)
     if len(args) == 1 and isinstance(args[0], dict):
         data = args[0]
     elif len(args) == 2 and isinstance(args[0], str) and isinstance(args[1], Array):

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5771,8 +5771,10 @@ def to_hdf5(filename, *args, chunks=True, use_vds=False, **kwargs):
 
 
 def to_hdf5_vds(fname: str, sources, **kwargs) -> None:
-    """
-    Store arrays in HDF5 file (using HDF5 VDS)
+    """Store arrays in HDF5 file using HDF5 VDS.
+
+    Useful for distributed writes as each chunk is stored in a separate file
+    as an individual task and then after exposed as one logical dataset.
 
     Parameters
     ----------

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5818,11 +5818,7 @@ def to_hdf5_vds(fname: str, sources, **kwargs) -> None:
         return parents / new_name
 
     def save_chunk(
-        chunk: np.ndarray,
-        fname: str,
-        dataset: str,
-        block_id: tuple[int, ...],
-        **kwargs
+        chunk: np.ndarray, fname: str, dataset: str, block_id: tuple[int, ...], **kwargs
     ) -> None:
         """
         Save one chunk to a individual hdf5 file.
@@ -5899,7 +5895,11 @@ def to_hdf5_vds(fname: str, sources, **kwargs) -> None:
 
             writing_tasks.append(
                 dask.delayed(save_chunk)(
-                    chunk, fname=str(full_path), dataset=dataset, block_id=block_id, **kwargs
+                    chunk,
+                    fname=str(full_path),
+                    dataset=dataset,
+                    block_id=block_id,
+                    **kwargs,
                 )
             )
 

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1808,10 +1808,14 @@ class Array(DaskMethodsMixin):
 
         return svg(self.chunks, size=size)
 
-    def to_hdf5(self, filename, datapath, **kwargs):
+    def to_hdf5(self, filename, datapath, use_vds=False, **kwargs):
         """Store array in HDF5 file
 
         >>> x.to_hdf5('myfile.hdf5', '/x')  # doctest: +SKIP
+
+        Can also use HDF5 virtual datasets to store arrays with:
+
+        >>> x.to_hdf5('myfile.hdf5', '/x', use_vds=True)  # doctest: +SKIP
 
         Optionally provide arguments as though to ``h5py.File.create_dataset``
 
@@ -5712,6 +5716,9 @@ def to_hdf5(filename, *args, chunks=True, use_vds=False, **kwargs):
     chunks: tuple or ``True``
         Chunk shape, or ``True`` to pass the chunks from the dask array.
         Defaults to ``True``.
+    use_vds: bool
+        Whether to use HDF5 Virtual Dataset to store the data. If False, all data will be stored in the same file. If True, each chunk will be stored in a separate file, and a VDS will be created to link them together.
+        Defaults to ``False``.
 
     Examples
     --------

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2454,7 +2454,6 @@ def test_to_hdf5():
         x.to_hdf5(fn, "/x")
         with h5py.File(fn, mode="r+") as f:
             d = f["/x"]
-
             assert_eq(d[:], x)
             assert d.chunks == (2, 2)
 
@@ -2482,6 +2481,28 @@ def test_to_hdf5():
             assert f["/x"].chunks == (2, 2)
             assert_eq(f["/y"][:], y)
             assert f["/y"].chunks == (2,)
+
+
+def test_to_hdf5_dist():
+    h5py = pytest.importorskip("h5py")
+    x = da.ones((4, 4), chunks=(2, 2))
+    y = da.ones(4, chunks=2, dtype="i4")
+
+    with tmpfile(".hdf5") as fn:
+        x.to_hdf5(fn, "x", distributed=True)
+        with h5py.File(fn, mode="r+") as f:
+            d = f["x"]
+            assert_eq(d[:], x)
+            assert tuple(d.attrs["chunks"]) == (2, 2)
+
+    with tmpfile(".hdf5") as fn:
+        da.to_hdf5(fn, {"x": x, "y": y}, distributed=True)
+
+        with h5py.File(fn, mode="r+") as f:
+            assert_eq(f["x"][:], x)
+            assert tuple(f["x"].attrs["chunks"]) == (2, 2)
+            assert_eq(f["y"][:], y)
+            assert tuple(f["y"].attrs["chunks"]) == (2,)
 
 
 def test_to_dask_dataframe():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2506,6 +2506,47 @@ def test_to_hdf5_vds(tmp_path):
         assert tuple(f["y"].attrs["chunks"]) == (2,)
 
 
+def test_to_hdf5_vds_move(tmp_path):
+    import shutil
+
+    h5py = pytest.importorskip("h5py")
+    x = da.ones((4, 4), chunks=(2, 2))
+
+    src = tmp_path / "src"
+    src.mkdir()
+    x.to_hdf5(str(src / "test.hdf5"), "x", use_vds=True)
+
+    dst = tmp_path / "dst"
+    shutil.move(str(src), str(dst))
+
+    with h5py.File(dst / "test.hdf5", mode="r") as f:
+        d = f["x"]
+        assert_eq(d[:], x)
+        assert tuple(d.attrs["chunks"]) == (2, 2)
+
+
+def test_to_hdf5_vds_missing_chunks(tmp_path):
+    import shutil
+
+    h5py = pytest.importorskip("h5py")
+    x = da.ones((4, 4), chunks=(2, 2))
+
+    src = tmp_path / "src"
+    src.mkdir()
+    x.to_hdf5(str(src / "test.hdf5"), "x", use_vds=True)
+
+    # Move only the main VDS file, leaving chunk files behind in src
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    shutil.move(str(src / "test.hdf5"), str(dst / "test.hdf5"))
+
+    # Chunk files are missing, so HDF5 fills with the fill value (-1)
+    with h5py.File(dst / "test.hdf5", mode="r") as f:
+        d = f["x"]
+        assert not np.array_equal(d, x.compute())
+        assert np.all(d == -1)
+
+
 def test_to_dask_dataframe():
     pytest.importorskip("pandas")
     dd = pytest.importorskip("dask.dataframe")

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2526,25 +2526,23 @@ def test_to_hdf5_vds_move(tmp_path):
 
 
 def test_to_hdf5_vds_missing_chunks(tmp_path):
-    import shutil
+    import os
 
     h5py = pytest.importorskip("h5py")
     x = da.ones((4, 4), chunks=(2, 2))
 
-    src = tmp_path / "src"
-    src.mkdir()
-    x.to_hdf5(str(src / "test.hdf5"), "x", use_vds=True)
+    fn = str(tmp_path / "test.hdf5")
+    x.to_hdf5(fn, "x", use_vds=True)
 
-    # Move only the main VDS file, leaving chunk files behind in src
-    dst = tmp_path / "dst"
-    dst.mkdir()
-    shutil.move(str(src / "test.hdf5"), str(dst / "test.hdf5"))
+    for f in os.listdir(str(tmp_path)):
+        if f.startswith(".test-") and f.endswith(".hdf5"):
+            (tmp_path / f).unlink()
 
-    # Chunk files are missing, so HDF5 fills with the fill value (-1)
-    with h5py.File(dst / "test.hdf5", mode="r") as f:
-        d = f["x"]
-        assert not np.array_equal(d, x.compute())
-        assert np.all(d == -1)
+    with h5py.File(fn, mode="r") as f:
+        data = f["x"][:]
+
+    assert not np.array_equal(data, x.compute())
+    assert np.all(data == -1)
 
 
 def test_to_dask_dataframe():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2483,26 +2483,27 @@ def test_to_hdf5():
             assert f["/y"].chunks == (2,)
 
 
-def test_to_hdf5_vds():
+def test_to_hdf5_vds(tmp_path):
     h5py = pytest.importorskip("h5py")
     x = da.ones((4, 4), chunks=(2, 2))
     y = da.ones(4, chunks=2, dtype="i4")
 
-    with tmpfile(".hdf5") as fn:
-        x.to_hdf5(fn, "x", use_vds=True)
-        with h5py.File(fn, mode="r+") as f:
-            d = f["x"]
-            assert_eq(d[:], x)
-            assert tuple(d.attrs["chunks"]) == (2, 2)
+    fn = str(tmp_path / "test.hdf5")
+    x.to_hdf5(fn, "x", use_vds=True)
+    with h5py.File(fn, mode="r+") as f:
+        d = f["x"]
+        assert_eq(d[:], x)
+        assert tuple(d.attrs["chunks"]) == (2, 2)
 
-    with tmpfile(".hdf5") as fn:
-        da.to_hdf5(fn, {"x": x, "y": y}, use_vds=True)
+    fn2 = str(tmp_path / "test2.hdf5")
 
-        with h5py.File(fn, mode="r+") as f:
-            assert_eq(f["x"][:], x)
-            assert tuple(f["x"].attrs["chunks"]) == (2, 2)
-            assert_eq(f["y"][:], y)
-            assert tuple(f["y"].attrs["chunks"]) == (2,)
+    da.to_hdf5(fn2, {"x": x, "y": y}, use_vds=True)
+
+    with h5py.File(fn2, mode="r+") as f:
+        assert_eq(f["x"][:], x)
+        assert tuple(f["x"].attrs["chunks"]) == (2, 2)
+        assert_eq(f["y"][:], y)
+        assert tuple(f["y"].attrs["chunks"]) == (2,)
 
 
 def test_to_dask_dataframe():

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2483,20 +2483,20 @@ def test_to_hdf5():
             assert f["/y"].chunks == (2,)
 
 
-def test_to_hdf5_dist():
+def test_to_hdf5_vds():
     h5py = pytest.importorskip("h5py")
     x = da.ones((4, 4), chunks=(2, 2))
     y = da.ones(4, chunks=2, dtype="i4")
 
     with tmpfile(".hdf5") as fn:
-        x.to_hdf5(fn, "x", distributed=True)
+        x.to_hdf5(fn, "x", use_vds=True)
         with h5py.File(fn, mode="r+") as f:
             d = f["x"]
             assert_eq(d[:], x)
             assert tuple(d.attrs["chunks"]) == (2, 2)
 
     with tmpfile(".hdf5") as fn:
-        da.to_hdf5(fn, {"x": x, "y": y}, distributed=True)
+        da.to_hdf5(fn, {"x": x, "y": y}, use_vds=True)
 
         with h5py.File(fn, mode="r+") as f:
             assert_eq(f["x"][:], x)


### PR DESCRIPTION
- [ ] Closes #3074
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

There are several issues related to the multi process writing of dask arrays to hdf5 file format using the `to_hdf5` method. Recently I was working in a project and had the need to save dask array data to hdf5 (couldn't use zarr) files in a distributed environment and was frustrated that dask doesn't have a real support for it. I see that part of the problem as due to the impossibility of pickling hdf5 objects, but I discovered the possibility of using [HDF5 VDS](https://docs.h5py.org/en/latest/vds.html) to save everything to "one" file completely in parallel. The method implemented saves each chunk to a separated file and creates a HDF5 VDS that aggregates the metadata to treat it as it was only one single file when reading (similar to what zarr does when creating separated files for the chunks).

## Changes

Add new method called `to_hdf5_distributed` that uses hdf5 virtual dataset to save dask arrays to hdf5 format without facing issues with locking or pickling.

Tests were also added for this new method in `dask/array/tests/test_array_core.py::test_to_hdf5_dist`.


## Notes

The method save every chunk to a separated file, the name of the file is currently ".-filename-dataset-chunk_id-suffix". This can lead to problems with dataset names as "/x" since the file couldn't be create due to the slash. Maybe there is a better way to name or save this separated chunks files, perhaps creates a directory?

I didn't implemented the possibility to set the chunk size when saving, so it will always save with the actual array chunks (as if chunks=True).