### PR TITLE
Test vs. intermediate versions of numpy and pandas

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -1,5 +1,5 @@
 # This job includes coverage
-name: test-environment-310
+name: test-environment
 channels:
   - conda-forge
   - nodefaults

--- a/continuous_integration/environment-3.11.yaml
+++ b/continuous_integration/environment-3.11.yaml
@@ -24,9 +24,9 @@ dependencies:
   - pytest-xdist
   - coverage
   # key optional dependencies
-  - numpy
-  - pandas
-  - pyarrow
+  - numpy=2.0
+  - pandas=2.2
+  - pyarrow=20.0
   - distributed  # Overridden by git tip below; used to pull in dependencies  
   # optional s3 I/O
   - boto3

--- a/continuous_integration/environment-3.12.yaml
+++ b/continuous_integration/environment-3.12.yaml
@@ -23,9 +23,9 @@ dependencies:
   - pytest-xdist
   - coverage
   # key optional dependencies
-  - numpy
-  - pandas
-  - pyarrow
+  - numpy=2.2
+  - pandas=2.3
+  - pyarrow=22.0
   - distributed  # Overridden by git tip below; used to pull in dependencies  
   # optional s3 I/O
   - boto3

--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -175,7 +175,7 @@ def test_parquet():
     pytest.importorskip("requests", minversion="2.21.0")
     pytest.importorskip(
         "pyarrow",
-        minversion="22.0.0",
+        minversion="23.0.0",
         reason="https://github.com/apache/arrow/issues/47981",
     )
     dd = pytest.importorskip("dask.dataframe")

--- a/dask/dataframe/dask_expr/_groupby.py
+++ b/dask/dataframe/dask_expr/_groupby.py
@@ -12,7 +12,7 @@ from pandas.core.apply import reconstruct_func, validate_func_kwargs
 from dask import is_dask_collection
 from dask._task_spec import Task
 from dask.core import flatten
-from dask.dataframe._compat import PANDAS_GE_300
+from dask.dataframe._compat import PANDAS_GE_220, PANDAS_GE_300
 from dask.dataframe.core import (
     _concat,
     apply_and_enforce,
@@ -1093,7 +1093,7 @@ class Median(GroupByShift):
 
 
 def groupby_get_group(df, *by_key, get_key=None, columns=None):
-    if PANDAS_GE_300 and is_scalar(get_key):
+    if PANDAS_GE_220 and is_scalar(get_key):
         get_key = (get_key,)
     return _groupby_get_group(df, list(by_key), get_key, columns)
 

--- a/dask/dataframe/dask_expr/tests/test_groupby.py
+++ b/dask/dataframe/dask_expr/tests/test_groupby.py
@@ -9,13 +9,22 @@ import numpy as np
 import pytest
 
 import dask
-from dask.dataframe._compat import PANDAS_GE_300
+from dask.dataframe._compat import PANDAS_GE_220, PANDAS_GE_300
 from dask.dataframe.dask_expr import from_pandas
 from dask.dataframe.dask_expr._groupby import Aggregation, GroupByUDFBlockwise
 from dask.dataframe.dask_expr._reductions import TreeReduce
 from dask.dataframe.dask_expr._shuffle import Shuffle, TaskShuffle, divisions_lru
 from dask.dataframe.dask_expr.io import FromPandas
 from dask.dataframe.dask_expr.tests._util import _backend_library, assert_eq, xfail_gpu
+
+if PANDAS_GE_220 and not PANDAS_GE_300:
+    pytestmark = [
+        pytest.mark.filterwarnings(
+            r"ignore:.*DataFrameGroupBy\.apply:DeprecationWarning"
+        ),
+        pytest.mark.filterwarnings(r"ignore:.*DataFrameGroupBy\.apply:FutureWarning"),
+    ]
+
 
 # Set DataFrame backend for this module
 pd = _backend_library()
@@ -395,7 +404,6 @@ def test_groupby_repartition_to_one(pdf, df):
     assert_eq(result, expected)
 
 
-@pytest.mark.filterwarnings("ignore:DataFrameGroupBy.apply operated ")
 def test_groupby_apply(df, pdf):
     def test(x):
         x["new"] = x.sum().sum()
@@ -432,7 +440,6 @@ def test_groupby_apply(df, pdf):
     assert_eq(query, pdf.groupby("x")[["y"]].apply(test))
 
 
-@pytest.mark.filterwarnings("ignore:DataFrameGroupBy.apply operated ")
 def test_groupby_transform(df, pdf):
     def test(x):
         return x
@@ -598,7 +605,6 @@ def test_groupby_projection_split_out(df, pdf):
     assert_eq(result, pdf_result)
 
 
-@pytest.mark.filterwarnings("ignore:DataFrameGroupBy.apply operated ")
 def test_numeric_column_names():
     df = pd.DataFrame({0: [0, 1, 0, 1], 1: [1, 2, 3, 4], 2: [0, 1, 0, 1]})
     ddf = from_pandas(df, npartitions=2)
@@ -611,7 +617,6 @@ def test_numeric_column_names():
     )
 
 
-@pytest.mark.filterwarnings("ignore:DataFrameGroupBy.apply operated ")
 def test_apply_divisions(pdf):
     pdf = pdf.set_index("x")
     df = from_pandas(pdf, npartitions=10)
@@ -669,7 +674,6 @@ def test_groupby_apply_args(df, pdf):
         )
 
 
-@pytest.mark.filterwarnings("ignore:DataFrameGroupBy.apply operated ")
 def test_groupby_ffill_bfill(pdf):
     pdf["y"] = pdf["y"].astype("float64")
 
@@ -806,7 +810,6 @@ def test_groupby_dir(df):
     assert "y" in dir(df.groupby("x"))
 
 
-@pytest.mark.filterwarnings("ignore:DataFrameGroupBy.apply operated ")
 def test_groupby_udf_user_warning(df, pdf):
     def func(df):
         return df + 1

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -547,9 +547,12 @@ def _cov_agg(_t, levels, ddof, std=False, sort=False):
 
     # stacking can lead to a sorted index
     if PANDAS_GE_300:
-        s_result = result.stack()
+        kwargs = {}
+    elif PANDAS_GE_220:
+        kwargs = {"future_stack": True}
     else:
-        s_result = result.stack(dropna=False)
+        kwargs = {"dropna": False}
+    s_result = result.stack(**kwargs)
     assert is_dataframe_like(s_result)
     return s_result
 

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -29,6 +29,15 @@ from dask.dataframe.groupby import NUMERIC_ONLY_NOT_IMPLEMENTED
 from dask.dataframe.utils import assert_eq, pyarrow_strings_enabled
 from dask.utils import M
 
+if PANDAS_GE_220 and not PANDAS_GE_300:
+    pytestmark = [
+        pytest.mark.filterwarnings(
+            r"ignore:.*DataFrameGroupBy\.apply:DeprecationWarning"
+        ),
+        pytest.mark.filterwarnings(r"ignore:.*DataFrameGroupBy\.apply:FutureWarning"),
+    ]
+
+
 AGG_FUNCS = [
     "sum",
     pytest.param(
@@ -2256,8 +2265,6 @@ def test_groupby_shift_with_freq(shuffle_method):
 # These warnings appear only on pandas >=2.1,<3.0
 @pytest.mark.filterwarnings(r"ignore:.*(DataFrame|Series)GroupBy\.sum:FutureWarning")
 @pytest.mark.filterwarnings(r"ignore:.*DataFrame\.sum with axis=None:FutureWarning")
-@pytest.mark.filterwarnings(r"ignore:.*DataFrameGroupBy\.apply:DeprecationWarning")
-@pytest.mark.filterwarnings(r"ignore:.*DataFrameGroupBy\.apply:FutureWarning")
 @pytest.mark.parametrize(
     "transformation", [lambda x: x.sum(), np.sum, "sum", pd.Series.rank]
 )

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -291,6 +291,10 @@ def test_to_hdf_distributed(c):
 def test_to_hdf_scheduler_distributed(npartitions, c):
     pytest.importorskip("numpy")
     pytest.importorskip("pandas")
+    from dask._pandas_compat import PANDAS_GE_220, PANDAS_GE_230
+
+    if PANDAS_GE_220 and not PANDAS_GE_230:
+        pytest.xfail(reason="Poor support for StringDtype")
 
     from dask.dataframe.io.tests.test_hdf import test_to_hdf_schedulers
 


### PR DESCRIPTION
Closes #12371

Change CI matrix to
### numpy
- numpy=1.24 (mindeps-array, mindeps-dataframe, mindeps-optional)
- numpy=1.24 (3.10)
- numpy=2.0 (3.11)
- numpy=2.2 (3.12)
- numpy>=2.4 (3.13, 3.14)
### pandas
- pandas=2.0 (mindeps-dataframe, mindeps-optional)
- pandas=2.1 (3.10)
- pandas=2.2 (3.11)
- pandas=2.3 (3.12)
- pandas>=3.0 (3.13, 3.14)
### pyarrow
- pyarrow=16 (mindeps-dataframe, mindeps-optional)
- pyarrow=16 (3.10)
- pyarrow=19 (3.11)
- pyarrow=22 (3.12)
- pyarrow>=24 (3.13, 3.14)

Note: the 3.10 environment is _astonishingly_ slow to resolve. I tried tampering with it and the result was conda hanging very badly.