### PR TITLE
`__package__` → `__spec__.parent`

### DIFF
--- a/dask/array/tests/test_api.py
+++ b/dask/array/tests/test_api.py
@@ -21,7 +21,7 @@ def test_api():
         m
         for m, mod in member_dict.items()
         if m not in DA_EXPORTED_SUBMODULES
-        if isinstance(mod, ModuleType) and mod.__package__ == "dask.array"
+        if isinstance(mod, ModuleType) and mod.__spec__.parent == "dask.array"
     }
     # imported utility modules
     members -= {"annotations", "builtins", "importlib", "warnings"}

--- a/dask/dataframe/tests/test_api.py
+++ b/dask/dataframe/tests/test_api.py
@@ -22,8 +22,8 @@ def test_api():
         for m, mod in member_dict.items()
         if m not in DA_EXPORTED_SUBMODULES
         if isinstance(mod, ModuleType)
-        and mod.__package__
-        and mod.__package__.startswith("dask.dataframe")
+        and mod.__spec__.parent
+        and mod.__spec__.parent.startswith("dask.dataframe")
     }
     # imported utility modules
     members -= {"annotations"}


### PR DESCRIPTION
Remove deprecated `__package__`, scheduled for [removal in Python 3.15](https://docs.python.org/3.15/reference/datamodel.html#module.__package__).

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`
