### PR TITLE
Support keyword arguments in dask.array.nan_to_num

### DIFF
--- a/dask/array/_array_expr/_blockwise.py
+++ b/dask/array/_array_expr/_blockwise.py
@@ -212,11 +212,12 @@ class Blockwise(ArrayExpr):
 
 
 class Elemwise(Blockwise):
-    _parameters = ["op", "dtype", "name", "where"]
+    _parameters = ["op", "dtype", "name", "where", "kwargs"]
     _defaults = {
         "dtype": None,
         "name": None,
         "where": True,
+        "kwargs": None,
     }
     align_arrays = True
     new_axes: dict = {}
@@ -253,6 +254,7 @@ class Elemwise(Blockwise):
 
     @cached_property
     def _info(self):
+        kwargs = self.operand("kwargs") or {}
         if self.operand("dtype") is not None:
             need_enforce_dtype = True
             dtype = self.operand("dtype")
@@ -275,7 +277,7 @@ class Elemwise(Blockwise):
             ]
             try:
                 dtype = apply_infer_dtype(
-                    self.op, vals, {}, "elemwise", suggest_dtype=False
+                    self.op, vals, kwargs, "elemwise", suggest_dtype=False
                 )
             except Exception:
                 raise NotImplementedError
@@ -284,7 +286,7 @@ class Elemwise(Blockwise):
                 for a in self.elemwise_args
             )
 
-        blockwise_kwargs = {}
+        blockwise_kwargs = dict(kwargs)
         op = self.op
         if self.where is not True:
             blockwise_kwargs["elemwise_where_function"] = op

--- a/dask/array/_array_expr/_collection.py
+++ b/dask/array/_array_expr/_collection.py
@@ -927,7 +927,7 @@ def elemwise(op, *args, out=None, where=True, dtype=None, name=None, **kwargs):
     # TODO(expr-soon): We should probably go through blockwise here
     args = [asanyarray(a) for a in args]
 
-    return new_collection(Elemwise(op, dtype, name, where, *args))
+    return new_collection(Elemwise(op, dtype, name, where, kwargs, *args))
 
 
 def rechunk(

--- a/dask/array/_array_expr/tests/test_collection.py
+++ b/dask/array/_array_expr/tests/test_collection.py
@@ -7,7 +7,7 @@ import pytest
 
 import dask.array as da
 from dask import is_dask_collection
-from dask.array import Array, assert_eq
+from dask.array import Array, _array_expr_enabled, assert_eq
 from dask.array._array_expr._rechunk import Rechunk
 
 
@@ -132,3 +132,17 @@ def test_stack_promote_type():
     df = da.from_array(f, chunks=5)
     res = da.stack([di, df])
     assert_eq(res, np.stack([i, f]))
+
+
+@pytest.mark.array_expr
+def test_nan_to_num_kwargs():
+    if not _array_expr_enabled():
+        pytest.skip("array expr disabled")
+
+    arr = np.array([np.nan, np.inf, -np.inf, 1.5])
+    darr = da.from_array(arr, chunks=2)
+
+    assert_eq(
+        da.nan_to_num(darr, nan=-1.0, posinf=7.5, neginf=-8.5),
+        np.nan_to_num(arr, nan=-1.0, posinf=7.5, neginf=-8.5),
+    )

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5125,12 +5125,6 @@ def elemwise(op, *args, out=None, where=True, dtype=None, name=None, **kwargs):
     --------
     blockwise
     """
-    if kwargs:
-        raise TypeError(
-            f"{op.__name__} does not take the following keyword arguments "
-            f"{sorted(kwargs)}"
-        )
-
     out = _elemwise_normalize_out(out)
     where = _elemwise_normalize_where(where)
     args = [np.asarray(a) if isinstance(a, (list, tuple)) else a for a in args]
@@ -5173,7 +5167,7 @@ def elemwise(op, *args, out=None, where=True, dtype=None, name=None, **kwargs):
             for a in args
         ]
         try:
-            dtype = apply_infer_dtype(op, vals, {}, "elemwise", suggest_dtype=False)
+            dtype = apply_infer_dtype(op, vals, kwargs, "elemwise", suggest_dtype=False)
         except OverflowError:
             raise
         except Exception:
@@ -5183,9 +5177,14 @@ def elemwise(op, *args, out=None, where=True, dtype=None, name=None, **kwargs):
         )
 
     if not name:
-        name = f"{funcname(op)}-{tokenize(op, dtype, *args, where)}"
+        name = f"{funcname(op)}-{tokenize(op, dtype, *args, where, kwargs)}"
 
-    blockwise_kwargs = dict(dtype=dtype, name=name, token=funcname(op).strip("_"))
+    blockwise_kwargs = dict(
+        dtype=dtype,
+        name=name,
+        token=funcname(op).strip("_"),
+        **kwargs,
+    )
 
     if where is not True:
         blockwise_kwargs["elemwise_where_function"] = op

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -371,6 +371,16 @@ def test_non_ufunc_others(func):
     assert_eq(dafunc(darr), npfunc(arr), equal_nan=True)
 
 
+def test_non_ufunc_kwargs():
+    arr = np.array([np.nan, np.inf, -np.inf, 1.5])
+    darr = da.from_array(arr, chunks=2)
+
+    assert_eq(
+        np.nan_to_num(darr, nan=-1.0, posinf=7.5, neginf=-8.5),
+        np.nan_to_num(arr, nan=-1.0, posinf=7.5, neginf=-8.5),
+    )
+
+
 def test_frompyfunc():
     myadd = da.frompyfunc(add, 2, 1)
     np_myadd = np.frompyfunc(add, 2, 1)


### PR DESCRIPTION
- [x] Closes #12350
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Support keyword arguments in the array elemwise path so `dask.array.nan_to_num` accepts `nan=`, `posinf=`, and `neginf=` like NumPy.

This threads keyword arguments through dtype inference, task naming, and blockwise execution for both the default array path and the experimental array-expr path.

Tests:
- `python -m pytest dask/array/tests/test_ufunc.py -k "non_ufunc_kwargs or non_ufunc_others" -q`
- `DASK_ARRAY__QUERY_PLANNING=True python -m pytest dask/array/_array_expr/tests/test_collection.py -k nan_to_num_kwargs --runarrayexpr -q`
- `pre-commit run --all-files`
