### PR TITLE
Fix: str.split coerces dtype by preserving meta dtype (Fixes #11884)Fix: preserve dtype in str.split meta construction (Issue #11884)

### DIFF
--- a/dask/dataframe/dask_expr/_str_accessor.py
+++ b/dask/dataframe/dask_expr/_str_accessor.py
@@ -186,6 +186,7 @@ class SplitMap(FunctionMap):
         meta = self.frame._meta._constructor(
             [delimiter.join(["a"] * (self.n + 1))],
             index=meta.iloc[:1].index,
+            dtype=self.frame._meta.dtype,
         )
         return make_meta(
             getattr(meta.str, self.attr)(n=self.n, expand=self.expand, pat=self.pat)


### PR DESCRIPTION
## Fix dtype coercion in str.split

This PR fixes Issue #11884 where `.str.split()` coerces dtype to object.

### Root Cause
Meta construction did not preserve original dtype.

### Fix
Pass `dtype=self.frame._meta.dtype` when constructing meta.

### Testing
- Ran tests for string accessor module:
  - 53 tests passed