### PR TITLE
Re-raise ModuleNotFoundError instead of ImportError

### DIFF
--- a/dask/_compatibility.py
+++ b/dask/_compatibility.py
@@ -104,6 +104,8 @@ def import_optional_dependency(
         module = importlib.import_module(name)
     except (importlib_metadata.PackageNotFoundError, ImportError) as err:
         if errors == "raise":
+            if isinstance(err, ImportError):
+                raise type(err)(msg) from err  # Typically ModuleNotFoundError
             raise ImportError(msg) from err
         return None
 

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -637,7 +637,8 @@ except ImportError as e:  # pragma: no cover
         "  conda install dask                 # either conda install\n"
         '  python -m pip install "dask[array]" --upgrade  # or python -m pip install'
     )
-    raise ImportError(f"{e}\n\n{msg}") from e
+    # Typically raise ModuleNotFoundError
+    raise type(e)(f"{e}\n\n{msg}") from e
 
 
 if _array_expr_enabled():

--- a/dask/array/backends.py
+++ b/dask/array/backends.py
@@ -171,7 +171,7 @@ def register_cupyx():
     try:
         from cupyx.scipy.sparse import hstack, vstack
     except ImportError as e:
-        raise ImportError(
+        raise type(e)(
             "Stacking of sparse arrays requires at least CuPy version 8.0.0"
         ) from e
 

--- a/dask/array/cupy_entry_point.py
+++ b/dask/array/cupy_entry_point.py
@@ -10,9 +10,9 @@ from dask.array.dispatch import to_cupy_dispatch
 def _cupy(strict=True):
     try:
         import cupy
-    except ImportError:
+    except ImportError as e:
         if strict:
-            raise ImportError("Please install `cupy` to use `CupyBackendEntrypoint`")
+            raise type(e)("Please install `cupy` to use `CupyBackendEntrypoint`") from e
         return None
     return cupy
 

--- a/dask/array/stats.py
+++ b/dask/array/stats.py
@@ -42,7 +42,7 @@ from dask.utils import derived_from
 try:
     import scipy.stats
 except ImportError as e:
-    raise ImportError("`dask.array.stats` requires `scipy` to be installed.") from e
+    raise type(e)("`dask.array.stats` requires `scipy` to be installed.") from e
 from scipy import special
 from scipy.stats import distributions
 

--- a/dask/bag/__init__.py
+++ b/dask/bag/__init__.py
@@ -43,4 +43,4 @@ except ImportError as e:
         "  conda install dask               # either conda install\n"
         '  python -m pip install "dask[bag]" --upgrade  # or python -m pip install'
     )
-    raise ImportError(f"{e}\n\n{msg}") from e
+    raise type(e)(f"{e}\n\n{msg}") from e

--- a/dask/base.py
+++ b/dask/base.py
@@ -381,7 +381,7 @@ class DaskMethodsMixin:
         try:
             from distributed import futures_of, wait
         except ImportError as e:
-            raise ImportError(
+            raise type(e)(
                 "Using async/await with dask requires the `distributed` package"
             ) from e
 

--- a/dask/cache.py
+++ b/dask/cache.py
@@ -34,9 +34,7 @@ class Cache(Callback):
         try:
             import cachey
         except ImportError as ex:
-            raise ImportError(
-                f'Cache requires cachey, "{ex}" problem importing'
-            ) from ex
+            raise type(ex)(f'Cache requires cachey, "{ex}" problem importing') from ex
         self._nbytes = cachey.nbytes
         if isinstance(cache, Number):
             cache = cachey.Cache(cache, *args, **kwargs)

--- a/dask/distributed.py
+++ b/dask/distributed.py
@@ -11,7 +11,7 @@ try:
     from distributed import *  # noqa: F403
 except ImportError as e:
     if e.msg == "No module named 'distributed'":
-        raise ImportError(_import_error_message) from e
+        raise type(e)(_import_error_message) from e
     else:
         raise
 
@@ -20,5 +20,5 @@ def __getattr__(value):
     try:
         import distributed
     except ImportError as e:
-        raise ImportError(_import_error_message) from e
+        raise type(e)(_import_error_message) from e
     return getattr(distributed, value)

--- a/dask/ml.py
+++ b/dask/ml.py
@@ -11,5 +11,5 @@ def __getattr__(value):
             "  conda install dask-ml                      # either conda install\n"
             "  python -m pip install dask-ml --upgrade    # or pip install"
         )
-        raise ImportError(msg) from e
+        raise type(e)(msg) from e
     return getattr(dask_ml, value)

--- a/dask/utils.py
+++ b/dask/utils.py
@@ -2233,7 +2233,7 @@ def get_default_shuffle_method() -> str:
         from dask.dataframe._compat import HAS_PYARROW
 
         return "p2p" if HAS_PYARROW else "tasks"
-    except ModuleNotFoundError:
+    except ImportError:
         return "tasks"
 
 


### PR DESCRIPTION
When catching ModuleNotFoundError, re-raise the exact class instead of a generic ImportError.

This PR also fixes a regression introduced by #12373 when numpy is not installed.