### PR TITLE
Update Optuna+Dask example to use optuna-integration

### DIFF
--- a/docs/source/ml.rst
+++ b/docs/source/ml.rst
@@ -42,13 +42,16 @@ values from the distribution it suggests based on the scores it has received.
 
 Dask and Optuna are often used together by running many objective functions in
 parallel and synchronizing the scores and parameter selection on the Dask
-scheduler.  To do this, we use the ``DaskStore`` object found in Optuna.
+scheduler.  To do this, we use the ``DaskStorage`` object provided by the
+`optuna-integration <https://optuna-integration.readthedocs.io/>`_ package
+(install it alongside Optuna with ``pip install optuna optuna-integration``).
 
 .. code-block:: python
 
    import optuna
+   from optuna_integration import DaskStorage
 
-   storage = optuna.integration.DaskStorage()
+   storage = DaskStorage()
 
    study = optuna.create_study(
        direction="maximize",


### PR DESCRIPTION
Closes #11270.

## Summary

The ML page's Optuna example still recommends `optuna.integration.DaskStorage()`. Optuna [moved third-party integrations out of the core package](https://optuna.org/blog/2024-01-12-jp.html) into the standalone `optuna-integration` package; the new path is `optuna_integration.DaskStorage`. The existing **link** in this same page already points at the optuna-integration docs, but the **code example** below it was never updated.

This PR:

- Adds an install hint pointing users at `pip install optuna optuna-integration`.
- Replaces `optuna.integration.DaskStorage()` with `DaskStorage()` and adds `from optuna_integration import DaskStorage` to the example.
- Fixes a typo: the prose called the object `DaskStore` (no `age`); it's `DaskStorage`.

## Checks

- [x] `pre-commit run --files docs/source/ml.rst` — clean (codespell, eof, etc.)
- [x] `docutils` parses the updated RST cleanly