### PR TITLE
Add numba, sparse, and h5py to 3.14t CI

### DIFF
--- a/continuous_integration/environment-3.14t.yaml
+++ b/continuous_integration/environment-3.14t.yaml
@@ -24,24 +24,21 @@ dependencies:
   - numpy
   - pandas>=3.0.1  # 3.0.0 has major race conditions
   - pyarrow
-  # conda variant of distributed depends on cytoolz, which is not available
-  # on conda yet.
-  # Manually install distributed dependencies from conda below.
-  # - distributed  # Overridden by git tip below; used to pull in dependencies
+  - distributed  # Overridden by git tip below; used to pull in dependencies
   # optional s3 I/O
   - boto3
   - botocore
   # - moto<5  # Not available for 3.14t on Windows
-  # - s3fs>=2026.1.0  # Not available for 3.14t
+  # - s3fs>=2026.3.0  # Pins obsolete boto3/botocore that don't release the GIL
   # other optional dependencies
   - mimesis
-  # - numba  # Not available for 3.14t
+  # - numba  # conda package for 3.14t not yet available
   - flask
-  # - h5py  # Not available for 3.14t
+  - h5py
   # - pytables  # Not available for 3.14t
-  # - zarr  # Not available for 3.14t
+  # - zarr  # Dependency numcodecs not available for 3.14t
   # - pyspark  # Huge package; limit where it is tested
-  # - tiledb-py  # Not available for 3.14t
+  # - tiledb-py  # Not available for 3.14t; pins pandas<3
   # - tiledb  # Not available for 3.14t
   - xarray
   # - sqlalchemy  # Not available for 3.14t
@@ -50,11 +47,11 @@ dependencies:
   - httpretty
   - aiohttp
   # - crick  # No Python 3.14 build yet
-  # - cytoolz  # conda package for 3.14t not yet available; installed via pip below
+  - cytoolz
   - ipython
   - ipycytoscape
   - ipywidgets
-  # - ipykernel  # Not available for 3.14t
+  # - ipykernel  # Does not release the GIL
   - lz4
   - psutil
   - requests
@@ -62,7 +59,7 @@ dependencies:
   - scikit-learn
   - scipy
   # - python-snappy  # dependency cramjam does not release the GIL
-  # - sparse  # Not available for 3.14t
+  # - sparse  # conda package for numba 3.14t not yet available
   - cachey
   - python-graphviz
   # - python-cityhash  # Not available for 3.14t
@@ -70,21 +67,13 @@ dependencies:
   - mmh3
   - jinja2
 
-  ##### 3.14t temporary hacks
-  # packages normally pulled in by the `distributed` conda package
-  - locket
   # FIXME https://github.com/msgpack/msgpack-python/issues/613
-  # Install placeholder to prevent distributed below from compiling the C extension from
-  # sources. tests.yml will replace this with a pure-python variant.
+  # msgpack C extension does not release the GIL.
+  # tests.yml will replace this with a pure-python variant.
   - msgpack-python
-  - sortedcontainers
-  - tblib
-  - tornado
-  - urllib3
-  - zict
-  ##### end 3.14t hacks
 
   - pip
   - pip:
-    - cytoolz  # conda package for 3.14t not yet available
+    - numba  # conda package for 3.14t not yet available
+    - sparse  # conda package for numba 3.14t not yet available
     - git+https://github.com/dask/distributed


### PR DESCRIPTION
Additionally, it is now possible to `conda install distributed`.
msgpack and zarr are still major blockers for everyday users.