### PR TITLE
disable storage options with existing store

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3926,7 +3926,9 @@ def _setup_zarr_store(
     # Cannot directly import FSStore from storage.
     from zarr import storage
 
-    if storage_options is not None:
+    if storage_options is not None and len(storage_options) > 0:
+        if isinstance(url, storage.StoreLike):
+            raise ValueError("Storage options cannot be used with existing store")
         if _zarr_v3():
             read_only = kwargs.pop("read_only", kwargs.pop("mode", "a") == "r")
             store = storage.FsspecStore.from_url(


### PR DESCRIPTION
Checks if url is an existing store. If so, raises excpetion if storage options are provided as this will lead to a unintelligible error with zarr 3 and complete successfully but fail to write data with zarr 2 with remote URL (e.g. S3).

```
import dask.array as da
import zarr
from packaging.version import Version

url = "s3://foo"
if Version(zarr.__version__).major >= 3:
    # zarr v3
    # FileNotFoundError: [Errno 2] No such file or directory: {os.getcwd()}/{url}/foo/zarr.json'
    da.to_zarr(
        arr=da.ones((10, 10)).rechunk((2, 2)),
        url=zarr.storage.FsspecStore.from_url(url),
        component="foo",
        storage_options={},
    )
else:
    # zarr v2
    # fails to write data silently
    da.to_zarr(
        arr=da.ones((10, 10)).rechunk((2, 2)),
        url=zarr.open(url).store,
        component="foo",
        storage_options={},
    )

```