### PR TITLE
fix: duplicated words in dask/array routines and slicing docstrings

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -1267,7 +1267,7 @@ def histogramdd(sample, bins, range=None, normed=None, weights=None, density=Non
         have an entry for each dimension. Unlike
         :func:`numpy.histogramdd`, if `bins` does not define bin
         edges, this argument is required (this function will not
-        automatically use the min and max of of the value in a given
+        automatically use the min and max of the value in a given
         dimension because the input data may be lazy in dask).
     normed : bool, optional
         An alias for the density argument that behaves identically. To

--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -1514,7 +1514,7 @@ def setitem_array(out_name, array, indices, value):
 
         The second case occurs when the block represented by key does
         overlap the indices. setitem is the chunk assignment function;
-        v_key is the dask key of the the part of the assignment value
+        v_key is the dask key of the part of the assignment value
         that corresponds to the block; and block_indices are the
         assignment indices that apply to the block.
 


### PR DESCRIPTION
Two one-line typo fixes for duplicated words in docstrings:
- `dask/array/routines.py` — "automatically use the min and max of of the value in a given" → "automatically use the min and max of the value in a given"
- `dask/array/slicing.py` — "v_key is the dask key of the the part of the assignment value" → "v_key is the dask key of the part of the assignment value"

No code/behavior change.