### PR TITLE
Fix fused key collisions in delayed block arrays

### DIFF
--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -1178,6 +1178,8 @@ def fuse_linear_task_spec(dsk, keys):
         else:
             # Renaming the keys is necessary to preserve the rootish detection for now
             renamed_key = default_fused_keys_renamer([tsk.key for tsk in linear_chain])
+            if renamed_key in result and renamed_key != top_key:
+                renamed_key = top_key
             result[renamed_key] = Task.fuse(*linear_chain, key=renamed_key)
             if renamed_key != top_key:
                 # Having the same prefixes can result in the same key, i.e. getitem-hash -> getitem-hash

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -922,6 +922,56 @@ def test_block_simple_column_wise():
     assert_eq(expected, result)
 
 
+def test_block_delayed_collection_args_with_long_fused_names():
+    tile_size = 4
+    tile_dtype = np.dtype(
+        [("A", "float32", (tile_size, tile_size)), ("B", "float32", (tile_size, tile_size))]
+    )
+
+    @delayed
+    def make_tile(shape, value):
+        return np.array(
+            tuple(np.full(shape, value, dtype="float32") for _ in tile_dtype.descr),
+            dtype=tile_dtype,
+        )
+
+    def a_long_function_name(array):
+        return array
+
+    def nest_array_in_delays(array):
+        array = da.from_delayed(
+            delayed(a_long_function_name)(array), shape=array.shape, dtype=np.float32
+        )
+        return da.from_delayed(
+            delayed(a_long_function_name)(array), shape=array.shape, dtype=np.float32
+        )
+
+    shape = (10, 10)
+
+    for _ in range(5):
+        mosaic = np.empty(shape, dtype=object)
+        value = 0
+        for x in range(shape[0]):
+            for y in range(shape[1]):
+                array = da.from_delayed(
+                    make_tile((tile_size, tile_size), value),
+                    shape=tuple(),
+                    dtype=tile_dtype,
+                )
+                array = da.stack(
+                    [nest_array_in_delays(array[field]) for field in ["A", "B"]],
+                    axis=0,
+                )
+                mosaic[x, y] = array.rechunk((-1,) + array.chunks[1:])
+                value += 1
+
+        result = da.block(mosaic.tolist()).compute(scheduler="single-threaded")
+        np.testing.assert_array_equal(
+            result[0, ::tile_size, ::tile_size],
+            np.arange(shape[0] * shape[1], dtype="float32").reshape(shape),
+        )
+
+
 def test_block_with_1d_arrays_row_wise():
     # # # 1-D vectors are treated as row arrays
     a1 = np.array([1, 2, 3])

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -925,7 +925,10 @@ def test_block_simple_column_wise():
 def test_block_delayed_collection_args_with_long_fused_names():
     tile_size = 4
     tile_dtype = np.dtype(
-        [("A", "float32", (tile_size, tile_size)), ("B", "float32", (tile_size, tile_size))]
+        [
+            ("A", "float32", (tile_size, tile_size)),
+            ("B", "float32", (tile_size, tile_size)),
+        ]
     )
 
     @delayed

--- a/dask/optimization.py
+++ b/dask/optimization.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import math
 import numbers
 from enum import Enum
@@ -417,11 +418,11 @@ def default_fused_keys_renamer(keys, max_fused_key_length=120):
     typ = type(first_key)
 
     if max_fused_key_length:  # Take into account size of hash suffix
-        max_fused_key_length -= 5
+        max_fused_key_length -= 9
 
     def _enforce_max_key_limit(key_name):
         if max_fused_key_length and len(key_name) > max_fused_key_length:
-            name_hash = f"{hash(key_name):x}"[:4]
+            name_hash = hashlib.sha1(key_name.encode()).hexdigest()[:8]
             key_name = f"{key_name[:max_fused_key_length]}-{name_hash}"
         return key_name
 

--- a/dask/tests/test_optimization.py
+++ b/dask/tests/test_optimization.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from functools import partial
 
 import pytest
@@ -9,6 +10,7 @@ from dask._task_spec import Alias, Task, TaskRef, convert_legacy_graph
 from dask.core import get_dependencies
 from dask.optimization import (
     cull,
+    default_fused_keys_renamer,
     functions_of,
     fuse,
     fuse_linear,
@@ -33,6 +35,19 @@ def test_cull():
     assert cull(d, ["out", "z"])[0] == d
     assert cull(d, [["out"], ["z"]]) == cull(d, ["out", "z"])
     pytest.raises(KeyError, lambda: cull(d, "badkey"))
+
+
+def test_default_fused_keys_renamer_uses_stable_digest_suffix():
+    keys = [
+        "load" + "x" * 150,
+        "getitem" + "y" * 150,
+        "output" + "z" * 150,
+    ]
+    full_name = "-".join(sorted(keys[:-1]) + [keys[-1]])
+    result = default_fused_keys_renamer(keys, max_fused_key_length=40)
+
+    assert result == f"{full_name[:31]}-{hashlib.sha1(full_name.encode()).hexdigest()[:8]}"
+    assert len(result) == 40
 
 
 def fuse2(*args, **kwargs):

--- a/dask/tests/test_optimization.py
+++ b/dask/tests/test_optimization.py
@@ -46,7 +46,9 @@ def test_default_fused_keys_renamer_uses_stable_digest_suffix():
     full_name = "-".join(sorted(keys[:-1]) + [keys[-1]])
     result = default_fused_keys_renamer(keys, max_fused_key_length=40)
 
-    assert result == f"{full_name[:31]}-{hashlib.sha1(full_name.encode()).hexdigest()[:8]}"
+    assert (
+        result == f"{full_name[:31]}-{hashlib.sha1(full_name.encode()).hexdigest()[:8]}"
+    )
     assert len(result) == 40
 
 

--- a/dask/tests/test_task_spec.py
+++ b/dask/tests/test_task_spec.py
@@ -907,6 +907,26 @@ def test_linear_fusion():
     assert not any("-" in k for k in dsk)
 
 
+def test_linear_fusion_avoids_renamed_key_collisions(monkeypatch):
+    monkeypatch.setattr(
+        "dask.optimization.default_fused_keys_renamer", lambda _: "collision"
+    )
+
+    tasks = [
+        a1 := Task("a1", func, 1),
+        Task("a2", func, a1.ref()),
+        b1 := Task("b1", func, 2),
+        Task("b2", func, b1.ref()),
+    ]
+    result = fuse_linear_task_spec({t.key: t for t in tasks}, {"a2", "b2"})
+
+    assert isinstance(result["collision"], Task)
+    assert isinstance(result["a2"], Alias)
+    assert result["a2"].target == "collision"
+    assert isinstance(result["b2"], Task)
+    assert result["b2"].key == "b2"
+
+
 def test_linear_fusion_intermediate_branch():
     tasks = [
         io := DataNode("foo", 1),


### PR DESCRIPTION
﻿Fixes #12164.

The issue reproducer creates many long delayed/getitem chains before `da.block`. During low-level TaskSpec fusion those chains can be renamed to shortened fused keys. The old suffix used Python's process-randomized `hash()` and only four hex characters, which made collisions realistic for this mosaic shape and could alias one fused tile chain to another.

What changed:

- use a stable SHA-1 digest suffix for shortened fused task names and expand the suffix to eight hex characters
- avoid reusing an already-emitted fused alias in TaskSpec linear fusion
- add a `da.block` regression covering nested delayed structured-array fields with long function names

Validation:

- `python -m pytest dask\tests\test_task_spec.py::test_linear_fusion dask\tests\test_task_spec.py::test_linear_fusion_avoids_renamed_key_collisions dask\tests\test_optimization.py::test_default_fused_keys_renamer_uses_stable_digest_suffix dask\array\tests\test_array_core.py::test_block_delayed_collection_args_with_long_fused_names -q`
- `python -m ruff check dask\_task_spec.py dask\optimization.py dask\tests\test_task_spec.py dask\tests\test_optimization.py dask\array\tests\test_array_core.py`
- `python -m compileall -q dask\_task_spec.py dask\optimization.py dask\tests\test_task_spec.py dask\tests\test_optimization.py dask\array\tests\test_array_core.py`
- `git diff --check`
- patched local reproducer passed 10/10 threaded iterations
