### PR TITLE
Fix da.quantile ValueError when weights parameter is provided

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1615,12 +1615,23 @@ def quantile(
     else:
         kwargs = {}
 
+    # When weights are provided, specify dtype explicitly to avoid
+    # dtype inference failure (weights shape won't match the tiny fake
+    # arrays that map_blocks creates for inference)
+    if kwargs.get("weights") is not None:
+        _dtype = a.dtype
+        if np.issubdtype(_dtype, np.integer):
+            _dtype = np.result_type(_dtype, np.float64)
+    else:
+        _dtype = None
+
     result = a.map_blocks(
         np.quantile,
         q=q,
         method=method,
         axis=axis,
         keepdims=keepdims,
+        dtype=_dtype,
         drop_axis=axis if not keepdims else None,
         new_axis=0 if isinstance(q, Iterable) else None,
         chunks=_get_quantile_chunks(a, q, axis, keepdims),
@@ -1790,9 +1801,20 @@ def nanquantile(
         if NUMPY_GE_200:
             kwargs.update({"weights": weights})
 
+    # When weights are provided, specify dtype explicitly to avoid
+    # dtype inference failure (weights shape won't match the tiny fake
+    # arrays that map_blocks creates for inference)
+    if kwargs.get("weights") is not None:
+        _dtype = a.dtype
+        if np.issubdtype(_dtype, np.integer):
+            _dtype = np.result_type(_dtype, np.float64)
+    else:
+        _dtype = None
+
     result = a.map_blocks(
         func,
         axis=axis,
+        dtype=_dtype,
         drop_axis=axis if not keepdims else None,
         new_axis=0 if isinstance(q, Iterable) else None,
         chunks=_get_quantile_chunks(a, q, axis, keepdims),

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -1099,3 +1099,26 @@ def test_nanquantile_two_dims():
     assert_eq(
         da.nanpercentile(darr, 0.75, axis=-1), np.nanpercentile(arr, 0.75, axis=-1)
     )
+
+
+def test_quantile_with_weights():
+    x = np.random.random((10, 4))
+    weights = np.ones(10)
+    darr = da.from_array(x, chunks=(5, 4))
+    result = da.quantile(darr, 0.5, axis=0, method="inverted_cdf", weights=weights)
+    expected = np.quantile(x, 0.5, axis=0, method="inverted_cdf", weights=weights)
+    assert_eq(result, expected)
+
+    # Test with non-uniform weights
+    weights2 = np.random.random(10)
+    result2 = da.quantile(darr, 0.5, axis=0, method="inverted_cdf", weights=weights2)
+    expected2 = np.quantile(x, 0.5, axis=0, method="inverted_cdf", weights=weights2)
+    assert_eq(result2, expected2)
+
+    # Test nanquantile with weights
+    x_nan = x.copy()
+    x_nan[0, 0] = np.nan
+    darr_nan = da.from_array(x_nan, chunks=(5, 4))
+    result3 = da.nanquantile(darr_nan, 0.5, axis=0, method="inverted_cdf", weights=weights)
+    expected3 = np.nanquantile(x_nan, 0.5, axis=0, method="inverted_cdf", weights=weights)
+    assert_eq(result3, expected3)


### PR DESCRIPTION
## Summary
- Fix `ValueError: Shape of weights must be consistent with shape of a` when calling `da.quantile` or `da.nanquantile` with `weights` parameter
- Root cause: `map_blocks` dtype inference creates tiny fake arrays that don't match the weights shape, causing numpy's shape validation to fail
- Fix: compute dtype explicitly when weights are present, bypassing the problematic inference path

## Details

When `weights` is passed through `kwargs` to `map_blocks`, the `apply_infer_dtype` function creates `(1,1,...)` shaped fake arrays from positional arguments but passes `kwargs` (including the full-sized `weights`) unchanged. This causes `np.quantile` to raise a shape mismatch error during dtype inference.

The fix adds explicit dtype computation before the `map_blocks` call when weights are present. For non-integer inputs the dtype matches the input array; for integer inputs it promotes to float64 (matching numpy's behavior). When weights are absent, `dtype=None` preserves the existing inference path.

Applied to both `quantile()` and `nanquantile()`.

Fixes #12322

## Test plan
- [x] Added `test_quantile_with_weights` covering uniform weights, non-uniform weights, and nanquantile with NaN values
- [ ] Existing quantile tests unaffected (non-weights path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)