### PR TITLE
docs: clarify coarsen reduction function contract

### DIFF
--- a/dask/array/chunk.py
+++ b/dask/array/chunk.py
@@ -88,7 +88,16 @@ def coarsen(reduction, x, axes, trim_excess=False, **kwargs):
     Parameters
     ----------
     reduction: function
-        Function like np.sum, np.mean, etc...
+        Reduction function (for example ``np.sum`` or ``np.mean``).
+
+        The function must accept:
+
+        - an ``array_like`` positional input,
+        - an ``axis=`` keyword containing a tuple of axes,
+        - and any extra ``**kwargs`` forwarded by ``coarsen``.
+
+        In practice, NumPy-style reductions and Array-API-compatible
+        reductions work well.
     x: np.ndarray
         Array to be coarsened
     axes: dict


### PR DESCRIPTION
## Summary
Clarifies what kind of callable can be passed as the `reduction` argument to `dask.array.coarsen`.

## Changes
- Expanded the `dask.array.chunk.coarsen` docstring for `reduction`
- Documented that `reduction` must accept:
  - an array-like positional input
  - `axis=` with a tuple of axes
  - forwarded `**kwargs`
- Added note that NumPy-style / Array-API-style reductions are expected

Fixes #9825

## Testing
- Not run in this environment (missing local test dependency: `cloudpickle`).
- Change is docs-only.
