### PR TITLE
Repair conda upload

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -30,12 +30,7 @@ jobs:
           locked: true
       
       - name: Build conda package
-        shell: bash -l {0}
-        run: |
-          # suffix for nightly package versions
-          export VERSION_SUFFIX=a`date +%y%m%d`
-
-          pixi r conda-build
+        run: pixi r conda-build
 
       - name: Upload conda build artifact
         uses: actions/upload-artifact@v7

--- a/pixi.toml
+++ b/pixi.toml
@@ -106,7 +106,7 @@ pyarrow = "*"
 # optional s3 I/O
 boto3 = "*"
 botocore = "*"
-# moto = "<5"  # Temporarily in feature.gil below
+# moto = "<5"  # Temporarily in feature.optional-gil below
 s3fs = ">=2021.9.0"  # Don't remove lower pin - resolves to ancient version without
 
 # optional dependencies pulled in by pip install dask[diagnostics]
@@ -117,7 +117,7 @@ jinja2 = "*"
 lz4 = "*"
 mmh3 = "*"
 # python-cityhash = "*"  # Temporarily in feature.optional-problematic below
-# python-snappy = "*"  # Temporarily in feature.gil below
+# python-snappy = "*"  # Temporarily in feature.optional-gil below
 python-xxhash = "*"
 
 # Other optional dependencies
@@ -127,11 +127,11 @@ numba = "*"
 numbagg = "*"
 flask = "*"
 h5py = "*"
-# pytables = "*"  # Temporarily in feature.gil below
-# zarr = "*"  # Temporarily in feature.gil below
+# pytables = "*"  # Temporarily in feature.optional-gil below
+# zarr = "*"  # Temporarily in feature.optional-gil below
 # tiledb-py = "*"  # Temporarily in feature.optional-problematic below
 xarray = "*"
-# sqlalchemy = "*"  # Temporarily in feature.gil below
+# sqlalchemy = "*"  # Temporarily in feature.optional-gil below
 jsonschema = "*"
 httpretty = "*"
 aiohttp = "*"
@@ -140,7 +140,7 @@ cytoolz = "*"
 ipython = "*"
 ipycytoscape = "*"
 ipywidgets = "*"
-# ipykernel = "*"  # Temporarily in feature.gil below
+# ipykernel = "*"  # Temporarily in feature.optional-gil below
 psutil = "*"
 requests = "*"
 scikit-image = "*"
@@ -149,7 +149,7 @@ scipy = "*"
 sparse = "*"
 cachey = "*"
 python-graphviz = "*"
-# matplotlib = "*"  # Temporarily in feature.gil below
+# matplotlib = "*"  # Temporarily in feature.optional-gil below
 
 # Optional dependencies that don't work yet in free-threading
 [feature.optional-gil.dependencies]
@@ -287,10 +287,10 @@ conda-build = "*"
 anaconda-client = "*"
 
 [feature.build.tasks]
-conda-build = "conda build continuous_integration/recipe --channel conda-forge --override-channels --output-folder dist/conda"
+conda-build = "VERSION_SUFFIX=a`date +%y%m%d` conda build continuous_integration/recipe --channel conda-forge --override-channels --output-folder dist/conda"
 [feature.build.tasks.conda-upload]
 cwd = "dist/conda"
-cmd = "anaconda upload --label dev noarch/*.tar.bz2"
+cmd = "anaconda upload --label dev noarch/*.conda"
 description = "Upload to anaconda.org. Requires ANACONDA_API_TOKEN env variable to be set."
 
 [environments]


### PR DESCRIPTION
CD to conda (https://anaconda.org/channels/dask/packages/dask-core/files) has been failing since April 28th due to the brownout of mambabuild.