### PR TITLE
Make sequential cumsum match NumPy accumulation order

### DIFF
--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -37,7 +37,7 @@ from dask.array.utils import (
 from dask.array.wrap import ones, zeros
 from dask.base import tokenize
 from dask.highlevelgraph import HighLevelGraph
-from dask.utils import apply, deepmap, derived_from
+from dask.utils import deepmap, derived_from
 
 try:
     import numbagg
@@ -1032,6 +1032,30 @@ def _prefixscan_first(func, x, axis, dtype):
     return func(x, axis=axis, dtype=dtype)
 
 
+def _cumreduction_apply(func, x, axis, dtype, use_dtype):
+    if use_dtype:
+        return func(x, axis=axis, dtype=dtype)
+    return func(x, axis=axis)
+
+
+def _cumreduction_merge(func, previous, x, axis, dtype, use_dtype):
+    if isinstance(previous, np.ma.masked_array) or isinstance(x, np.ma.masked_array):
+        previous = np.ma.array(
+            np.ma.getdata(previous),
+            mask=np.zeros_like(np.ma.getmaskarray(previous), dtype=bool),
+        )
+        x = np.ma.concatenate([previous, x], axis=axis)
+    else:
+        x = np.concatenate([previous, x], axis=axis)
+    result = _cumreduction_apply(func, x, axis, dtype, use_dtype)
+    slc = (
+        (slice(None),) * axis
+        + (slice(1, None),)
+        + (slice(None),) * (x.ndim - axis - 1)
+    )
+    return result[slc]
+
+
 def prefixscan_blelloch(func, preop, binop, x, axis=None, dtype=None, out=None):
     """Generic function to perform parallel cumulative scan (a.k.a prefix scan)
 
@@ -1231,11 +1255,6 @@ def cumreduction(
         except AttributeError:
             pass
 
-    if use_dtype:
-        m = x.map_blocks(partial(func, dtype=dtype), axis=axis, dtype=dtype)
-    else:
-        m = x.map_blocks(func, axis=axis, dtype=dtype)
-
     name = f"{func.__name__}-{tokenize(func, axis, binop, ident, x, dtype)}"
     n = x.numblocks[axis]
     full = slice(None, None, None)
@@ -1246,14 +1265,14 @@ def cumreduction(
     )
     dsk = dict()
     for ind in indices:
-        shape = tuple(x.chunks[i][ii] if i != axis else 1 for i, ii in enumerate(ind))
-        dsk[(name, "extra") + ind] = (
-            apply,
-            np.full_like,
-            (x._meta, ident, m.dtype),
-            {"shape": shape},
+        dsk[(name,) + ind] = (
+            _cumreduction_apply,
+            func,
+            (x.name,) + ind,
+            axis,
+            dtype,
+            use_dtype,
         )
-        dsk[(name,) + ind] = (m.name,) + ind
 
     for i in range(1, n):
         last_indices = indices
@@ -1263,16 +1282,19 @@ def cumreduction(
             )
         )
         for old, ind in zip(last_indices, indices):
-            this_slice = (name, "extra") + ind
-            dsk[this_slice] = (
-                binop,
-                (name, "extra") + old,
-                (operator.getitem, (m.name,) + old, slc),
+            previous = (operator.getitem, (name,) + old, slc)
+            dsk[(name,) + ind] = (
+                _cumreduction_merge,
+                func,
+                previous,
+                (x.name,) + ind,
+                axis,
+                dtype,
+                use_dtype,
             )
-            dsk[(name,) + ind] = (binop, this_slice, (m.name,) + ind)
 
-    graph = HighLevelGraph.from_collections(name, dsk, dependencies=[m])
-    result = Array(graph, name, x.chunks, m.dtype, meta=x._meta)
+    graph = HighLevelGraph.from_collections(name, dsk, dependencies=[x])
+    result = Array(graph, name, x.chunks, dtype, meta=x._meta)
     return handle_out(out, result)
 
 

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1049,9 +1049,7 @@ def _cumreduction_merge(func, previous, x, axis, dtype, use_dtype):
         x = np.concatenate([previous, x], axis=axis)
     result = _cumreduction_apply(func, x, axis, dtype, use_dtype)
     slc = (
-        (slice(None),) * axis
-        + (slice(1, None),)
-        + (slice(None),) * (x.ndim - axis - 1)
+        (slice(None),) * axis + (slice(1, None),) + (slice(None),) * (x.ndim - axis - 1)
     )
     return result[slc]
 

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -671,13 +671,10 @@ def test_array_cumreduction_axis(func, use_nan, axis, method):
 
 
 def test_array_sequential_cumsum_matches_numpy_order():
-    rng = np.random.default_rng(0)
-    a = 1000 * rng.random((2, 15))
-    d = da.from_array(a, chunks=(2, 5))
+    a = np.array([[1.0, 0.0, 0.0, 1e16, -1e16, 2.0]])
+    d = da.from_array(a, chunks=(1, 3))
 
-    result = d.cumsum(axis=-1).compute()
-
-    np.testing.assert_array_equal(result, np.cumsum(a, axis=-1))
+    assert_eq(d.cumsum(axis=-1), np.cumsum(a, axis=-1))
 
 
 @pytest.mark.parametrize("func", ["cumsum", "cumprod", "nancumsum", "nancumprod"])

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -670,6 +670,16 @@ def test_array_cumreduction_axis(func, use_nan, axis, method):
     assert_eq(a_r, d_r)
 
 
+def test_array_sequential_cumsum_matches_numpy_order():
+    rng = np.random.default_rng(0)
+    a = 1000 * rng.random((2, 15))
+    d = da.from_array(a, chunks=(2, 5))
+
+    result = d.cumsum(axis=-1).compute()
+
+    np.testing.assert_array_equal(result, np.cumsum(a, axis=-1))
+
+
 @pytest.mark.parametrize("func", ["cumsum", "cumprod", "nancumsum", "nancumprod"])
 @pytest.mark.parametrize("method", ["sequential", "blelloch"])
 @pytest.mark.parametrize("target_dtype", [None, int, float])

--- a/dask/cli.py
+++ b/dask/cli.py
@@ -65,7 +65,7 @@ def config_get(key=None):
         sys.exit(1)
 
     if isinstance(data, (list, dict)):
-        click.echo_via_pager(yaml.dump(data))
+        _echo_yaml(data)
     elif data is None:
         click.echo("None")
     else:
@@ -157,7 +157,15 @@ For example, you could set the following:
 @config.command(name="list")
 def config_list():
     """Print the whole config."""
-    click.echo_via_pager(yaml.dump(dask.config.config))
+    _echo_yaml(dask.config.config)
+
+
+def _echo_yaml(data):
+    output = yaml.dump(data)
+    if sys.stdout.isatty():
+        click.echo_via_pager(output)
+    else:
+        click.echo(output, nl=False)
 
 
 def _register_command_ep(interface, entry_point):

--- a/dask/cli.py
+++ b/dask/cli.py
@@ -65,7 +65,7 @@ def config_get(key=None):
         sys.exit(1)
 
     if isinstance(data, (list, dict)):
-        _echo_yaml(data)
+        click.echo_via_pager(yaml.dump(data))
     elif data is None:
         click.echo("None")
     else:
@@ -157,15 +157,7 @@ For example, you could set the following:
 @config.command(name="list")
 def config_list():
     """Print the whole config."""
-    _echo_yaml(dask.config.config)
-
-
-def _echo_yaml(data):
-    output = yaml.dump(data)
-    if sys.stdout.isatty():
-        click.echo_via_pager(output)
-    else:
-        click.echo(output, nl=False)
+    click.echo_via_pager(yaml.dump(dask.config.config))
 
 
 def _register_command_ep(interface, entry_point):


### PR DESCRIPTION
- [x] Closes #12359
- [x] Tests added / passed
- [ ] Passes `pre-commit run --all-files`

## Summary
- make the sequential cumulative-reduction path seed each later chunk with the previous cumulative value before scanning the chunk
- preserve masked-array masks while using the prior cumulative data value for the seed
- add a regression test that checks chunked `cumsum` matches NumPy's accumulation order exactly

## Tests
- `.venv\Scripts\python -m pytest dask\array\tests\test_reductions.py -q`
- `.venv\Scripts\python -m pytest dask\array\tests\test_array_core.py -k "cumulative" -q`
- `.venv\Scripts\python -m pytest dask\array\tests\test_masked.py -k "cumulative" -q`
- `.venv\Scripts\python -m ruff check dask\array\reductions.py dask\array\tests\test_reductions.py`
- `git diff --check`

AI assistance was used for code and test iteration. I reviewed the changes and take responsibility for the contribution.