### PR TITLE
Require pyyaml >=5.4.1

### DIFF
--- a/continuous_integration/environment-mindeps-optional.yaml
+++ b/continuous_integration/environment-mindeps-optional.yaml
@@ -15,11 +15,11 @@ dependencies:
   # optional dependencies pulled in by pip install dask[array,dataframe]
   - numpy=1.26  # pyarrow 16 requires numpy >=1.26; see mindeps-array for 1.24
   - pandas=2.0
+  - pyarrow=16.0
   # optional dependencies pulled in by pip install dask[diagnostics]
   - bokeh=3.1.0
   - jinja2=2.10.3
   # optional dependencies pulled in by pip install dask[complete]
-  - pyarrow=16.0
   - lz4=4.3.2
   # optional dependencies used by dask
   - cachey=0.1.1

--- a/continuous_integration/recipe/meta.yaml
+++ b/continuous_integration/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - fsspec >=2021.09.0
     - packaging >=20.0
     - partd >=1.4.0
-    - pyyaml >=5.3.1
+    - pyyaml >=5.4.1
     - toolz >=0.10.0
     - importlib_metadata >=4.13.0 # [py<312]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "fsspec >= 2021.09.0",
     "packaging >= 20.0",
     "partd >= 1.4.0",
-    "pyyaml >= 5.3.1",
+    "pyyaml >= 5.4.1",
     "toolz >= 0.12.0",
     # importlib.metadata has the following bugs fixed in 3.10.9 and 3.11.1
     # https://github.com/python/cpython/issues/99130
@@ -71,7 +71,6 @@ diagnostics = [
 delayed = []
 complete = [
     "dask[array,dataframe,distributed,diagnostics]",
-    "pyarrow >= 16.0",
     "lz4 >= 4.3.2",
 ]
 test = [


### PR DESCRIPTION
pip requires pyyaml>=5.3.1, which does not exist in conda for python 3.10 and is untested.
Bump it everywhere to 5.4.1, which is already the de facto minimum version in conda.

FYI @jrbourbeau 