### PR TITLE
Fix HLL uint32 truncation and add configurable shuffle hash key

### DIFF
--- a/dask/dask-schema.yaml
+++ b/dask/dask-schema.yaml
@@ -66,6 +66,16 @@ properties:
               Compression algorithm used for on disk-shuffling. Partd, the library used
               for compression supports ZLib, BZ2, and SNAPPY
 
+          hash-key:
+            type:
+            - string
+            - "null"
+            description: |
+              Hash key for shuffle partitioning. When set to a 16-character string,
+              this key is passed to pd.util.hash_pandas_object to change hash output
+              for string/object columns. Set to a random value to mitigate
+              HashDoS-style partition hotspotting in adversarial environments.
+
 
       parquet:
         type: object

--- a/dask/dask.yaml
+++ b/dask/dask.yaml
@@ -11,6 +11,7 @@ dataframe:
   shuffle:
     method: null
     compression: null  # compression for on disk-shuffling. Partd supports ZLib, BZ2, SNAPPY
+    hash-key: null  # Hash key for shuffle partitioning. Set to a random string to mitigate HashDoS.
   parquet:
     metadata-task-size-local: 512  # Number of files per local metadata-processing task
     metadata-task-size-remote: 1  # Number of files per remote metadata-processing task

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -547,6 +547,10 @@ def get_parallel_type_object(_):
 def hash_object_pandas(
     obj, index=True, encoding="utf8", hash_key=None, categorize=True
 ):
+    if hash_key is None:
+        from dask import config
+
+        hash_key = config.get("dataframe.shuffle.hash-key", None)
     return pd.util.hash_pandas_object(
         obj, index=index, encoding=encoding, hash_key=hash_key, categorize=categorize
     )

--- a/dask/dataframe/hyperloglog.py
+++ b/dask/dataframe/hyperloglog.py
@@ -20,9 +20,9 @@ from pandas.util import hash_pandas_object
 def compute_first_bit(a):
     "Compute the position of the first nonzero bit for each int in an array."
     # TODO: consider making this less memory-hungry
-    bits = np.bitwise_and.outer(a, 1 << np.arange(32))
+    bits = np.bitwise_and.outer(a, np.uint64(1) << np.arange(64, dtype=np.uint64))
     bits = bits.cumsum(axis=1).astype(bool)
-    return 33 - bits.sum(axis=1)
+    return 65 - bits.sum(axis=1)
 
 
 def compute_hll_array(obj, b):
@@ -30,14 +30,14 @@ def compute_hll_array(obj, b):
 
     if not 8 <= b <= 16:
         raise ValueError("b should be between 8 and 16")
-    num_bits_discarded = 32 - b
+    num_bits_discarded = 64 - b
     m = 1 << b
 
     # Get an array of the hashes
     hashes = hash_pandas_object(obj, index=False)
     if isinstance(hashes, pd.Series):
         hashes = hashes._values
-    hashes = hashes.astype(np.uint32)
+    hashes = hashes.astype(np.uint64)
 
     # Of the first b bits, which is the first nonzero?
     j = hashes >> num_bits_discarded
@@ -78,6 +78,6 @@ def estimate_count(Ms, b):
         V = (M == 0).sum()
         if V:
             return m * np.log(m / V)
-    if E > 2**32 / 30.0:
-        return -(2**32) * np.log1p(-E / 2**32)
+    if E > 2**64 / 30.0:
+        return -(2**64) * np.log1p(-E / 2**64)
     return E

--- a/dask/dataframe/tests/test_hashing.py
+++ b/dask/dataframe/tests/test_hashing.py
@@ -82,3 +82,42 @@ def test_hash_object_dispatch(obj):
     result = dd.dispatch.hash_object_dispatch(obj)
     expected = pd.util.hash_pandas_object(obj)
     assert_eq(result, expected)
+
+
+def test_hash_object_dispatch_custom_hash_key():
+    """hash_object_dispatch should respect the dataframe.shuffle.hash-key config."""
+    import dask
+
+    # hash_key only affects string/object dtypes in pandas
+    obj = pd.DataFrame({"x": ["a", "b", "c"], "y": ["d", "e", "f"]})
+    default_hash = dd.dispatch.hash_object_dispatch(obj, index=False)
+
+    with dask.config.set({"dataframe.shuffle.hash-key": "abcdefghijklmnop"}):
+        keyed_hash = dd.dispatch.hash_object_dispatch(obj, index=False)
+
+    # Different key should produce different hashes
+    assert not (
+        default_hash == keyed_hash
+    ).all(), "Custom hash key should produce different hashes than default"
+
+
+def test_hash_object_dispatch_explicit_key_overrides_config():
+    """Explicitly passed hash_key should take precedence over config."""
+    import dask
+
+    # hash_key only affects string/object dtypes in pandas
+    obj = pd.Series(["a", "b", "c"])
+    explicit_hash = dd.dispatch.hash_object_dispatch(
+        obj, index=False, hash_key="abcdefghijklmnop"
+    )
+
+    with dask.config.set({"dataframe.shuffle.hash-key": "zyxwvutsrqponmlk"}):
+        config_hash = dd.dispatch.hash_object_dispatch(obj, index=False)
+        explicit_in_config = dd.dispatch.hash_object_dispatch(
+            obj, index=False, hash_key="abcdefghijklmnop"
+        )
+
+    # Explicit key should give same result regardless of config
+    assert_eq(explicit_hash, explicit_in_config)
+    # Config key should differ from explicit key
+    assert not (explicit_hash == config_hash).all()

--- a/dask/dataframe/tests/test_hyperloglog.py
+++ b/dask/dataframe/tests/test_hyperloglog.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 import dask.dataframe as dd
+from dask.dataframe.hyperloglog import estimate_count
 
 rs = np.random.RandomState(96)
 
@@ -94,3 +95,43 @@ def test_larger_data():
         seed=1,
     )
     assert df.nunique_approx().compute() > 1000
+
+
+def test_hll_uses_uint64():
+    """HLL should use full 64-bit hashes, not truncate to uint32."""
+    from dask.dataframe.hyperloglog import compute_hll_array
+
+    # Verify that compute_hll_array processes hashes as uint64 internally
+    # by checking the state array handles high-bit bucket indices correctly.
+    # With b=10, we have 1024 buckets addressed by the top 10 bits of uint64.
+    # A uint32 truncation would lose upper bits and misassign buckets.
+    df = pd.DataFrame({"x": range(10000)})
+    state = compute_hll_array(df, b=10)
+    approx = estimate_count(state, b=10)
+    exact = len(df.drop_duplicates())
+    # Should be within 10% of exact count
+    assert (
+        abs(approx - exact) / exact < 0.10
+    ), f"HLL estimate {approx} too far from exact {exact}"
+
+
+def test_compute_first_bit_64bit():
+    """compute_first_bit should handle 64-bit hash values correctly."""
+    from dask.dataframe.hyperloglog import compute_first_bit
+
+    # For value (1 << 40): bit 40 is set.
+    # Bits 0-39 are zero, bits 40-63 are counted after cumsum+bool.
+    # Result = 65 - (64 - 40) = 65 - 24 = 41
+    arr = np.array([1 << 40], dtype=np.uint64)
+    result = compute_first_bit(arr)
+    assert result[0] == 41, f"compute_first_bit gave {result[0]} for 1<<40, expected 41"
+
+    # Zero should give max position (65 = no bits set)
+    arr_zero = np.array([0], dtype=np.uint64)
+    result_zero = compute_first_bit(arr_zero)
+    assert result_zero[0] == 65
+
+    # Value 1 (bit 0 set): all 64 cumsum positions are True after bit 0
+    arr_one = np.array([1], dtype=np.uint64)
+    result_one = compute_first_bit(arr_one)
+    assert result_one[0] == 1

--- a/examples/hash_pandas_object_demo.py
+++ b/examples/hash_pandas_object_demo.py
@@ -1,0 +1,195 @@
+"""
+Bilingual demo for pd.util.hash_pandas_object collision and HashDoS risks.
+
+双语演示脚本：展示 pd.util.hash_pandas_object 的碰撞现象，以及在
+Dask 分桶/路由场景下可能带来的 HashDoS 风险。
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from dask.dataframe.hyperloglog import compute_hll_array, estimate_count
+from dask.dataframe.shuffle import partitioning_index
+
+
+def print_section(title_cn: str, title_en: str) -> None:
+    print("\n" + "=" * 88)
+    print(f"{title_cn} / {title_en}")
+    print("=" * 88)
+
+
+def print_kv(label_cn: str, label_en: str, value) -> None:
+    print(f"{label_cn} / {label_en}: {value}")
+
+
+def demo_scalar_collisions() -> None:
+    print_section(
+        "场景 1：跨 dtype 的确定性碰撞",
+        "Scenario 1: Deterministic cross-dtype collisions",
+    )
+
+    cases = [
+        (
+            pd.Series([True], dtype="bool"),
+            pd.Series([1], dtype="int64"),
+            "布尔 True 与整数 1",
+            "bool True vs int 1",
+        ),
+        (
+            pd.Series([pd.Timestamp("1970-01-01 00:00:00.000000001")]),
+            pd.Series([1], dtype="int64"),
+            "纳秒时间戳 1ns 与整数 1",
+            "timestamp 1ns vs int 1",
+        ),
+        (
+            pd.Series([5], dtype="int8"),
+            pd.Series([5], dtype="int64"),
+            "int8(5) 与 int64(5)",
+            "int8(5) vs int64(5)",
+        ),
+    ]
+
+    for left, right, label_cn, label_en in cases:
+        left_hash = int(pd.util.hash_pandas_object(left, index=False).iloc[0])
+        right_hash = int(pd.util.hash_pandas_object(right, index=False).iloc[0])
+        print(f"- {label_cn} / {label_en}")
+        print(f"  left={left.iloc[0]!r}, dtype={left.dtype}, hash={left_hash}")
+        print(f"  right={right.iloc[0]!r}, dtype={right.dtype}, hash={right_hash}")
+        print(f"  collision / 发生碰撞: {left_hash == right_hash}")
+
+    print(
+        "\n结论 / Takeaway: pandas 会先把多种数值/时间 dtype 规整到统一的 "
+        "uint64 表示，再做 64 位混洗，因此这类碰撞是确定性的。"
+    )
+
+
+def demo_dataframe_row_collision() -> None:
+    print_section(
+        "场景 2：整行组合哈希碰撞",
+        "Scenario 2: Whole-row combined-hash collision",
+    )
+
+    df1 = pd.DataFrame({"A": [1604090909467468979, 2], "B": [4, 4]})
+    df2 = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+
+    h1 = pd.util.hash_pandas_object(df1, index=False)
+    h2 = pd.util.hash_pandas_object(df2, index=False)
+
+    print("df1")
+    print(df1)
+    print("df2")
+    print(df2)
+    print_kv("df1 行哈希", "df1 row hashes", h1.tolist())
+    print_kv("df2 行哈希", "df2 row hashes", h2.tolist())
+    print_kv(
+        "第 0 行哈希是否相同",
+        "Whether row-0 hashes collide",
+        int(h1.iloc[0]) == int(h2.iloc[0]),
+    )
+
+    print(
+        "\n说明 / Note: 这不是单列值相等，而是 DataFrame 多列通过 "
+        "combine_hash_arrays 组合后出现的整行碰撞。"
+    )
+
+
+def demo_hll_undercount() -> None:
+    print_section(
+        "场景 3：HyperLogLog 低估唯一值数量",
+        "Scenario 3: HyperLogLog undercounts unique rows",
+    )
+
+    rows = pd.DataFrame(
+        {
+            "A": [1604090909467468979, 1],
+            "B": [4, 3],
+        }
+    )
+    row_hashes = pd.util.hash_pandas_object(rows, index=False)
+    state = compute_hll_array(rows, b=10)
+    approx = estimate_count(state, b=10)
+    exact = len(rows.drop_duplicates())
+
+    print(rows)
+    print_kv("整行哈希", "row hashes", row_hashes.tolist())
+    print_kv("精确唯一行数", "exact unique row count", exact)
+    print_kv("HLL 估计值", "HLL estimate", round(float(approx), 6))
+    print(
+        "\n结论 / Takeaway: 如果两个不同的输入在进入 HLL 前就已经拥有相同哈希，"
+        "那么 HLL 会把它们当成同一个元素，导致近似去重被低估。"
+    )
+
+
+def collect_keys_for_bucket(
+    npartitions: int, target_bucket: int, count: int
+) -> list[str]:
+    keys: list[str] = []
+    i = 0
+    while len(keys) < count:
+        key = f"attack_{i}"
+        frame = pd.DataFrame({"key": [key]})
+        bucket = int(partitioning_index(frame[["key"]], npartitions).iloc[0])
+        if bucket == target_bucket:
+            keys.append(key)
+        i += 1
+    return keys
+
+
+def demo_hashdos_bucket_hotspot() -> None:
+    print_section(
+        "场景 4：分桶热点与 HashDoS 风险",
+        "Scenario 4: Bucket hotspot and HashDoS risk",
+    )
+
+    npartitions = 16
+    target_bucket = 0
+    crafted_keys = collect_keys_for_bucket(
+        npartitions=npartitions, target_bucket=target_bucket, count=64
+    )
+
+    attack_df = pd.DataFrame(
+        {
+            "key": crafted_keys * 64,
+            "payload": range(len(crafted_keys) * 64),
+        }
+    )
+    buckets = partitioning_index(attack_df[["key"]], npartitions)
+    counts = pd.Series(buckets).value_counts().sort_index()
+
+    print_kv("目标分区", "target bucket", target_bucket)
+    print_kv("分区总数", "number of partitions", npartitions)
+    print_kv("命中目标桶的不同 key 数量", "distinct crafted keys", len(crafted_keys))
+    print_kv("攻击样本总行数", "total crafted rows", len(attack_df))
+    print_kv("前 10 个命中的 key", "first 10 matching keys", crafted_keys[:10])
+    print("\n分桶分布 / Bucket distribution:")
+    print(counts.to_string())
+    print_kv(
+        "目标桶负载占比",
+        "target-bucket load ratio",
+        f"{counts.get(target_bucket, 0) / len(attack_df):.2%}",
+    )
+
+    print(
+        "\n最大风险 / Primary risk: 如果系统把同一 bucket 路由到同一 worker/node，"
+        "那么攻击者可以构造大量不同 key 落到同一个分区，形成热点节点。"
+    )
+    print(
+        "这会导致 / This can cause: 内存放大、单节点 CPU 打满、shuffle/merge 延迟上升、"
+        "任务失败，严重时表现为 HashDoS。"
+    )
+
+
+def main() -> None:
+    print(
+        "pd.util.hash_pandas_object collision and HashDoS demo\n"
+        "pd.util.hash_pandas_object 碰撞与 HashDoS 双语演示"
+    )
+    demo_scalar_collisions()
+    demo_dataframe_row_collision()
+    demo_hll_undercount()
+    demo_hashdos_bucket_hotspot()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hash_pandas_object_vulnerability_report.md
+++ b/examples/hash_pandas_object_vulnerability_report.md
@@ -1,0 +1,141 @@
+# `pd.util.hash_pandas_object` Collision and HashDoS Report
+
+# `pd.util.hash_pandas_object` 碰撞与 HashDoS 漏洞披露报告
+
+## Summary / 摘要
+
+This report documents multiple collision behaviors in `pd.util.hash_pandas_object` and explains their security impact in the current Dask codebase.
+
+本报告描述了 `pd.util.hash_pandas_object` 的多类碰撞行为，并说明它们在当前 Dask 代码库中的安全影响。
+
+The most important risk is not only logical collision in abstract hashing theory, but practical **HashDoS-style partition hotspotting**: if many crafted keys are routed to the same hash bucket and that bucket is handled by a single partition, worker, or node, the system can suffer severe skew, memory pressure, and denial-of-service symptoms.
+
+最重要的风险不仅是抽象意义上的哈希碰撞，而是实际可利用的 **HashDoS 式热点分桶**：如果大量构造输入被路由到同一个哈希桶，而该桶对应单个分区、worker 或节点，那么系统会出现严重倾斜、内存压力以及拒绝服务症状。
+
+## Affected Code Paths / 受影响路径
+
+- [hyperloglog.py](/home/dem0/project/LLM-HASH/dask/dask/dataframe/hyperloglog.py#L37): `compute_hll_array` hashes rows with `pd.util.hash_pandas_object(..., index=False)` and then truncates to `uint32`.
+- [shuffle.py](/home/dem0/project/LLM-HASH/dask/dask/dataframe/shuffle.py#L81): `partitioning_index` routes rows with `hash_object_dispatch(df, index=False) % npartitions`.
+- [multi.py](/home/dem0/project/LLM-HASH/dask/dask/dataframe/multi.py#L318): multi-column join routing relies on hash-based partitioning.
+- [backends.py](/home/dem0/project/LLM-HASH/dask/dask/dataframe/backends.py#L547): pandas backend forwards to `pd.util.hash_pandas_object`.
+
+## Collision Classes / 碰撞类型
+
+### 1. Cross-dtype deterministic collisions / 跨 dtype 的确定性碰撞
+
+The pandas implementation canonicalizes several scalar types into `uint64` before mixing. As a result, the following examples hash identically:
+
+pandas 会先把多种标量类型规整为 `uint64` 再混洗，因此以下示例会得到相同哈希：
+
+- `True` and `1`
+- `Timestamp("1970-01-01 00:00:00.000000001")` and `1`
+- `int8(5)` and `int64(5)`
+
+These are deterministic collisions, not rare accidents.
+
+这些是确定性的碰撞，不是低概率偶发事件。
+
+### 2. Combined row-hash collisions / 多列整行组合碰撞
+
+Distinct rows can collide after pandas combines per-column hashes into a single row hash.
+
+不同的行在 pandas 把各列哈希组合成整行哈希后，也可能发生碰撞。
+
+Demonstrated example:
+
+演示样例：
+
+```python
+df1 = pd.DataFrame({"A": [1604090909467468979, 2], "B": [4, 4]})
+df2 = pd.DataFrame({"A": [1, 2],                    "B": [3, 4]})
+```
+
+The first row of `df1` and the first row of `df2` produce the same row hash under `pd.util.hash_pandas_object(..., index=False)`.
+
+在 `pd.util.hash_pandas_object(..., index=False)` 下，`df1` 的第 0 行与 `df2` 的第 0 行会产生相同整行哈希。
+
+## Security Impact / 安全影响
+
+### A. HyperLogLog undercount / HyperLogLog 低估
+
+If two different rows collide before entering HyperLogLog, then the HLL state cannot distinguish them.
+
+如果两个不同的输入在进入 HyperLogLog 前已经碰撞，那么 HLL 状态将无法区分它们。
+
+Impact:
+
+影响：
+
+- `nunique_approx()` may undercount distinct values or rows.
+- Large-cardinality workloads become more sensitive because Dask further truncates hashes to `uint32`.
+
+### B. Shuffle / merge hotspotting / shuffle 与 merge 热点分桶
+
+For shuffle and hash-join routing, collisions usually do not directly produce wrong join results, because equality is rechecked later.
+
+对于 shuffle 和 hash join 路由，碰撞通常不会直接导致错误 join 结果，因为后续仍会做真实键比较。
+
+However, the system can still be attacked operationally:
+
+但系统在运行层面仍可能被攻击：
+
+- Many distinct attacker-controlled keys can be chosen so that `hash(key) % npartitions` falls into the same bucket.
+- If that bucket is assigned to one partition, worker, or node, the attacker can create a hotspot.
+- This can trigger excessive memory growth, scheduler backpressure, long shuffle tails, worker crashes, and service unavailability.
+
+也就是说：
+
+- 攻击者可以挑选大量不同 key，使 `hash(key) % npartitions` 落入同一桶。
+- 如果该桶被分配给一个分区、worker 或节点，就会形成热点。
+- 结果可能包括内存暴涨、调度背压、shuffle 长尾、worker 崩溃和服务不可用。
+
+This is the primary **HashDoS risk**.
+
+这正是最核心的 **HashDoS 风险**。
+
+## Severity Assessment / 严重性评估
+
+- Correctness risk for shuffle/join: Medium
+- Accuracy risk for `nunique_approx()`: High
+- Availability risk from bucket hotspotting / HashDoS: High
+
+说明：
+
+- `shuffle/join` 的正确性风险通常不是最高，因为后续仍会做实际比较
+- `nunique_approx()` 的准确性风险更直接
+- 若攻击者可控输入 key，`HashDoS` 带来的可用性风险最高
+
+## Reproduction / 复现方式
+
+Run the bilingual demo:
+
+运行双语演示脚本：
+
+```bash
+/home/dem0/miniconda3/envs/LLM-HASH/bin/python examples/hash_pandas_object_demo.py
+```
+
+The demo shows:
+
+演示内容包括：
+
+- deterministic scalar collisions / 标量确定性碰撞
+- combined row-hash collisions / 整行组合碰撞
+- HLL undercount / HLL 低估
+- crafted bucket hotspotting / 构造型热点分桶
+
+## Suggested Mitigations / 缓解建议
+
+- Avoid treating `hash_pandas_object` as a collision-resistant primitive.
+- For security-sensitive routing, add a stronger keyed hash or a second verification hash.
+- Add skew detection and bucket load monitoring during shuffle.
+- Consider salting or rotating hash partitioning in adversarial environments.
+- For HLL-sensitive paths, evaluate a backend-generic stronger hash and avoid avoidable truncation.
+
+建议：
+
+- 不要把 `hash_pandas_object` 当作抗碰撞安全哈希
+- 对安全敏感的路由增加更强的带密钥哈希或二次校验哈希
+- 在 shuffle 中增加倾斜检测与 bucket 负载监控
+- 在对抗环境下考虑加盐或轮换分桶策略
+- 对 HLL 路径评估更稳健的哈希方案，并减少不必要的截断

--- a/examples/hash_pandas_object_vulnerability_report_en.md
+++ b/examples/hash_pandas_object_vulnerability_report_en.md
@@ -1,0 +1,253 @@
+# Vulnerability Disclosure: `pd.util.hash_pandas_object` Collisions and HashDoS Impact in Dask
+
+GitHub repository: https://github.com/dask/dask
+
+Local report path: `examples/hash_pandas_object_vulnerability_report_en.md`
+
+## Summary
+
+`pd.util.hash_pandas_object` is used in multiple Dask DataFrame code paths, including HyperLogLog-based approximate cardinality estimation and hash-based partition routing for shuffle and join operations.
+
+The hashing behavior is not collision-resistant. In the current codebase, this leads to two practical security-relevant outcomes:
+
+- Distinct inputs can produce identical row hashes before entering `HyperLogLog`, causing undercounting in `nunique_approx()`.
+- An attacker can craft many distinct keys that map into the same hash bucket after `% npartitions`, creating a partition hotspot. If a bucket is handled by a single partition, worker, or node, this can produce a HashDoS-style availability issue.
+
+The primary risk is **availability degradation via hash-bucket hotspotting**, not only abstract hash collision.
+
+## Affected Components
+
+- `dask/dataframe/hyperloglog.py`
+- `dask/dataframe/shuffle.py`
+- `dask/dataframe/multi.py`
+- `dask/dataframe/backends.py`
+
+## Impact
+
+### 1. HyperLogLog accuracy impact
+
+`compute_hll_array` hashes rows with `pd.util.hash_pandas_object(..., index=False)` and then truncates the result to `uint32`. If two distinct rows already collide before the HLL stage, the estimator cannot distinguish them and may undercount unique elements.
+
+This affects:
+
+- `nunique_approx()`
+- any workflow relying on HLL-based uniqueness estimation
+
+### 2. Shuffle / join routing impact
+
+Hash-based routing in Dask partitions rows with:
+
+```python
+hash_object_dispatch(df, index=False) % npartitions
+```
+
+Even when collisions do not directly corrupt join correctness, they still allow attackers to concentrate a large number of distinct keys into a single partition. This can create:
+
+- partition skew
+- memory amplification
+- CPU saturation on a single worker
+- long shuffle tails
+- worker failure or task retries
+- service degradation or denial of service
+
+This is the primary **HashDoS** concern.
+
+## Severity
+
+- Integrity / correctness risk for shuffle and join: Medium
+- Accuracy risk for `nunique_approx()`: High
+- Availability risk from bucket hotspotting / HashDoS: High
+
+## Root Cause
+
+There are two relevant causes:
+
+### A. Deterministic canonicalization collisions
+
+Pandas canonicalizes several scalar types to `uint64` before mixing. As a result, certain cross-dtype values hash identically. Examples include:
+
+- `True` and `1`
+- `Timestamp("1970-01-01 00:00:00.000000001")` and `1`
+- `int8(5)` and `int64(5)`
+
+### B. Combined row-hash collisions
+
+For DataFrames, pandas combines per-column hashes into a single row hash. This combination is not injective, so distinct rows can collide.
+
+Example:
+
+```python
+df1 = pd.DataFrame({"A": [1604090909467468979, 2], "B": [4, 4]})
+df2 = pd.DataFrame({"A": [1, 2],                    "B": [3, 4]})
+```
+
+The first row of `df1` and the first row of `df2` produce the same row hash under `pd.util.hash_pandas_object(..., index=False)`.
+
+## Reproduction Script
+
+The following standalone script reproduces:
+
+- deterministic cross-dtype collisions
+- combined row-hash collisions
+- HyperLogLog undercount
+- hash-bucket hotspotting / HashDoS-style skew
+
+```python
+from __future__ import annotations
+
+import pandas as pd
+
+from dask.dataframe.hyperloglog import compute_hll_array, estimate_count
+from dask.dataframe.shuffle import partitioning_index
+
+
+def collect_keys_for_bucket(npartitions: int, target_bucket: int, count: int) -> list[str]:
+    keys: list[str] = []
+    i = 0
+    while len(keys) < count:
+        key = f"attack_{i}"
+        frame = pd.DataFrame({"key": [key]})
+        bucket = int(partitioning_index(frame[["key"]], npartitions).iloc[0])
+        if bucket == target_bucket:
+            keys.append(key)
+        i += 1
+    return keys
+
+
+def main() -> None:
+    print("=== 1. Deterministic cross-dtype collisions ===")
+    cases = [
+        (pd.Series([True], dtype="bool"), pd.Series([1], dtype="int64"), "bool True vs int 1"),
+        (
+            pd.Series([pd.Timestamp("1970-01-01 00:00:00.000000001")]),
+            pd.Series([1], dtype="int64"),
+            "timestamp 1ns vs int 1",
+        ),
+        (pd.Series([5], dtype="int8"), pd.Series([5], dtype="int64"), "int8(5) vs int64(5)"),
+    ]
+    for left, right, label in cases:
+        left_hash = int(pd.util.hash_pandas_object(left, index=False).iloc[0])
+        right_hash = int(pd.util.hash_pandas_object(right, index=False).iloc[0])
+        print(label, left_hash, right_hash, left_hash == right_hash)
+
+    print("\n=== 2. Combined row-hash collision ===")
+    df1 = pd.DataFrame({"A": [1604090909467468979, 2], "B": [4, 4]})
+    df2 = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+    h1 = pd.util.hash_pandas_object(df1, index=False)
+    h2 = pd.util.hash_pandas_object(df2, index=False)
+    print("df1 row hashes:", h1.tolist())
+    print("df2 row hashes:", h2.tolist())
+    print("row-0 collision:", int(h1.iloc[0]) == int(h2.iloc[0]))
+
+    print("\n=== 3. HyperLogLog undercount ===")
+    rows = pd.DataFrame({"A": [1604090909467468979, 1], "B": [4, 3]})
+    row_hashes = pd.util.hash_pandas_object(rows, index=False)
+    state = compute_hll_array(rows, b=10)
+    approx = estimate_count(state, b=10)
+    exact = len(rows.drop_duplicates())
+    print("row hashes:", row_hashes.tolist())
+    print("exact unique rows:", exact)
+    print("HLL estimate:", float(approx))
+
+    print("\n=== 4. Bucket hotspot / HashDoS reproduction ===")
+    npartitions = 16
+    target_bucket = 0
+    crafted_keys = collect_keys_for_bucket(npartitions, target_bucket, 64)
+    attack_df = pd.DataFrame(
+        {
+            "key": crafted_keys * 64,
+            "payload": range(len(crafted_keys) * 64),
+        }
+    )
+    buckets = partitioning_index(attack_df[["key"]], npartitions)
+    counts = pd.Series(buckets).value_counts().sort_index()
+    print("target bucket:", target_bucket)
+    print("distinct crafted keys:", len(crafted_keys))
+    print("total crafted rows:", len(attack_df))
+    print("bucket counts:")
+    print(counts.to_string())
+    print("target bucket ratio:", counts.get(target_bucket, 0) / len(attack_df))
+
+
+if __name__ == "__main__":
+    main()
+```
+
+## How to Run
+
+From the repository root:
+
+```bash
+python examples/hash_pandas_object_demo.py
+```
+
+Or save the standalone script above and run it in a Python environment where the local Dask source tree is importable.
+
+## Expected vs Actual Results
+
+### Deterministic cross-dtype collisions
+
+Expected from a collision-resistant routing primitive:
+
+- distinct semantic values should not predictably collide
+
+Actual:
+
+- `True` and `1` hash identically
+- `Timestamp(1ns)` and `1` hash identically
+- `int8(5)` and `int64(5)` hash identically
+
+### Combined row-hash collision
+
+Expected:
+
+- distinct rows should not be easy to collide when used for routing or approximate uniqueness
+
+Actual:
+
+- the first row of `df1` collides with the first row of `df2`
+
+### HyperLogLog
+
+Expected:
+
+- two distinct rows should contribute to a cardinality close to `2`
+
+Actual:
+
+- the HLL estimate is close to `1`, because both rows share the same pre-HLL hash
+
+### HashDoS hotspotting
+
+Expected:
+
+- crafted attacker-controlled keys should distribute across partitions
+
+Actual:
+
+- a large set of distinct keys can be selected so that all records land in the same bucket
+
+## Security Relevance
+
+This issue matters when:
+
+- inputs are attacker-controlled or adversarial
+- shuffle and join workloads run on shared infrastructure
+- the system assumes hash distribution is sufficiently uniform
+- availability matters more than a single-query correctness failure
+
+The key observation is:
+
+> If a hash bucket maps to one partition, worker, or node, then bucket-targeted crafted inputs can create a practical HashDoS condition.
+
+## Suggested Mitigations
+
+- Do not treat `hash_pandas_object` as a collision-resistant or security-strength hash.
+- Add skew detection and bucket load monitoring during shuffle.
+- Consider salting or keyed hashing for adversarial environments.
+- Consider secondary verification or stronger hashing for security-sensitive routing.
+- Reevaluate the HLL path to reduce pre-estimation collision impact and avoid avoidable truncation.
+
+## Notes
+
+This report is focused on practical exploitation impact in the current Dask code paths, especially partition hotspotting and `nunique_approx()` undercounting.


### PR DESCRIPTION
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

## Summary

This PR addresses hash collision vulnerabilities in Dask's HyperLogLog and shuffle routing paths, as documented in `examples/hash_pandas_object_vulnerability_report_en.md`.

### 1. HyperLogLog: uint32 → uint64

`compute_hll_array` previously truncated 64-bit hashes from `pd.util.hash_pandas_object` to `uint32`, halving entropy and increasing collision probability. This caused `nunique_approx()` to undercount in certain scenarios.

**Changes:**
- `compute_first_bit`: operate on 64-bit range instead of 32-bit
- `compute_hll_array`: keep hashes as `uint64` instead of casting to `uint32`
- `estimate_count`: adjust large-cardinality threshold from `2^32` to `2^64`

### 2. Configurable shuffle hash key

Added `dataframe.shuffle.hash-key` config option. When set, this key is passed to `pd.util.hash_pandas_object`, changing the hash output for string/object columns. This mitigates HashDoS-style partition hotspotting where an attacker crafts keys to land in the same bucket.

**Changes:**
- `backends.py`: `hash_object_pandas` reads config key when no explicit key is passed
- `dask.yaml`: new `hash-key: null` under `dataframe.shuffle`

### 3. Tests

- `test_hll_uses_uint64`: verifies HLL accuracy with full 64-bit processing
- `test_compute_first_bit_64bit`: verifies 64-bit bit-position computation
- `test_hash_object_dispatch_custom_hash_key`: verifies config key changes hash output
- `test_hash_object_dispatch_explicit_key_overrides_config`: verifies explicit key takes precedence over config

### 4. Vulnerability report and demo

- `examples/hash_pandas_object_demo.py`: bilingual demo reproducing all collision scenarios
- `examples/hash_pandas_object_vulnerability_report.md`: bilingual report
- `examples/hash_pandas_object_vulnerability_report_en.md`: English-only detailed report

## Test plan

- [x] `pytest dask/dataframe/tests/test_hyperloglog.py` — 35 passed
- [x] `pytest dask/dataframe/tests/test_hashing.py` — 24 passed
- [x] `pre-commit run --all-files` — all checks passed