### PR TITLE
BUG: raise NotImplementedError for da.quantile with weights on NumPy < 2.0

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1615,9 +1615,7 @@ def quantile(
     else:
         kwargs = {}
         if weights is not None:
-            raise NotImplementedError(
-                "da.quantile with weights requires NumPy >= 2.0"
-            )
+            raise NotImplementedError("da.quantile with weights requires NumPy >= 2.0")
 
     result = a.map_blocks(
         np.quantile,

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1614,6 +1614,10 @@ def quantile(
         kwargs = {"weights": weights}
     else:
         kwargs = {}
+        if weights is not None:
+            raise NotImplementedError(
+                "da.quantile with weights requires NumPy >= 2.0"
+            )
 
     result = a.map_blocks(
         np.quantile,


### PR DESCRIPTION
## Summary

Fix `ValueError` when passing `weights` to `da.quantile` on NumPy < 2.0.

## Problem

When `weights` were passed to `da.quantile` on NumPy < 2.0, the `weights` argument was silently ignored because:
- `NUMPY_GE_200` is `False`, so `kwargs = {}`
- The weights were never forwarded to `np.quantile`
- This caused incorrect results with a confusing error message

## Solution

Raise a clear `NotImplementedError` when `weights` is provided and NumPy version is < 2.0, explaining that weights support requires NumPy >= 2.0.

## Example

```python
import dask.array as da
import numpy as np

x = np.random.random((10, 4))
weights = np.ones(10)

# Before fix: confusing ValueError about shape mismatch
# After fix: clear NotImplementedError explaining NumPy >= 2.0 requirement
da.quantile(da.from_array(x), weights=weights, q=0.5, axis=0)
# NotImplementedError: da.quantile with weights requires NumPy >= 2.0
```

Fixes dask/dask#12322
