### PR TITLE
Fix `add_prefix`/`add_suffix` in pandas nightly; support explicit axis

### DIFF
--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -3676,12 +3676,20 @@ class DataFrame(FrameBase):
         return concat(modes, axis=1)
 
     @derived_from(pd.DataFrame)
-    def add_prefix(self, prefix):
-        return new_collection(expr.AddPrefix(self, prefix))
+    def add_prefix(self, prefix, axis=None):
+        if axis in (None, 1, "columns"):
+            return new_collection(expr.AddPrefix(self, prefix))
+        if axis in (0, "index"):
+            raise NotImplementedError(f"add_prefix({axis=}) is not implemented in Dask")
+        raise ValueError("axis must be either 0, 1, 'index', 'columns', or None")
 
     @derived_from(pd.DataFrame)
-    def add_suffix(self, suffix):
-        return new_collection(expr.AddSuffix(self, suffix))
+    def add_suffix(self, suffix, axis=None):
+        if axis in (None, 1, "columns"):
+            return new_collection(expr.AddSuffix(self, suffix))
+        if axis in (0, "index"):
+            raise NotImplementedError(f"add_suffix({axis=}) is not implemented in Dask")
+        raise ValueError("axis must be either 0, 1, 'index', 'columns', or None")
 
     def pivot_table(self, index, columns, values, aggfunc="mean"):
         """

--- a/dask/dataframe/dask_expr/_expr.py
+++ b/dask/dataframe/dask_expr/_expr.py
@@ -2450,17 +2450,20 @@ class AddPrefixSeries(Elemwise):
     _filter_passthrough = True
     _preserves_partitioning_information = True
 
+    @functools.cached_property
+    def _meta(self):
+        return super()._meta.set_axis(pd.Index([], dtype="str"))
+
     def _divisions(self):
-        return tuple(self.prefix + str(division) for division in self.frame.divisions)
+        return tuple(f"{self.prefix}{division}" for division in self.frame.divisions)
 
 
 class AddSuffixSeries(AddPrefixSeries):
     _parameters = ["frame", "suffix"]
     operation = M.add_suffix
-    _preserves_partitioning_information = True
 
     def _divisions(self):
-        return tuple(str(division) + self.suffix for division in self.frame.divisions)
+        return tuple(f"{division}{self.suffix}" for division in self.frame.divisions)
 
 
 class AddPrefix(Elemwise):

--- a/dask/dataframe/dask_expr/tests/test_collection.py
+++ b/dask/dataframe/dask_expr/tests/test_collection.py
@@ -776,20 +776,6 @@ def test_blockwise(func, pdf, df):
     assert_eq(func(pdf), func(df))
 
 
-def test_add_prefix():
-    df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [4, 5, 6, 7, 8]})
-    ddf = from_pandas(df, npartitions=2)
-    assert_eq(ddf.add_prefix("abc"), df.add_prefix("abc"))
-    assert_eq(ddf.x.add_prefix("abc"), df.x.add_prefix("abc"))
-
-
-def test_add_suffix():
-    df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [4, 5, 6, 7, 8]})
-    ddf = from_pandas(df, npartitions=2)
-    assert_eq(ddf.add_suffix("abc"), df.add_suffix("abc"))
-    assert_eq(ddf.x.add_suffix("abc"), df.x.add_suffix("abc"))
-
-
 def test_select_dtypes_projection(df):
     result = df.select_dtypes(np.number)
     assert isinstance(result.expr.operand("columns"), list)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -2962,18 +2962,52 @@ def test_dataframe_map_raises():
         ddf.map(lambda x: x + 1)
 
 
-def test_add_prefix():
-    df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [4, 5, 6, 7, 8]})
+@pytest.mark.parametrize(
+    "index",
+    [
+        ["foo", "bar"],
+        [1, 2],
+        [1.1, 2.2],
+        pd.RangeIndex(2),
+        pd.DatetimeIndex(["2020-01-01", "2020-01-02"]),
+    ],
+)
+def test_add_prefix_add_suffix(index):
+    df = pd.DataFrame([[1, 2], [3, 4]], index=index, columns=index)
     ddf = dd.from_pandas(df, npartitions=2)
+
     assert_eq(ddf.add_prefix("abc"), df.add_prefix("abc"))
-    assert_eq(ddf.x.add_prefix("abc"), df.x.add_prefix("abc"))
-
-
-def test_add_suffix():
-    df = pd.DataFrame({"x": [1, 2, 3, 4, 5], "y": [4, 5, 6, 7, 8]})
-    ddf = dd.from_pandas(df, npartitions=2)
     assert_eq(ddf.add_suffix("abc"), df.add_suffix("abc"))
-    assert_eq(ddf.x.add_suffix("abc"), df.x.add_suffix("abc"))
+    assert_eq(ddf[index[0]].add_prefix("abc"), df[index[0]].add_prefix("abc"))
+    assert_eq(ddf[index[0]].add_suffix("abc"), df[index[0]].add_suffix("abc"))
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        ["foo", "bar"],
+        [1, 2],
+        [1.1, 2.2],
+        pd.RangeIndex(2),
+        pd.DatetimeIndex(["2020-01-01", "2020-01-02"]),
+    ],
+)
+@pytest.mark.parametrize(
+    "axis",
+    [
+        None,
+        1,
+        "columns",
+        pytest.param(0, marks=pytest.mark.xfail(reason="Not implemented")),
+        pytest.param("index", marks=pytest.mark.xfail(reason="Not implemented")),
+    ],
+)
+def test_add_prefix_add_suffix_axis(index, axis):
+    df = pd.DataFrame([[1, 2], [3, 4]], index=index, columns=index)
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    assert_eq(ddf.add_prefix("abc", axis=axis), df.add_prefix("abc", axis=axis))
+    assert_eq(ddf.add_suffix("abc", axis=axis), df.add_suffix("abc", axis=axis))
 
 
 def test_abs():


### PR DESCRIPTION
Out of scope: actually add support for `add_prefix(axis=0)` (new in Pandas 2.0)