### PR TITLE
Fix LaTeX formula for split_every in docstrings

### DIFF
--- a/dask/array/_array_expr/_reductions.py
+++ b/dask/array/_array_expr/_reductions.py
@@ -73,9 +73,9 @@ def reduction(
         intermediate ``combine`` function will be used, so that any one
         ``combine`` or ``aggregate`` function has no more than ``split_every``
         inputs. The depth of the aggregation graph will be
-        :math:`log_{split_every}(input chunks along reduced axes)`. Setting to
-        a low value can reduce cache size and network transfers, at the cost of
-        more CPU and a larger dask graph.
+        :math:`log_\text{split\_every}(\text{input chunks along reduced axes})`.
+        Setting to a low value can reduce cache size and network transfers, at
+        the cost of more CPU and a larger dask graph.
 
         Omit to let dask heuristically decide a good default. A default can
         also be set globally with the ``split_every`` key in

--- a/dask/array/_array_expr/_reductions.py
+++ b/dask/array/_array_expr/_reductions.py
@@ -73,7 +73,7 @@ def reduction(
         intermediate ``combine`` function will be used, so that any one
         ``combine`` or ``aggregate`` function has no more than ``split_every``
         inputs. The depth of the aggregation graph will be
-        :math:`\\log_\\text{split\\_every}(\\text{input chunks along reduced axes})`.
+        :math:`\\log_\\text{split_every}(\\text{input chunks along reduced axes})`.
         Setting to a low value can reduce cache size and network transfers, at
         the cost of more CPU and a larger dask graph.
 

--- a/dask/array/_array_expr/_reductions.py
+++ b/dask/array/_array_expr/_reductions.py
@@ -73,7 +73,7 @@ def reduction(
         intermediate ``combine`` function will be used, so that any one
         ``combine`` or ``aggregate`` function has no more than ``split_every``
         inputs. The depth of the aggregation graph will be
-        :math:`log_\text{split\_every}(\text{input chunks along reduced axes})`.
+        :math:`log_\\text{split\\_every}(\\text{input chunks along reduced axes})`.
         Setting to a low value can reduce cache size and network transfers, at
         the cost of more CPU and a larger dask graph.
 

--- a/dask/array/_array_expr/_reductions.py
+++ b/dask/array/_array_expr/_reductions.py
@@ -73,7 +73,7 @@ def reduction(
         intermediate ``combine`` function will be used, so that any one
         ``combine`` or ``aggregate`` function has no more than ``split_every``
         inputs. The depth of the aggregation graph will be
-        :math:`log_\\text{split\\_every}(\\text{input chunks along reduced axes})`.
+        :math:`\\log_\\text{split\\_every}(\\text{input chunks along reduced axes})`.
         Setting to a low value can reduce cache size and network transfers, at
         the cost of more CPU and a larger dask graph.
 

--- a/dask/array/_reductions_generic.py
+++ b/dask/array/_reductions_generic.py
@@ -73,9 +73,9 @@ def reduction(
         intermediate ``combine`` function will be used, so that any one
         ``combine`` or ``aggregate`` function has no more than ``split_every``
         inputs. The depth of the aggregation graph will be
-        :math:`log_{split_every}(input chunks along reduced axes)`. Setting to
-        a low value can reduce cache size and network transfers, at the cost of
-        more CPU and a larger dask graph.
+        :math:`log_\text{split\_every}(\text{input chunks along reduced axes})`.
+        Setting to a low value can reduce cache size and network transfers, at
+        the cost of more CPU and a larger dask graph.
 
         Omit to let dask heuristically decide a good default. A default can
         also be set globally with the ``split_every`` key in

--- a/dask/array/_reductions_generic.py
+++ b/dask/array/_reductions_generic.py
@@ -73,7 +73,7 @@ def reduction(
         intermediate ``combine`` function will be used, so that any one
         ``combine`` or ``aggregate`` function has no more than ``split_every``
         inputs. The depth of the aggregation graph will be
-        :math:`log_\text{split\_every}(\text{input chunks along reduced axes})`.
+        :math:`\\log_\\text{split\\_every}(\\text{input chunks along reduced axes})`.
         Setting to a low value can reduce cache size and network transfers, at
         the cost of more CPU and a larger dask graph.
 

--- a/dask/array/_reductions_generic.py
+++ b/dask/array/_reductions_generic.py
@@ -73,7 +73,7 @@ def reduction(
         intermediate ``combine`` function will be used, so that any one
         ``combine`` or ``aggregate`` function has no more than ``split_every``
         inputs. The depth of the aggregation graph will be
-        :math:`\\log_\\text{split\\_every}(\\text{input chunks along reduced axes})`.
+        :math:`\\log_\\text{split_every}(\\text{input chunks along reduced axes})`.
         Setting to a low value can reduce cache size and network transfers, at
         the cost of more CPU and a larger dask graph.
 

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1181,7 +1181,7 @@ def _aggregate_docstring(based_on=None):
             intermediate ``combine`` function will be used, so that any one 
             ``combine`` or ``aggregate`` function has no more than ``split_every`` 
             inputs. The depth of the aggregation graph will be 
-            :math:`\\log_\\text{{split\\_every}}(\\text{{input chunks along reduced axes}})`.
+            :math:`\\log_\\text{{split_every}}(\\text{{input chunks along reduced axes}})`.
             Setting to a low value can reduce cache size and network transfers, at
             the cost of more CPU and a larger dask graph.
         split_out : int, optional

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1181,7 +1181,7 @@ def _aggregate_docstring(based_on=None):
             intermediate ``combine`` function will be used, so that any one 
             ``combine`` or ``aggregate`` function has no more than ``split_every`` 
             inputs. The depth of the aggregation graph will be 
-            :math:`\\log_\\text{split\\_every}(\\text{input chunks along reduced axes})`.
+            :math:`\\log_\\text{{split\\_every}}(\\text{{input chunks along reduced axes}})`.
             Setting to a low value can reduce cache size and network transfers, at
             the cost of more CPU and a larger dask graph.
         split_out : int, optional

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1181,7 +1181,7 @@ def _aggregate_docstring(based_on=None):
             intermediate ``combine`` function will be used, so that any one 
             ``combine`` or ``aggregate`` function has no more than ``split_every`` 
             inputs. The depth of the aggregation graph will be 
-            :math:`log_\text{split\_every}(\text{input chunks along reduced axes})`.
+            :math:`\\log_\\text{split\\_every}(\\text{input chunks along reduced axes})`.
             Setting to a low value can reduce cache size and network transfers, at
             the cost of more CPU and a larger dask graph.
         split_out : int, optional

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1181,9 +1181,9 @@ def _aggregate_docstring(based_on=None):
             intermediate ``combine`` function will be used, so that any one 
             ``combine`` or ``aggregate`` function has no more than ``split_every`` 
             inputs. The depth of the aggregation graph will be 
-            :math:``log_`split_every`(input chunks along reduced axes)``. Setting to 
-            a low value can reduce cache size and network transfers, at the cost of 
-            more CPU and a larger dask graph.
+            :math:`log_\text{split\_every}(\text{input chunks along reduced axes})`.
+            Setting to a low value can reduce cache size and network transfers, at
+            the cost of more CPU and a larger dask graph.
         split_out : int, optional
             Number of output results in group-by like aggregations (defaults to 1)
         shuffle : bool or str, optional

--- a/dask/graph_manipulation.py
+++ b/dask/graph_manipulation.py
@@ -44,7 +44,7 @@ def checkpoint(
     split_every: int >= 2 or False, optional
         Determines the depth of the recursive aggregation. If greater than the number of
         input keys, the aggregation will be performed in multiple steps; the depth of
-        the aggregation graph will be :math:`log_\text{split\_every}(\text{input keys})`.
+        the aggregation graph will be :math:`\\log_\\text{split\\_every}(\\text{input keys})`.
         Setting to a low value can reduce cache size and network transfers, at the cost
         of more CPU and a larger dask graph.
 

--- a/dask/graph_manipulation.py
+++ b/dask/graph_manipulation.py
@@ -44,7 +44,7 @@ def checkpoint(
     split_every: int >= 2 or False, optional
         Determines the depth of the recursive aggregation. If greater than the number of
         input keys, the aggregation will be performed in multiple steps; the depth of
-        the aggregation graph will be :math:`\\log_\\text{split\\_every}(\\text{input keys})`.
+        the aggregation graph will be :math:`\\log_\\text{split_every}(\\text{input keys})`.
         Setting to a low value can reduce cache size and network transfers, at the cost
         of more CPU and a larger dask graph.
 

--- a/dask/graph_manipulation.py
+++ b/dask/graph_manipulation.py
@@ -44,9 +44,9 @@ def checkpoint(
     split_every: int >= 2 or False, optional
         Determines the depth of the recursive aggregation. If greater than the number of
         input keys, the aggregation will be performed in multiple steps; the depth of
-        the aggregation graph will be :math:`log_{split_every}(input keys)`. Setting to
-        a low value can reduce cache size and network transfers, at the cost of more CPU
-        and a larger dask graph.
+        the aggregation graph will be :math:`log_\text{split\_every}(\text{input keys})`.
+        Setting to a low value can reduce cache size and network transfers, at the cost
+        of more CPU and a larger dask graph.
 
         Set to False to disable. Defaults to 8.
 


### PR DESCRIPTION
LaTeX formulas should now render as: 
<img width="352" height="21" alt="image" src="https://github.com/user-attachments/assets/6799908d-7fd0-427b-b2d4-5b90b93f0316" />

As opposed to the current representation:
<img width="336" height="20" alt="image" src="https://github.com/user-attachments/assets/00810661-a825-4e76-acd9-9251cfca86c1" />
