### PR TITLE
Run some tests serially in pytest-xdist

### DIFF
--- a/continuous_integration/scripts/run_tests.sh
+++ b/continuous_integration/scripts/run_tests.sh
@@ -13,7 +13,7 @@ if [[ $ARRAYEXPR == 'true' ]]; then
 fi
 
 if [[ $PARALLEL == 'true' ]]; then
-    CMD="$CMD -n4"
+    CMD="$CMD --dist loadgroup -n auto"
 fi
 
 CMD="$CMD $@"

--- a/dask/bytes/tests/test_http.py
+++ b/dask/bytes/tests/test_http.py
@@ -16,6 +16,10 @@ from dask.utils import tmpdir
 aiohttp = pytest.importorskip("aiohttp")
 requests = pytest.importorskip("requests")
 
+# Tests in this module are not concurrent-safe.
+# Force them to run sequentially in pytest-xdist.
+pytestmark = pytest.mark.xdist_group(name="http")
+
 files = ["a", "b"]
 
 errs = (

--- a/dask/bytes/tests/test_s3.py
+++ b/dask/bytes/tests/test_s3.py
@@ -11,6 +11,10 @@ from functools import partial
 
 import pytest
 
+# Tests in this module are not concurrent-safe.
+# Force them to run sequentially in pytest-xdist.
+pytestmark = pytest.mark.xdist_group(name="s3")
+
 s3fs = pytest.importorskip("s3fs")
 boto3 = pytest.importorskip("boto3")
 moto = pytest.importorskip("moto", minversion="1.3.14")


### PR DESCRIPTION
These tests are very obviously racy as they contend for the same resources across processes.
I'm very confused as to why they don't trip all the times in CI.

This PR also changes the number of xdist workers from 4 to auto. In ubuntu-latest, this changes from 4 to 2.
There is no change in end-to-end runtime.