### PR TITLE
XFAIL flaky `test_len`

### DIFF
--- a/dask/dataframe/dask_expr/tests/test_collection.py
+++ b/dask/dataframe/dask_expr/tests/test_collection.py
@@ -1721,6 +1721,7 @@ def test_repartition_partition_size(df):
     assert all(div is not None for div in df2.divisions)
 
 
+@pytest.mark.xfail(reason="https://github.com/dask/dask/issues/12275", strict=False)
 def test_len(df, pdf):
     df2 = df[["x"]] + 1
     assert len(df2) == len(pdf)


### PR DESCRIPTION
Work around #12275 

In an earlier iteration, I tried using `@pytest.mark.repeat`. It doesn't work: when it flakes, it flakes 10 times in a row.
This makes me suspect that the issue may be caused by set ordering (which changes at every interpreter start).
