### PR TITLE
Remove numexpr

### DIFF
--- a/continuous_integration/environment-3.10.yaml
+++ b/continuous_integration/environment-3.10.yaml
@@ -44,7 +44,6 @@ dependencies:
   - tiledb-py
   - tiledb
   - xarray
-  - numexpr
   - sqlalchemy
   - jsonschema
   - bokeh

--- a/continuous_integration/scripts/install.sh
+++ b/continuous_integration/scripts/install.sh
@@ -25,7 +25,7 @@ if [[ ${UPSTREAM_DEV} ]]; then
     # `s3fs` to avoid dependency conflicts
     python -m pip install --upgrade git+https://github.com/fsspec/filesystem_spec
     # TODO: Add nightly `scikit-image` back once it's available
-    conda uninstall --force numpy pandas scipy numexpr numba sparse scikit-image numbagg
+    conda uninstall --force numpy pandas scipy numba sparse scikit-image numbagg
     python -m pip install --no-deps --pre --retries 10 \
         -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
         numpy \

--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -3620,18 +3620,6 @@ class DataFrame(FrameBase):
             Dask does not fully support referring to variables using the '@' character,
             use f-strings or the ``local_dict`` keyword argument instead.
 
-        Notes
-        -----
-        This is like the sequential version except that this will also happen
-        in many threads.  This may conflict with ``numexpr`` which will use
-        multiple threads itself.  We recommend that you set ``numexpr`` to use a
-        single thread:
-
-        .. code-block:: python
-
-            import numexpr
-            numexpr.set_num_threads(1)
-
         See also
         --------
         pandas.DataFrame.query

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2544,8 +2544,6 @@ def test_sample_raises():
 
 
 def test_query():
-    pytest.importorskip("numexpr")
-
     df = pd.DataFrame({"x": [1, 2, 3, 4], "y": [5, 6, 7, 8]})
     ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(ddf.query("x**2 > y"), df.query("x**2 > y"))


### PR DESCRIPTION
Clean up downstream of https://github.com/dask/dask/pull/11606
numexpr is no longer used even if installed:
https://github.com/dask/dask/blob/8ea0dd32d2ca0f802cc68a26dceae831077a6005/dask/dataframe/core.py#L32