### PR TITLE
Fix cholesky decomposition for complex dtype

### DIFF
--- a/dask/array/linalg.py
+++ b/dask/array/linalg.py
@@ -1288,6 +1288,10 @@ def inv(a):
     return solve(a, eye(a.shape[0], chunks=a.chunks[0][0]))
 
 
+def _conj_transpose(a):
+    return np.transpose(a).conj()
+
+
 def _cholesky_lower(a):
     return np.linalg.cholesky(a)
 
@@ -1371,7 +1375,7 @@ def _cholesky(a):
                         prevs.append(prev)
                     target = (operator.sub, target, (sum, prevs))
                 dsk[name, i, i] = (_cholesky_lower, target)
-                dsk[name_upper, i, i] = (np.transpose, (name, i, i))
+                dsk[name_upper, i, i] = (_conj_transpose, (name, i, i))
             else:
                 # solving x.dot(L11.T) = (A21 - L20.dot(L10.T)) is equal to
                 # L11.dot(x.T) = A21.T - L10.dot(L20.T)
@@ -1385,7 +1389,7 @@ def _cholesky(a):
                         prevs.append(prev)
                     target = (operator.sub, target, (sum, prevs))
                 dsk[name_upper, j, i] = (_solve_triangular_lower, (name, j, j), target)
-                dsk[name, i, j] = (np.transpose, (name_upper, j, i))
+                dsk[name, i, j] = (_conj_transpose, (name_upper, j, i))
 
     graph_upper = HighLevelGraph.from_collections(name_upper, dsk, dependencies=[a])
     graph_lower = HighLevelGraph.from_collections(name, dsk, dependencies=[a])

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -835,6 +835,22 @@ def test_cholesky(shape, chunk):
     )
 
 
+
+@pytest.mark.parametrize(("shape", "chunk"), [(20, 10), (12, 3), (30, 6)])
+def test_cholesky_complex(shape, chunk):
+    rng = np.random.default_rng(42)
+    A = rng.standard_normal((shape, shape)) + 1j * rng.standard_normal((shape, shape))
+    A = A @ A.conj().T + shape * np.eye(shape)
+    dA = da.from_array(A, (chunk, chunk))
+
+    L = da.linalg.cholesky(dA, lower=True)
+    assert_eq(L, np.linalg.cholesky(A), check_graph=False, check_chunks=False)
+
+    U = da.linalg.cholesky(dA, lower=False)
+    assert_eq(U, np.linalg.cholesky(A).conj().T, check_graph=False, check_chunks=False)
+
+
+
 @pytest.mark.parametrize("iscomplex", [False, True])
 @pytest.mark.parametrize(("nrow", "ncol", "chunk"), [(20, 10, 5), (100, 10, 10)])
 def test_lstsq(nrow, ncol, chunk, iscomplex):


### PR DESCRIPTION
## Summary
- Fix incorrect cholesky decomposition for complex-valued matrices
- The blocked cholesky algorithm used plain transpose (`np.transpose`) where conjugate transpose is mathematically required
- NumPy's cholesky satisfies `A = L @ L*.T` (Hermitian), but dask used plain transpose giving wrong results for complex dtypes
- Added `_conj_transpose` helper that applies `.T.conj()` — this is a no-op for real matrices since `conj()` on real data is identity

## Test plan
- Added parametrized test `test_cholesky_complex` with complex Hermitian positive-definite matrices
- Verified both `lower=True` and `lower=False` results match NumPy's `np.linalg.cholesky`
- Existing real-valued cholesky tests continue to pass

Fixes #12335

🤖 Generated with [Claude Code](https://claude.com/claude-code)