### PR TITLE
Clean up minimum pyarrow version checks

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -2622,14 +2622,15 @@ def split(seq, n):
 
 def to_dataframe(seq, columns, dtypes):
     import pandas as pd
-    from packaging.version import Version
+
+    from dask._pandas_compat import PANDAS_GE_300
 
     seq = reify(seq)
     # pd.DataFrame expects lists, only copy if necessary
     if not isinstance(seq, list):
         seq = list(seq)
 
-    kwargs = {} if Version(pd.__version__).major >= 3 else {"copy": False}
+    kwargs = {} if PANDAS_GE_300 else {"copy": False}
     res = pd.DataFrame(seq, columns=list(columns))
     return res.astype(dtypes, **kwargs)
 

--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -171,16 +171,14 @@ def test_open_glob(dir_server):
 
 
 @pytest.mark.network
-@pytest.mark.parametrize(
-    "engine",
-    ["pyarrow"],
-)
-def test_parquet(engine):
+def test_parquet():
     pytest.importorskip("requests", minversion="2.21.0")
+    pytest.importorskip(
+        "pyarrow",
+        minversion="22.0.0",
+        reason="https://github.com/apache/arrow/issues/47981",
+    )
     dd = pytest.importorskip("dask.dataframe")
-    pa = pytest.importorskip(engine)
-    if Version(pa.__version__) >= Version("22.0.0"):
-        pytest.skip(reason="https://github.com/apache/arrow/issues/47981")
 
     df = dd.read_parquet(
         [
@@ -188,7 +186,7 @@ def test_parquet(engine):
             "master/parquet-testdata/impala/1.1.1-NONE/"
             "nation.impala.parquet"
         ],
-        engine=engine,
+        engine="pyarrow",
     ).compute()
     assert df.n_nationkey.tolist() == list(range(25))
     assert df.columns.tolist() == ["n_nationkey", "n_name", "n_regionkey", "n_comment"]

--- a/dask/dataframe/_compat.py
+++ b/dask/dataframe/_compat.py
@@ -40,19 +40,12 @@ from dask._pandas_compat import (
 
 try:
     import pyarrow as pa
+
+    PYARROW_VERSION = Version(pa.__version__)
+    HAS_PYARROW = PYARROW_VERSION >= Version("16.0.0")
 except ImportError:
+    PYARROW_VERSION = Version("0.0.0")
     HAS_PYARROW = False
-else:
-    HAS_PYARROW = True
-
-
-if HAS_PYARROW:
-    PYARROW_VERSION: Version | None = Version(pa.__version__)
-    # we know that Version should be non-None when PYARROW_VERSION is True.
-    PYARROW_GE_2101: bool | None = PYARROW_VERSION.release >= (21, 0, 1)  # type: ignore[union-attr]
-else:
-    PYARROW_VERSION = None
-    PYARROW_GE_2101 = None
 
 
 __all__ = [
@@ -81,6 +74,5 @@ __all__ = [
     "IndexingError",
     "HAS_PYARROW",
     "PYARROW_VERSION",
-    "PYARROW_GE_2101",
     "tm",
 ]

--- a/dask/dataframe/backends.py
+++ b/dask/dataframe/backends.py
@@ -52,9 +52,7 @@ try:
     import pyarrow as pa
     import pyarrow.compute
 except ImportError:
-    HAS_PYARROW = False
-else:
-    HAS_PYARROW = True
+    pass
 
 
 class DataFrameBackendEntrypoint(DaskBackendEntrypoint):

--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -11,9 +11,7 @@ from typing import Any, ClassVar, Literal
 
 import numpy as np
 import pandas as pd
-import pyarrow as pa
 from fsspec.utils import stringify_path
-from packaging.version import parse as parse_version
 from pandas import CategoricalDtype
 from pandas.api.types import (
     is_bool_dtype,
@@ -5379,10 +5377,6 @@ def read_parquet(
         or isinstance(filesystem, str)
         and filesystem.lower() in ("arrow", "pyarrow")
     ):
-        if parse_version(pa.__version__) < parse_version("15.0.0"):
-            raise ValueError(
-                "pyarrow>=15.0.0 is required to use the pyarrow filesystem."
-            )
         if metadata_task_size is not None:
             raise NotImplementedError(
                 "metadata_task_size is not supported when using the pyarrow filesystem."

--- a/dask/dataframe/tests/test_utils_dataframe.py
+++ b/dask/dataframe/tests/test_utils_dataframe.py
@@ -8,7 +8,6 @@ from collections.abc import Iterable
 import numpy as np
 import pandas as pd
 import pytest
-from packaging.version import Version
 
 import dask
 import dask.dataframe as dd
@@ -709,25 +708,11 @@ def test_valid_divisions(divisions, valid):
 
 
 def test_pyarrow_strings_enabled():
-    try:
-        import pyarrow as pa
-    except ImportError:
-        pa = None
-
-    # If `pyarrow>=12` are installed, then default to using pyarrow strings
-    if (
-        dask.config.get("dataframe.convert-string") in (True, None)
-        and pa is not None
-        and Version(pa.__version__) >= Version("12.0.0")
-    ):
-        assert pyarrow_strings_enabled() is True
-    else:
-        assert pyarrow_strings_enabled() is False
-
-    # Regardless of dependencies that are installed, always obey
-    # the `dataframe.convert-string` config value if it's specified
     with dask.config.set({"dataframe.convert-string": False}):
         assert pyarrow_strings_enabled() is False
+
+    with dask.config.set({"dataframe.convert-string": None}):
+        assert pyarrow_strings_enabled() is True
 
     with dask.config.set({"dataframe.convert-string": True}):
         assert pyarrow_strings_enabled() is True

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -2230,12 +2230,11 @@ def get_default_shuffle_method() -> str:
         return "disk"
 
     try:
-        from distributed.shuffle import check_minimal_arrow_version
+        from dask.dataframe._compat import HAS_PYARROW
 
-        check_minimal_arrow_version()
+        return "p2p" if HAS_PYARROW else "tasks"
     except ModuleNotFoundError:
         return "tasks"
-    return "p2p"
 
 
 def get_meta_library(like):


### PR DESCRIPTION
In the past, depending on pyarrow version, you may or may not have had access to arrow strings, dask.dataframe query planning, and p2p shuffle (and the three features required three different minimum versions).

All of these are obsolete now that dask.dataframe's only engine is query planning, and that pyarrow's minimum version is >=16.