### PR TITLE
Add inconsistencies= to skew and kurtosis derived_from decorators

### DIFF
--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -1643,7 +1643,15 @@ Expr={expr}"""
             raise ValueError("No known divisions to enforce!")
         return new_collection(expr.EnforceRuntimeDivisions(self))
 
-    @derived_from(pd.DataFrame)
+    @derived_from(
+        pd.DataFrame,
+        inconsistencies=(
+            "Dask uses the scipy.stats definition of skewness without "
+            "a bias correction term, so values differ from pandas by a factor of "
+            "(n * (n - 1)) ** 0.5 / (n - 2). bias=False and nan_policy other than "
+            "'propagate' are not implemented."
+        ),
+    )
     def skew(
         self,
         axis=0,
@@ -1702,7 +1710,14 @@ Expr={expr}"""
             result = result.fillna(0.0)
         return result
 
-    @derived_from(pd.DataFrame)
+    @derived_from(
+        pd.DataFrame,
+        inconsistencies=(
+            "Dask uses the scipy.stats definition of kurtosis without "
+            "a bias correction term, so values differ from pandas. "
+            "bias=False and nan_policy other than 'propagate' are not implemented."
+        ),
+    )
     def kurtosis(
         self,
         axis=0,


### PR DESCRIPTION
follow-up to #12305 — extends the `inconsistencies=` parameter to `DataFrame.skew()` and `DataFrame.kurtosis()`.

both methods already have detailed `.. note::` blocks in their docstrings explaining the differences from pandas, but the standardized `inconsistencies=` kwarg on `@derived_from` wasn't wired in yet.

inconsistencies documented:
- **skew**: uses scipy.stats definition without bias correction term, values differ from pandas by a factor of `(n * (n - 1)) ** 0.5 / (n - 2)`. `bias=False` and `nan_policy` other than `'propagate'` not implemented.
- **kurtosis**: same bias correction difference. `bias=False` and `nan_policy` other than `'propagate'` not implemented.

ref: #9187