### PR TITLE
Fix flaky `test_ffill_bfill`

### DIFF
--- a/dask/_pandas_compat.py
+++ b/dask/_pandas_compat.py
@@ -49,7 +49,8 @@ def assert_numpy_array_equal(left, right):
 
 
 def makeDataFrame():
-    data = np.random.randn(30, 4)
+    rng = np.random.Generator(0)
+    data = rng.standard_normal((30, 4))
     index = list(string.ascii_letters)[:30]
     return pd.DataFrame(data, index=index, columns=list("ABCD"))
 

--- a/dask/_pandas_compat.py
+++ b/dask/_pandas_compat.py
@@ -49,7 +49,7 @@ def assert_numpy_array_equal(left, right):
 
 
 def makeDataFrame():
-    rng = np.random.Generator(0)
+    rng = np.random.default_rng(0)
     data = rng.standard_normal((30, 4))
     index = list(string.ascii_letters)[:30]
     return pd.DataFrame(data, index=index, columns=list("ABCD"))


### PR DESCRIPTION
`test_ffill_bfill` randomly fails with 

> E           ValueError: All NaN partition encountered in `fillna`. Try using ``df.repartition`` to increase the partition size, or specify `limit` in `fillna`.

This is because the test randomly generates the data with an unfixed seed, 
which in turn can occasionally generate a partition full of NaNs, 
which in turn hits a design choice of `dask.dataframe.Series.ffill` where you have to explicitly set `limit` to enable reading from earlier partitions.

(the alternative was to have output partition n statically gain a dependency to input partitions [0, n-1], which is very bad for performance and this is why it's off by default).
