### PR TITLE
Switch back to conda

### DIFF
--- a/.github/workflows/additional.yml
+++ b/.github/workflows/additional.yml
@@ -19,7 +19,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v4.0.1
         with:
           miniforge-version: latest
-          use-mamba: true
           channel-priority: strict
           environment-file: continuous_integration/environment-3.12.yaml
           activate-environment: test-environment

--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -30,7 +30,6 @@ jobs:
         with:
           miniforge-version: latest
           condarc-file: continuous_integration/condarc
-          use-mamba: true
           # Note: this file is in the dask/distributed repo
           environment-file: continuous_integration/scripts/test-report-environment.yml
           activate-environment: dask
@@ -38,8 +37,8 @@ jobs:
       - name: Show conda options
         run: conda config --show
 
-      - name: mamba list
-        run: mamba list
+      - name: conda list
+        run: conda list
 
       - uses: actions/cache@v5
         id: cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v4.0.1
         with:
           miniforge-version: latest
-          use-mamba: true
           channel-priority: strict
           environment-file: continuous_integration/environment-${{ matrix.environment }}.yaml
           activate-environment: test-environment

--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -48,7 +48,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v4.0.1
         with:
           miniforge-version: latest
-          use-mamba: true
           channel-priority: strict
           environment-file: continuous_integration/environment-3.12.yaml
           activate-environment: test-environment

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -5,13 +5,10 @@ if [[ ${UPSTREAM_DEV} ]]; then
     # NOTE: `dask/tests/test_ci.py::test_upstream_packages_installed` should up be
     # updated when packages here are updated.
 
-    # Pick up https://github.com/mamba-org/mamba/pull/2903
-    mamba install -n base 'mamba>=1.5.2'
+    conda uninstall --force bokeh
+    conda install -y -c bokeh/label/dev bokeh
 
-    mamba uninstall --force bokeh
-    mamba install -y -c bokeh/label/dev bokeh
-
-    mamba uninstall --force pyarrow pyarrow-core
+    conda uninstall --force pyarrow pyarrow-core
     python -m pip install --no-deps \
         --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
         --prefer-binary --pre pyarrow
@@ -28,7 +25,7 @@ if [[ ${UPSTREAM_DEV} ]]; then
     # `s3fs` to avoid dependency conflicts
     python -m pip install --upgrade git+https://github.com/fsspec/filesystem_spec
     # TODO: Add nightly `scikit-image` back once it's available
-    mamba uninstall --force numpy pandas scipy numexpr numba sparse scikit-image numbagg
+    conda uninstall --force numpy pandas scipy numexpr numba sparse scikit-image numbagg
     python -m pip install --no-deps --pre --retries 10 \
         -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
         numpy \
@@ -38,18 +35,18 @@ if [[ ${UPSTREAM_DEV} ]]; then
         # scikit-image
 
     # Used when automatically opening an issue when the `upstream` CI build fails
-    mamba install pytest-reportlog
+    conda install pytest-reportlog
 
 fi
 
 # Install dask
 python -m pip install --quiet --no-deps -e .[complete]
-echo mamba list
-mamba list
+echo conda list
+conda list
 
 # For debugging
 echo -e "--\n--Conda Environment (re-create this with \`conda env create --name <name> -f <output_file>\`)\n--"
-mamba env export | grep -E -v '^prefix:.*$' > env.yaml
+conda env export | grep -E -v '^prefix:.*$' > env.yaml
 cat env.yaml
 
 set +xe


### PR DESCRIPTION
Nowadays conda internally uses libmamba. Calling the mamba executable is no longer necessary for most.