### PR TITLE
Fix typos

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -2102,7 +2102,7 @@ def setitem(x, v, indices):
 
     # Copy the array to guarantee no other objects are corrupted.
     # When x is the output of a scalar __getitem__ call, it is a
-    # np.generic, which is read-only. Convert it to a (writeable)
+    # np.generic, which is read-only. Convert it to a (writable)
     # 0-d array. x could also be a cupy array etc.
     x = np.asarray(x) if isinstance(x, np.generic) else x.copy()
 

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -6100,7 +6100,7 @@ def test_load_store_chunk():
 
 def test_scalar_setitem():
     """After a da.Array.__getitem__ call that returns a scalar, the chunk contains a
-    read-only np.generic instead of a writeable np.ndarray. This is a specific quirk of
+    read-only np.generic instead of a writable np.ndarray. This is a specific quirk of
     numpy; cupy and other backends always return a 0-dimensional array.
     Make sure that __setitem__ still works.
     """

--- a/dask/array/tests/test_random.py
+++ b/dask/array/tests/test_random.py
@@ -287,7 +287,7 @@ def test_array_broadcasting(generator_class):
         a = generator_class().normal(1000 * o, 0.01, chunks=(50,))
         assert 800 < a.mean().compute() < 1200
 
-    # ensure that mis-matched chunks align well
+    # ensure that mismatched chunks align well
     x = np.arange(10) ** 3
     y = da.from_array(x, chunks=(1,))
     z = generator_class().normal(y, 0.01, chunks=(10,))

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -816,11 +816,11 @@ def test_hdf_filenames():
 def test_hdf_path_exceptions():
     # single file doesn't exist
     with pytest.raises(IOError):
-        dd.read_hdf("nonexistant_store_X34HJK", "/tmp")
+        dd.read_hdf("nonexistent_store_X34HJK", "/tmp")
 
     # a file from a list of files doesn't exist
     with pytest.raises(IOError):
-        dd.read_hdf(["nonexistant_store_X34HJK", "nonexistant_store_UY56YH"], "/tmp")
+        dd.read_hdf(["nonexistent_store_X34HJK", "nonexistent_store_UY56YH"], "/tmp")
 
     # list of files is empty
     with pytest.raises(ValueError):

--- a/docs/source/graphviz.rst
+++ b/docs/source/graphviz.rst
@@ -117,7 +117,7 @@ to install than graphviz in some deployment settings.
 
 Visualize the high level graph
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The low level Dask task graph can be overwhelimg, especially for large computations.
+The low level Dask task graph can be overwhelming, especially for large computations.
 A more concise alternative is to look at the Dask high level graph instead.
 The high level graph can be visualized using ``.dask.visualize()``.
 


### PR DESCRIPTION
Fixes a few more typos found by [typos](https://github.com/crate-ci/typos).

I have left out `leafs` → `leaves`.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [X] Passes `pre-commit run --all-files`
