### PR TITLE
Fix typo in array-chunks.rst

### DIFF
--- a/docs/source/array-chunks.rst
+++ b/docs/source/array-chunks.rst
@@ -50,7 +50,7 @@ For performance, a good choice of ``chunks`` follows the following rules:
 5.  Chunks should align with your storage, if applicable.
 
     Array data formats are often chunked as well.  When loading or saving data,
-    if is useful to have Dask array chunks that are aligned with the chunking
+    it is useful to have Dask array chunks that are aligned with the chunking
     of your storage, often an even multiple times larger in each direction
 
 Learn more in `Choosing good chunk sizes in Dask`_ by Genevieve Buckley.


### PR DESCRIPTION
- [x] Closes #xxxx (N/A)
- [ ] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Just a single character change on a documentation page. There isn't a issue for this, I could make on for this but it seemed easier to just raise the PR.

I don't believe tests are required for this change either.