### PR TITLE
Fix cumulative min/max across empty dataframe partitions

### DIFF
--- a/dask/dataframe/dask_expr/tests/test_cumulative.py
+++ b/dask/dataframe/dask_expr/tests/test_cumulative.py
@@ -20,3 +20,5 @@ def test_cumulative_empty_partitions():
 
     assert_eq(df2.cumprod(), pdf2.cumprod())
     assert_eq(df2.cumsum(), pdf2.cumsum())
+    assert_eq(df2.cummin(), pdf2.cummin())
+    assert_eq(df2.cummax(), pdf2.cummax())

--- a/dask/dataframe/methods.py
+++ b/dask/dataframe/methods.py
@@ -321,14 +321,16 @@ def cumprod_aggregate(x, y):
 
 def cummin_aggregate(x, y):
     if is_series_like(x) or is_dataframe_like(x):
-        return x.where((x < y) | x.isnull(), y, axis=x.ndim - 1)
+        axis = x.ndim - 1 if is_series_like(y) or is_dataframe_like(y) else None
+        return x.where((x < y) | x.isnull(), y, axis=axis)
     else:  # scalar
         return min(x, y)
 
 
 def cummax_aggregate(x, y):
     if is_series_like(x) or is_dataframe_like(x):
-        return x.where((x > y) | x.isnull(), y, axis=x.ndim - 1)
+        axis = x.ndim - 1 if is_series_like(y) or is_dataframe_like(y) else None
+        return x.where((x > y) | x.isnull(), y, axis=axis)
     else:  # scalar
         return max(x, y)
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -651,22 +651,8 @@ def test_cumulative_with_duplicate_columns():
     [
         M.cumsum,
         M.cumprod,
-        pytest.param(
-            M.cummin,
-            marks=[
-                pytest.mark.xfail(
-                    reason="ValueError: Can only compare identically-labeled Series objects"
-                )
-            ],
-        ),
-        pytest.param(
-            M.cummax,
-            marks=[
-                pytest.mark.xfail(
-                    reason="ValueError: Can only compare identically-labeled Series objects"
-                )
-            ],
-        ),
+        M.cummin,
+        M.cummax,
     ],
 )
 def test_cumulative_empty_partitions(func):


### PR DESCRIPTION
- [ ] Closes #12337
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Addresses the remaining `test_cumulative_empty_partitions` failures called out in #12337.

The cumulative min/max helpers were always passing `axis=` into `pandas.where`, which breaks when the carry-over value from the previous partition is a scalar. This change only uses axis-based alignment when the carry-over value is array-like, which fixes `cummin` and `cummax` for one-column dataframes with empty partitions.

Tests:
- `python -m pytest dask/dataframe/tests/test_dataframe.py -k cumulative_empty_partitions -q`
- `python -m pytest dask/dataframe/dask_expr/tests/test_cumulative.py -q`
- `pre-commit run --all-files`
