### PR TITLE
fix: prevent ZeroDivisionError in _split_up_single_chunk (#12186)

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3428,6 +3428,9 @@ def _split_up_single_chunk(
     c: int, this_chunksize_tolerance: float, max_chunk_size: int, proposed: int
 ) -> list[int]:
     # Calculate by what factor we have to split this chunk
+    if proposed == 0:
+        # Fallback to max_chunk_size if proposed is zero
+        proposed = max(1, max_chunk_size)
     m = c / proposed
     if math.ceil(m) / m > this_chunksize_tolerance:
         # We want to smooth things potentially if rounding up would change the result


### PR DESCRIPTION
Fixes #12186

## Problem
The _split_up_single_chunk function in dask/array/core.py performs division by the proposed parameter without checking if it's zero. When the chunking algorithm calculates proposed=0 based on memory constraints or edge cases, this causes a ZeroDivisionError.

## Solution
Add a guard clause that handles the proposed=0 case by falling back to max_chunk_size (minimum 1), allowing the function to proceed with reasonable chunk sizing.

## Changes
- Added guard clause at function entry point (3 lines)
- When proposed=0, use max(1, max_chunk_size) as fallback
- Prevents ZeroDivisionError while maintaining sensible chunking behavior

## Testing
- Fix is minimal and surgical (3-line guard clause)
- Preserves existing logic for all proposed > 0 cases
- Handles edge case gracefully without changing algorithm