### PR TITLE
docs: order array arguments in docstring

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1311,8 +1311,6 @@ class Array(DaskMethodsMixin):
         Task dependency graph
     name : string
         Name of array in dask
-    shape : tuple of ints
-        Shape of the entire array
     chunks: iterable of tuples
         block sizes along each dimension
     dtype : str or dtype
@@ -1320,6 +1318,8 @@ class Array(DaskMethodsMixin):
     meta : empty ndarray
         empty ndarray created with same NumPy backend, ndim and dtype as the
         Dask Array being created (overrides dtype)
+    shape : tuple of ints
+        Shape of the entire array
 
     See Also
     --------


### PR DESCRIPTION
The online documentation for Array
at
https://docs.dask.org/en/latest/generated/dask.array.Array.html#dask.array.Array shows the arguments in the order
dask, name, chunks, dtype, meta, shape,
so sort the parameters in the docstring
in the same order.

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pre-commit run --all-files`
