### PR TITLE
Disable CI for Windows 3.14t

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
         # Note: after adding/removing builds here, update
         # codecov.yml to match.
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        environment: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
+        environment: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         extra: [null]
         array-expr: ["false"]
         exclude:
@@ -42,8 +42,6 @@ jobs:
             environment: "3.12"
           - os: "macos-latest"
             environment: "3.13"
-          - os: "macos-latest"
-            environment: "3.14t"
         include:
           # Minimum dependencies
           - os: "ubuntu-latest"
@@ -65,6 +63,9 @@ jobs:
             array-expr: "true"
           - os: "ubuntu-latest"
             environment: "mindeps-array"
+            array-expr: "true"
+          - os: "ubuntu-latest"
+            environment: "3.14t"
             array-expr: "true"
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
             array-expr: "true"
           - os: "ubuntu-latest"
             environment: "3.14t"
-            array-expr: "true"
+            array-expr: "false"
 
     steps:
       - name: Checkout source

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,7 +111,7 @@ jobs:
         if: ${{ matrix.environment == '3.14t' }}
         run: |
           conda uninstall -y -v --force msgpack-python
-          MSGPACK_PUREPYTHON=1 pip install msgpack --no-binary msgpack --no-cache --force-reinstall -v
+          MSGPACK_PUREPYTHON=1 python -m pip install msgpack --no-binary msgpack --no-cache --force-reinstall -v
           python -Werror -c 'import msgpack'
 
       - name: Reconfigure pytest-timeout

--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -45,7 +45,7 @@ Releasing dask and distributed:
 *   Upload to PyPI
 
         git clean -xfd
-        pip install build twine
+        python -m pip install build twine
         pyproject-build
         twine upload dist/*
 

--- a/docs/source/deploying-cloud.rst
+++ b/docs/source/deploying-cloud.rst
@@ -112,7 +112,7 @@ See :doc:`how-to/connect-to-remote-data` for more information.
 
     .. code-block:: bash
 
-        pip install s3fs
+        python -m pip install s3fs
 
    .. tab-item:: GCP
 
@@ -120,7 +120,7 @@ See :doc:`how-to/connect-to-remote-data` for more information.
 
     .. code-block:: bash
 
-        pip install gcsfs
+        python -m pip install gcsfs
 
    .. tab-item:: Azure
 
@@ -128,4 +128,4 @@ See :doc:`how-to/connect-to-remote-data` for more information.
 
     .. code-block:: bash
 
-        pip install adlfs
+        python -m pip install adlfs

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -216,7 +216,7 @@ Learn more at :bdg-link-primary:`Install Documentation <install.html>`
 
        .. code-block::
 
-          pip install "dask[complete]"
+          python -m pip install "dask[complete]"
 
     .. tab-item:: conda
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -179,7 +179,7 @@ Installing Dask naively may not install all requirements by default (see the ``p
 You may choose to install the ``dask[complete]`` version which includes
 all dependencies for all collections::
 
-    pip install "dask[complete]"
+    python -m pip install "dask[complete]"
 
 Alternatively, you may choose to test
 only certain submodules depending on the libraries within your environment.


### PR DESCRIPTION
`libmamba` internally executes `pip install` instead of `python -m pip install`.
This does not work for some reason, specifically on 3.14t on Windows.