### PR TITLE
Skip apply_gufunc compensation when post-rechunk block fits array.chunk-size

### DIFF
--- a/dask/array/gufunc.py
+++ b/dask/array/gufunc.py
@@ -6,12 +6,13 @@ import re
 import numpy as np
 from tlz import concat, merge, unique
 
+from dask import config
 from dask.array._shuffle import _calculate_new_chunksizes
 from dask.array.core import Array, apply_infer_dtype, asarray, blockwise, getitem
 from dask.array.utils import meta_from_array
 from dask.core import flatten
 from dask.highlevelgraph import HighLevelGraph
-from dask.utils import cached_max
+from dask.utils import cached_max, parse_bytes
 
 # Modified version of `numpy.lib.function_base._parse_gufunc_signature`
 # Modifications:
@@ -455,13 +456,26 @@ def apply_gufunc(
                     # Dimensions that we can reduce to compensate for the increase
                     changeable_dimensions.add(i)
             if factor > 1 and len(changeable_dimensions) > 0:
-                result = _calculate_new_chunksizes(
-                    a.chunks,
-                    list(a.chunks),
-                    changeable_dimensions,
-                    math.prod(map(cached_max, a.chunks)) / factor,
-                )
-                new_args.append(a.rechunk(result))
+                # Only compensate if the post-rechunk block would exceed the
+                # configured chunk-size target. Otherwise shrinking loop dims
+                # just over-splits already-small blocks and blows up the task
+                # graph (see the follow-up to #11683 / pydata/xarray#9907).
+                itemsize = a.dtype.itemsize if hasattr(a, "dtype") else 8
+                original_elements = math.prod(map(cached_max, a.chunks))
+                post_bytes = original_elements * factor * itemsize
+                limit = config.get("array.chunk-size")
+                if isinstance(limit, str):
+                    limit = parse_bytes(limit)
+                if post_bytes <= limit:
+                    new_args.append(a)
+                else:
+                    result = _calculate_new_chunksizes(
+                        a.chunks,
+                        list(a.chunks),
+                        changeable_dimensions,
+                        original_elements / factor,
+                    )
+                    new_args.append(a.rechunk(result))
             else:
                 new_args.append(a)
         args = new_args

--- a/dask/array/tests/test_gufunc.py
+++ b/dask/array/tests/test_gufunc.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_equal
 
+import dask
 import dask.array as da
 from dask.array import Array, apply_gufunc, as_gufunc, gufunc
 from dask.array.gufunc import _parse_gufunc_signature, _validate_normalize_axes
@@ -703,9 +704,12 @@ def test_as_gufunc_with_meta():
     assert_eq(np.array([expected[1].compute()]), result[1].compute())
 
 
-def test_gufunc_chunksizes_adjustment():
+def test_gufunc_chunksizes_adjustment_below_limit():
+    # When the post-rechunk block size stays under array.chunk-size, we
+    # do NOT shrink loop dims — shrinking already-small blocks blows up the
+    # task graph without any memory benefit. See follow-up to #11683 /
+    # pydata/xarray#9907.
     def foo(x, *args):
-        # simulating xarray interpolate (kind off)
         return x
 
     arr = da.random.random((1, 459, 750), chunks=(1, -1, 250))
@@ -721,5 +725,35 @@ def test_gufunc_chunksizes_adjustment():
         vectorize=False,
         allow_rechunk=True,
     )
+    # Post-rechunk per-block ≈ 2.6 MiB, well under the 128 MiB default, so
+    # the loop dim of length 459 stays as one chunk.
+    assert result.chunks == ((1,), (459,), (750,))
+    assert_eq(result, arr.compute())
+
+
+def test_gufunc_chunksizes_adjustment_above_limit():
+    # When the post-rechunk block size would exceed array.chunk-size, loop
+    # dims DO get shrunk to keep per-task memory in check. We force this
+    # here by dropping the chunk-size target to 1 MiB so the 2.6 MiB
+    # post-rechunk block crosses it.
+    def foo(x, *args):
+        return x
+
+    arr = da.random.random((1, 459, 750), chunks=(1, -1, 250))
+    arr2 = da.random.random((750,), chunks=(-1,))
+
+    with dask.config.set({"array.chunk-size": "1 MiB"}):
+        result = apply_gufunc(
+            foo,
+            "(dim0_0),(dim0_1),(dim0_2)->(dim0)",
+            *[arr, arr2, arr2.copy()],
+            keepdims=False,
+            output_dtypes=["float64"],
+            output_sizes={"dim0": 750},
+            vectorize=False,
+            allow_rechunk=True,
+        )
+    # Compensation splits axis 1 to keep per-block under the lowered limit.
+    assert len(result.chunks[1]) > 1
     assert result.chunks == ((1,), (153, 153, 153), (750,))
     assert_eq(result, arr.compute())


### PR DESCRIPTION
- [x] Tests added
- [x] Passes `pre-commit run --all-files`

Follow-up to #11683. The loop-dim compensation block there unconditionally shrinks loop chunks after rechunking a core dim to `-1`, even when the original block was already small. Result: task graphs explode without any memory benefit.

```python
import dask.array as da

src = da.zeros((200, 400), chunks=(2, 400))           # 100 input chunks, ~6 KB each
out = da.apply_gufunc(
    lambda x, c: x[:1], "(i),(i)->(j)",
    src, da.arange(200.0),
    axes=[(0,), (0,), (0,)], output_sizes={"j": 50},
    allow_rechunk=True, output_dtypes=float,
)
len(out.__dask_graph__())
# before: 20,701       after: 404
```

Fix: guard the compensation with an `array.chunk-size` budget. Only shrink loop dims when the post-rechunk block would actually exceed the limit. The memory-protection branch from #11683 still fires when it should — new test `test_gufunc_chunksizes_adjustment_above_limit` forces the budget down and pins that behavior.

Related: pydata/xarray#9907 (the original report motivating #11683; already closed), pydata/xarray#10130 (open memory-OOM report where the compensation over-fire contributes to graph blowup).

Companion xarray PR (pydata/xarray#11312) addresses the architectural side for `interp(method="linear"|"nearest")`; this one helps every `apply_gufunc(allow_rechunk=True)` caller.

cc @phofl @crusaderky