### PR TITLE
Strictly expect test failures

### DIFF
--- a/dask/array/tests/test_array_function.py
+++ b/dask/array/tests/test_array_function.py
@@ -98,18 +98,15 @@ def test_array_notimpl_function_dask(func):
         func(y)
 
 
-@pytest.mark.parametrize(
-    "func", [lambda x: np.real(x), lambda x: np.imag(x), lambda x: np.transpose(x)]
-)
-def test_array_function_sparse(func):
+@pytest.mark.parametrize("func", [np.real, np.imag, np.transpose])
+def test_array_function_sparse(xfail, func):
     sparse = pytest.importorskip("sparse")
-    if Version(sparse.__version__) == Version("0.15.2"):
-        pytest.skip(reason="https://github.com/pydata/sparse/issues/682")
+    if Version(sparse.__version__) == Version("0.15.2") and func in (np.real, np.imag):
+        xfail(reason="https://github.com/pydata/sparse/issues/682")
+
     x = da.random.default_rng().random((500, 500), chunks=(100, 100))
     x[x < 0.9] = 0
-
     y = x.map_blocks(sparse.COO)
-
     assert_eq(func(x), func(y))
 
 

--- a/dask/array/tests/test_creation.py
+++ b/dask/array/tests/test_creation.py
@@ -1086,9 +1086,10 @@ def test_nan_empty_like(shape_chunks, dtype):
 @pytest.mark.parametrize("val", [0, 0.0, 99, -1])
 @pytest.mark.parametrize("shape_chunks", [((50, 4), (10, 2)), ((50,), (10,))])
 @pytest.mark.parametrize("dtype", ["u4", np.float32, None, np.int64])
-def test_nan_full_like(val, shape_chunks, dtype):
+def test_nan_full_like(xfail, val, shape_chunks, dtype):
     if NUMPY_GE_210 and val == -1 and dtype == "u4":
-        pytest.xfail("can't insert negative numbers into unsigned integer")
+        xfail("can't insert negative numbers into unsigned integer")
+
     shape, chunks = shape_chunks
     x1 = da.random.standard_normal(size=shape, chunks=chunks)
     y1 = x1[x1 < 0.5]

--- a/dask/array/tests/test_linalg.py
+++ b/dask/array/tests/test_linalg.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import sys
-
 import pytest
 
 pytest.importorskip("numpy")
@@ -13,7 +11,6 @@ from packaging.version import Version
 
 import dask.array as da
 from dask.array.linalg import qr, sfqr, svd, svd_compressed, tsqr
-from dask.array.numpy_compat import _np_version
 from dask.array.utils import assert_eq, same_keys, svd_flip
 
 
@@ -1031,11 +1028,6 @@ def test_svd_full_matrices_false(shape):
     assert_eq(dv, nv)
 
 
-@pytest.mark.xfail(
-    sys.platform == "darwin" and _np_version < Version("1.22"),
-    reason="https://github.com/dask/dask/issues/7189",
-    strict=False,
-)
 @pytest.mark.parametrize(
     "shape, chunks, axis",
     [[(5,), (2,), None], [(5,), (2,), 0], [(5,), (2,), (0,)], [(5, 6), (2, 2), None]],
@@ -1052,11 +1044,6 @@ def test_norm_any_ndim(shape, chunks, axis, norm, keepdims):
     assert_eq(a_r, d_r)
 
 
-@pytest.mark.xfail(
-    _np_version < Version("1.23"),
-    reason="https://github.com/numpy/numpy/pull/17709",
-    strict=False,
-)
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("isreal", [True, False])
 @pytest.mark.parametrize("keepdims", [False, True])
@@ -1078,12 +1065,6 @@ def test_norm_any_prec(norm, keepdims, precision, isreal):
     assert d_r.dtype == d_a.dtype
 
 
-@pytest.mark.slow
-@pytest.mark.xfail(
-    sys.platform == "darwin" and _np_version < Version("1.22"),
-    reason="https://github.com/dask/dask/issues/7189",
-    strict=False,
-)
 @pytest.mark.parametrize(
     "shape, chunks",
     [

--- a/dask/array/tests/test_reductions.py
+++ b/dask/array/tests/test_reductions.py
@@ -1152,9 +1152,9 @@ def test_quantile_dask_q(np_func, da_func):
 @pytest.mark.parametrize("axis", [-1, 0])
 @pytest.mark.parametrize("rechunk", [True, False])
 @quantile_nanquantile
-def test_quantile_nd_q(np_func, da_func, axis, rechunk):
+def test_quantile_nd_q(xfail, np_func, da_func, axis, rechunk):
     if not NUMPY_GE_200 and np_func is np.nanquantile and axis == -1:
-        pytest.xfail("Incorrect outputs on numpy<2")
+        xfail("Incorrect outputs on numpy<2")
 
     shape = 10, 15, 20, 15
     arr = np.random.randn(*shape)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -2208,9 +2208,9 @@ def test_unravel_index():
         ([1, [2, 3], [[1, 2], [3, 4], [5, 6], [7, 8]]], None, dict(dims=(8, 9, 10))),
     ],
 )
-def test_ravel_multi_index(asarray, arr, chunks, kwargs):
+def test_ravel_multi_index(xfail, asarray, arr, chunks, kwargs):
     if any(np.isscalar(x) for x in arr) and asarray in (np.asarray, da.from_array):
-        pytest.skip()
+        xfail("?")
 
     if asarray is da.from_array:
         arr = np.asarray(arr)

--- a/dask/array/tests/test_ufunc.py
+++ b/dask/array/tests/test_ufunc.py
@@ -151,9 +151,10 @@ unary_ufuncs = [
 
 
 @pytest.mark.parametrize("ufunc", unary_ufuncs)
-def test_unary_ufunc(ufunc):
+def test_unary_ufunc(xfail, ufunc):
     if ufunc == "fix":
-        pytest.skip("fix calls floor in a way that we do not yet support")
+        xfail("fix calls floor in a way that we do not yet support")
+
     dafunc = getattr(da, ufunc)
     npfunc = getattr(np, ufunc)
 

--- a/dask/conftest.py
+++ b/dask/conftest.py
@@ -58,7 +58,7 @@ def xfail(request: pytest.FixtureRequest):
         def test1(xfail):
             if param1 == 2 and param2 == 6:
                 xfail("This combination of parameters is known to fail")
-            # Test continues, inncluding in the XFAIL'ed condition
+            # Test continues, including in the XFAIL'ed use case
 
     Parameters
     ----------

--- a/dask/conftest.py
+++ b/dask/conftest.py
@@ -34,3 +34,48 @@ def shuffle_method(request):
 
     with dask.config.set({"dataframe.shuffle.method": request.param}):
         yield request.param
+
+
+@pytest.fixture
+def xfail(request: pytest.FixtureRequest):
+    """
+    This fixture returns a function that, when called inside the test,
+    XFAILs the currently running test.
+
+    You should prefer using `@pytest.mark.xfail` when possible. However, when a failure
+    condition is too complicated to test statically (e.g. when it depends on the
+    intersection of multiple pytest parameters), this is preferable to just calling
+    `pytest.xfail`. The difference is that `pytest.xfail` will immediately end the test,
+    while this fixture allows the test to execute, so that it may result in a XPASS.
+
+    xref https://github.com/pandas-dev/pandas/issues/38902
+
+    Usage
+    -----
+    ::
+        @pytest.mark.parametrize("param1", [1, 2, 3])
+        @pytest.mark.parametrize("param2", [4, 5, 6])
+        def test1(xfail):
+            if param1 == 2 and param2 == 6:
+                xfail("This combination of parameters is known to fail")
+            # Test continues, inncluding in the XFAIL'ed condition
+
+    Parameters
+    ----------
+    reason : str
+        Reason for the expected failure.
+    strict: bool, optional
+        If True, the test will be marked as failed if it passes (XPASS).
+        If False, the test will be marked as passed both if it fails (XFAIL)
+        or passes (XPASS).
+        Default: ``xfail_strict`` value in ``pyproject.toml``, or False if absent.
+    """
+
+    def _(reason: str, strict: bool | None = None) -> None:
+        if strict is not None:
+            marker = pytest.mark.xfail(reason=reason, strict=strict)
+        else:
+            marker = pytest.mark.xfail(reason=reason)
+        request.node.add_marker(marker)
+
+    return _

--- a/dask/dataframe/dask_expr/tests/test_collection.py
+++ b/dask/dataframe/dask_expr/tests/test_collection.py
@@ -435,8 +435,6 @@ def test_fillna():
 @pytest.mark.parametrize("how", ("ffill", "bfill"))
 @pytest.mark.parametrize("axis", ("index", 0))
 def test_ffill_and_bfill(limit, axis, how):
-    if limit is None:
-        pytest.xfail("Need to determine partition size for Fill.before <= frame size")
     pdf = pd.DataFrame({"x": [1, 2, None, None, 5, 6]})
     df = from_pandas(pdf, npartitions=2)
     actual = getattr(df, how)(axis=axis, limit=limit)
@@ -463,9 +461,9 @@ def test_reset_index_projections(pdf):
 @pytest.mark.parametrize("periods", (1, 2))
 @pytest.mark.parametrize("freq", (None, "1h", timedelta(hours=1)))
 @pytest.mark.parametrize("axis", ("index", 0, "columns", 1))
-def test_shift(pdf, df, periods, freq, axis):
+def test_shift(xfail, pdf, df, periods, freq, axis):
     if freq and axis in ("columns", 1):
-        pytest.skip(reason="Neither dask or pandas supports freq w/ axis 1 shift")
+        xfail(reason="Neither dask or pandas supports freq w/ axis 1 shift")
 
     if freq is not None:
         pdf["time"] = pd.date_range("2000-01-01", "2000-01-02", periods=len(pdf))
@@ -1657,7 +1655,9 @@ def test_repartition_partition_size(df):
     assert all(div is not None for div in df2.divisions)
 
 
-@pytest.mark.xfail(reason="https://github.com/dask/dask/issues/12275", strict=False)
+@pytest.mark.xfail(
+    reason="Very flaky https://github.com/dask/dask/issues/12275", strict=False
+)
 def test_len(df, pdf):
     df2 = df[["x"]] + 1
     assert len(df2) == len(pdf)

--- a/dask/dataframe/dask_expr/tests/test_groupby.py
+++ b/dask/dataframe/dask_expr/tests/test_groupby.py
@@ -58,8 +58,6 @@ def test_groupby_unsupported_by(pdf, df):
     ],
 )
 def test_groupby_numeric(pdf, df, api, numeric_only, split_every):
-    if not numeric_only and api in {"var", "std"}:
-        pytest.xfail("not implemented")
     g = df.groupby("x")
     agg = getattr(g, api)(numeric_only=numeric_only, split_every=split_every)
 

--- a/dask/dataframe/dask_expr/tests/test_merge.py
+++ b/dask/dataframe/dask_expr/tests/test_merge.py
@@ -624,8 +624,6 @@ def test_merge_pandas_object():
 def test_pairwise_merge_results_in_identical_output_df(
     how, npartitions_base, npartitions_other, clear_divisions
 ):
-    if clear_divisions and (npartitions_other != 3 or npartitions_base != 1):
-        pytest.skip(reason="Runtime still slower than I would like, so save some time")
     dfs_to_merge = []
     for i in range(10):
         df = pd.DataFrame(

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1033,14 +1033,6 @@ def test_read_parquet_custom_columns(tmpdir, engine):
 )
 @pytest.mark.skip_with_pyarrow_strings  # don't want to convert binary data to pyarrow strings
 def test_roundtrip(tmpdir, df, write_kwargs, read_kwargs, engine):
-    if "x" in df and df.x.dtype == "M8[ns]" and engine == "pyarrow":
-        pytest.xfail(reason="Parquet pyarrow v1 doesn't support nanosecond precision")
-
-    # non-ns times
-    if "x" in df and (df.x.dtype == "M8[ms]" or df.x.dtype == "M8[us]"):
-        if engine == "pyarrow":
-            pytest.xfail("https://github.com/apache/arrow/issues/15079")
-
     tmp = str(tmpdir)
     if df.index.name is None:
         df.index.name = "index"

--- a/dask/dataframe/tests/test_accessors.py
+++ b/dask/dataframe/tests/test_accessors.py
@@ -44,12 +44,14 @@ class MyAccessor:
     [
         (dd.Series, dd.extensions.register_series_accessor),
         (dd.DataFrame, dd.extensions.register_dataframe_accessor),
-        (dd.Index, dd.extensions.register_index_accessor),
+        pytest.param(
+            dd.Index,
+            dd.extensions.register_index_accessor,
+            marks=pytest.mark.xfail(reason="from_pandas doesn't support Index"),
+        ),
     ],
 )
 def test_register(obj, registrar):
-    if obj is dd.Index:
-        pytest.skip("from_pandas doesn't support Index")
     with ensure_removed(obj, "mine"):
         before = set(dir(obj))
         registrar("mine")(MyAccessor)

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -11,7 +11,7 @@ from pandas.api.types import is_scalar
 
 import dask.dataframe as dd
 from dask.array.numpy_compat import NUMPY_GE_125, NUMPY_GE_200
-from dask.dataframe._compat import PANDAS_GE_300
+from dask.dataframe._compat import PANDAS_GE_210, PANDAS_GE_220, PANDAS_GE_300
 from dask.dataframe.utils import assert_eq, pyarrow_strings_enabled
 
 try:
@@ -707,11 +707,11 @@ def test_reduction_series_invalid_axis():
             pytest.raises(ValueError, lambda s=s, axis=axis: s.mean(axis=axis))
 
 
+@pytest.mark.xfail(
+    pyarrow_strings_enabled() and not PANDAS_GE_300,
+    reason="known failure with arrow strings",
+)
 def test_reductions_non_numeric_dtypes():
-    # test non-numric blocks
-    if pyarrow_strings_enabled() and not PANDAS_GE_300:
-        pytest.xfail(reason="known failure with arrow strings")
-
     def check_raises(d, p, func):
         pytest.raises((TypeError, ValueError), lambda: getattr(d, func)().compute())
         pytest.raises((TypeError, ValueError), lambda: getattr(p, func)())
@@ -864,22 +864,11 @@ def test_reductions_frame(split_every):
         ("var", {"ddof": 0, "skipna": False}),
     ],
 )
-@pytest.mark.parametrize(
-    "numeric_only",
-    [
-        None,
-        True,
-        pytest.param(
-            False,
-            marks=pytest.mark.xfail(
-                True, reason="numeric_only=False not implemented", strict=False
-            ),
-        ),
-    ],
-)
-def test_reductions_frame_dtypes(func, kwargs, numeric_only):
-    if pyarrow_strings_enabled() and func == "sum" and numeric_only is None:
-        pytest.xfail("Known failure with pyarrow strings")
+@pytest.mark.parametrize("numeric_only", [None, True, False])
+def test_reductions_frame_dtypes(xfail, func, kwargs, numeric_only):
+    if func == "sum" and not numeric_only and not PANDAS_GE_210:
+        xfail("Known failure")
+
     df = pd.DataFrame(
         {
             "int": [1, 2, 3, 4, 5, 6, 7, 8],
@@ -1467,11 +1456,13 @@ def test_std_raises_with_arrow_string_ea():
     ],
 )
 @pytest.mark.parametrize("func", ["std", "var", "skew", "kurtosis"])
-def test_reductions_with_pandas_and_arrow_ea(dtype, func):
-    if func in ["skew", "kurtosis"]:
+def test_reductions_with_pandas_and_arrow_ea(xfail, dtype, func):
+    if func in ("skew", "kurtosis"):
         pytest.importorskip("scipy")
-        if "pyarrow" in dtype:
-            pytest.xfail("skew/kurtosis not implemented for arrow dtypes")
+        if "pyarrow" in dtype and func == "skew" and not PANDAS_GE_220:
+            xfail("skew not implemented for arrow dtypes")
+        if "pyarrow" in dtype and func == "kurtosis":
+            xfail("kurtosis not implemented for arrow dtypes")
 
     ser = pd.Series([1, 2, 3, 4], dtype=dtype)
     ds = dd.from_pandas(ser, npartitions=2)

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -11,12 +11,7 @@ from pandas.api.types import is_scalar
 
 import dask.dataframe as dd
 from dask.array.numpy_compat import NUMPY_GE_125, NUMPY_GE_200
-from dask.dataframe._compat import (
-    PANDAS_GE_210,
-    PANDAS_GE_220,
-    PANDAS_GE_230,
-    PANDAS_GE_300,
-)
+from dask.dataframe._compat import PANDAS_GE_210, PANDAS_GE_220, PANDAS_GE_230
 from dask.dataframe.utils import assert_eq, pyarrow_strings_enabled
 
 try:

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -11,7 +11,12 @@ from pandas.api.types import is_scalar
 
 import dask.dataframe as dd
 from dask.array.numpy_compat import NUMPY_GE_125, NUMPY_GE_200
-from dask.dataframe._compat import PANDAS_GE_210, PANDAS_GE_220, PANDAS_GE_300
+from dask.dataframe._compat import (
+    PANDAS_GE_210,
+    PANDAS_GE_220,
+    PANDAS_GE_230,
+    PANDAS_GE_300,
+)
 from dask.dataframe.utils import assert_eq, pyarrow_strings_enabled
 
 try:
@@ -866,7 +871,12 @@ def test_reductions_frame(split_every):
 )
 @pytest.mark.parametrize("numeric_only", [None, True, False])
 def test_reductions_frame_dtypes(xfail, func, kwargs, numeric_only):
-    if func == "sum" and not numeric_only and not PANDAS_GE_210:
+    if (
+        func == "sum"
+        and not numeric_only
+        # Fails on Pandas 2.0 and 2.2, but not 2.1 for some reason
+        and (not PANDAS_GE_210 or (PANDAS_GE_220 and not PANDAS_GE_230))
+    ):
         xfail("Known failure")
 
     df = pd.DataFrame(

--- a/dask/dataframe/tests/test_arithmetics_reduction.py
+++ b/dask/dataframe/tests/test_arithmetics_reduction.py
@@ -713,7 +713,7 @@ def test_reduction_series_invalid_axis():
 
 
 @pytest.mark.xfail(
-    pyarrow_strings_enabled() and not PANDAS_GE_300,
+    pyarrow_strings_enabled() and not PANDAS_GE_230,
     reason="known failure with arrow strings",
 )
 def test_reductions_non_numeric_dtypes():

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -1082,7 +1082,7 @@ def test_bfill(group_keys, limit):
     )
 
 
-# @pytest.mark.flaky(reruns=5)  # See https://github.com/dask/dask/issues/9793
+@pytest.mark.flaky(reruns=5)  # See https://github.com/dask/dask/issues/9793
 @pytest.mark.parametrize(
     "grouper_id,grouper",
     [

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2790,17 +2790,17 @@ def test_groupby_sort_true_split_out():
 def test_groupby_aggregate_categorical_observed(
     xfail, agg_func, known_cats, ordered_cats, groupby, observed
 ):
-    if agg_func in ["cov", "corr", "nunique"]:
+    if agg_func in ("cov", "corr", "nunique"):
         xfail("Not implemented for DataFrameGroupBy yet.")
     elif (
-        agg_func in ["mean", "median", "std", "sum", "var", "prod"]
+        agg_func in ("mean", "median", "std", "sum", "var", "prod")
         and groupby == "cat_1"
     ):
         xfail("Can't calculate over categorical")
     elif agg_func == "median" and not observed:
         xfail("Unknown issue")
-    elif agg_func == "prod" and not observed and not PANDAS_GE_220:
-        xfail("Fixed in later versions of Pandas")
+    elif agg_func == "prod" and not observed and not PANDAS_GE_300:
+        xfail("Fixed in Pandas 3")
 
     pdf = pd.DataFrame(
         {

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -40,46 +40,16 @@ if PANDAS_GE_220 and not PANDAS_GE_300:
 
 AGG_FUNCS = [
     "sum",
-    pytest.param(
-        "mean",
-        marks=pytest.mark.xfail(
-            reason="numeric_only=False not implemented",
-            strict=False,
-        ),
-    ),
+    "mean",
     "median",
     "min",
     "max",
     "count",
     "size",
-    pytest.param(
-        "std",
-        marks=pytest.mark.xfail(
-            reason="numeric_only=False not implemented",
-            strict=False,
-        ),
-    ),
-    pytest.param(
-        "var",
-        marks=pytest.mark.xfail(
-            reason="numeric_only=False not implemented",
-            strict=False,
-        ),
-    ),
-    pytest.param(
-        "cov",
-        marks=pytest.mark.xfail(
-            reason="numeric_only=False not implemented",
-            strict=False,
-        ),
-    ),
-    pytest.param(
-        "corr",
-        marks=pytest.mark.xfail(
-            reason="numeric_only=False not implemented",
-            strict=False,
-        ),
-    ),
+    "std",
+    "var",
+    "cov",
+    "corr",
     "nunique",
     "first",
     "last",
@@ -274,22 +244,23 @@ def test_groupby_on_index(scheduler):
             )
 
 
+@pytest.mark.filterwarnings("ignore:invalid value encountered:RuntimeWarning")
 @pytest.mark.parametrize(
-    "grouper",
+    "grouper_id,grouper",
     [
-        lambda df: df.groupby("a")["b"],
-        lambda df: df.groupby(["a", "b"]),
-        lambda df: df.groupby(["a", "b"])["c"],
-        lambda df: df.groupby(df["a"])[["b", "c"]],
-        lambda df: df.groupby("a")[["b", "c"]],
-        lambda df: df.groupby("a")[["b"]],
-        lambda df: df.groupby(["a", "b", "c"]),
+        (0, lambda df: df.groupby("a")["b"]),
+        (1, lambda df: df.groupby(["a", "b"])),
+        (2, lambda df: df.groupby(["a", "b"])["c"]),
+        (3, lambda df: df.groupby(df["a"])[["b", "c"]]),
+        (4, lambda df: df.groupby("a")[["b", "c"]]),
+        (5, lambda df: df.groupby("a")[["b"]]),
+        (6, lambda df: df.groupby(["a", "b", "c"])),
     ],
 )
-def test_groupby_multilevel_getitem(grouper, agg_func):
+def test_groupby_multilevel_getitem(xfail, grouper_id, grouper, agg_func):
     # nunique is not implemented for DataFrameGroupBy
-    if agg_func == "nunique":
-        return
+    if agg_func == "nunique" and grouper_id in (1, 3, 4, 5, 6):
+        xfail("not implemented for DataFrameGroupBy")
 
     df = pd.DataFrame(
         {
@@ -693,9 +664,14 @@ def test_split_apply_combine_on_series(empty):
 
 
 @pytest.mark.parametrize("keyword", ["split_every", "split_out"])
-def test_groupby_reduction_split(keyword, agg_func, shuffle_method):
-    if agg_func in {"first", "last"} and shuffle_method == "disk":
-        pytest.skip(reason="https://github.com/dask/dask/issues/10034")
+def test_groupby_reduction_split(xfail, keyword, agg_func, shuffle_method):
+    if (
+        agg_func in {"first", "last"}
+        and shuffle_method == "disk"
+        and keyword == "split_out"
+    ):
+        xfail(reason="https://github.com/dask/dask/issues/10034")
+
     pdf = pd.DataFrame(
         {"a": [1, 2, 6, 4, 4, 6, 4, 3, 7] * 100, "b": [4, 2, 7, 3, 3, 1, 1, 1, 2] * 100}
     )
@@ -905,7 +881,7 @@ def test_groupby_normalize_by():
     assert d.groupby([d["a"], "b"]).by == ["a", "b"]
 
 
-def test_aggregate__single_element_groups(agg_func):
+def test_aggregate_single_element_groups(agg_func):
     spec = agg_func
 
     # nunique/cov is not supported in specs
@@ -1106,19 +1082,26 @@ def test_bfill(group_keys, limit):
     )
 
 
-@pytest.mark.flaky(reruns=5)  # See https://github.com/dask/dask/issues/9793
+# @pytest.mark.flaky(reruns=5)  # See https://github.com/dask/dask/issues/9793
 @pytest.mark.parametrize(
-    "grouper",
+    "grouper_id,grouper",
     [
-        lambda df: ["a"],
-        lambda df: ["a", "b"],
-        lambda df: df["a"],
-        lambda df: [df["a"], df["b"]],
-        lambda df: [df["a"] > 2, df["b"] > 1],
+        (0, lambda df: ["a"]),
+        (1, lambda df: ["a", "b"]),
+        (2, lambda df: df["a"]),
+        (3, lambda df: [df["a"], df["b"]]),
+        (4, lambda df: [df["a"] > 2, df["b"] > 1]),
     ],
 )
 @pytest.mark.parametrize("split_out", [1, 2])
-def test_dataframe_aggregations_multilevel(grouper, agg_func, split_out):
+def test_dataframe_aggregations_multilevel(
+    xfail, grouper_id, grouper, agg_func, split_out
+):
+    if agg_func in ("cov", "corr") and split_out == 1 and grouper_id == 4:
+        xfail("Unknown issue")
+    elif agg_func in ("cov", "corr") and split_out > 1:
+        xfail("https://github.com/dask/dask/issues/9509")
+
     sort = split_out == 1  # Don't sort for split_out > 1
 
     def call(g, m, **kwargs):
@@ -1150,8 +1133,6 @@ def test_dataframe_aggregations_multilevel(grouper, agg_func, split_out):
 
     # not supported by pandas
     if agg_func != "nunique":
-        if agg_func in ("cov", "corr") and split_out > 1:
-            pytest.skip("https://github.com/dask/dask/issues/9509")
         assert_eq(
             call(pdf.groupby(grouper(pdf), sort=sort)[["c", "d"]], agg_func),
             call(
@@ -2688,22 +2669,15 @@ def test_groupby_large_ints_exception(backend):
 
 
 @pytest.mark.parametrize("by", ["a", "b", "c", ["a", "b"], ["a", "c"]])
-# TODO: Remove the need for `strict=False` below
 @pytest.mark.parametrize(
     "agg",
     [
         "count",
         pytest.param(
-            "mean",
-            marks=pytest.mark.xfail(
-                reason="numeric_only=False not implemented", strict=False
-            ),
+            "mean", marks=pytest.mark.xfail(reason="numeric_only=False not implemented")
         ),
         pytest.param(
-            "std",
-            marks=pytest.mark.xfail(
-                reason="numeric_only=False not implemented", strict=False
-            ),
+            "std", marks=pytest.mark.xfail(reason="numeric_only=False not implemented")
         ),
     ],
 )
@@ -2814,20 +2788,19 @@ def test_groupby_sort_true_split_out():
 @pytest.mark.parametrize("groupby", ["cat_1", ["cat_1", "cat_2"]])
 @pytest.mark.parametrize("observed", [True, False], ids=["observed", "unobserved"])
 def test_groupby_aggregate_categorical_observed(
-    known_cats, ordered_cats, agg_func, groupby, observed
+    xfail, agg_func, known_cats, ordered_cats, groupby, observed
 ):
     if agg_func in ["cov", "corr", "nunique"]:
-        pytest.skip("Not implemented for DataFrameGroupBy yet.")
-    if agg_func == "median" and isinstance(groupby, str):
-        pytest.skip("Can't calculate median over categorical")
-    if agg_func == "median":
-        pytest.skip("Can't deal with unobserved cats in median at the moment")
-    if agg_func in ["sum", "count", "prod"] and groupby != "cat_1":
-        pytest.skip("Gives zeros rather than nans.")
-    if agg_func in ["std", "var"] and observed:
-        pytest.skip("Can't calculate observed with all nans")
-    if agg_func in ["sum", "prod"]:
-        pytest.xfail("Not implemented for category type with pandas 2.0")
+        xfail("Not implemented for DataFrameGroupBy yet.")
+    elif (
+        agg_func in ["mean", "median", "std", "sum", "var", "prod"]
+        and groupby == "cat_1"
+    ):
+        xfail("Can't calculate over categorical")
+    elif agg_func == "median" and not observed:
+        xfail("Unknown issue")
+    elif agg_func == "prod" and not observed and not PANDAS_GE_220:
+        xfail("Fixed in later versions of Pandas")
 
     pdf = pd.DataFrame(
         {

--- a/dask/dataframe/tests/test_map.py
+++ b/dask/dataframe/tests/test_map.py
@@ -13,9 +13,10 @@ from dask.dataframe.utils import assert_eq
 @pytest.mark.parametrize("map_npart", [1, 3])
 @pytest.mark.parametrize("sorted_index", [False, True])
 @pytest.mark.parametrize("sorted_map_index", [False, True])
-def test_series_map(base_npart, map_npart, sorted_index, sorted_map_index):
-    if map_npart != base_npart:
-        pytest.xfail(reason="not yet implemented")
+def test_series_map(xfail, base_npart, map_npart, sorted_index, sorted_map_index):
+    if (not sorted_index or not sorted_map_index) and map_npart != base_npart:
+        xfail(reason="not yet implemented")
+
     base = pd.Series(np.arange(100, dtype="i2"))
     if not sorted_index:
         index = np.arange(100)

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import platform
 import warnings
 
 import numpy as np
@@ -16,6 +17,8 @@ from dask.dataframe.utils import (
     check_meta,
     has_known_categories,
 )
+
+X86 = platform.machine().lower() in ("x86_64", "amd64")
 
 
 def test_merge_indexed_dataframe_to_indexed_dataframe():
@@ -1894,28 +1897,21 @@ def test_concat5():
         )
 
 
+xfail_10558 = pytest.mark.xfail(
+    PANDAS_GE_220 and X86,
+    reason="https://github.com/dask/dask/issues/10558",
+)
+
+
+@pytest.mark.repeat(100)
 @pytest.mark.parametrize(
     "known, cat_index, divisions",
     [
         (True, True, False),
-        pytest.param(
-            True,
-            False,
-            True,
-            marks=pytest.mark.xfail(
-                PANDAS_GE_220, reason="https://github.com/dask/dask/issues/10558"
-            ),
-        ),
+        pytest.param(True, False, True, marks=xfail_10558),
         (True, False, False),
         (False, True, False),
-        pytest.param(
-            False,
-            False,
-            True,
-            marks=pytest.mark.xfail(
-                PANDAS_GE_220, reason="https://github.com/dask/dask/issues/10558"
-            ),
-        ),
+        pytest.param(False, False, True, marks=xfail_10558),
         (False, False, False),
     ],
 )

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -18,8 +18,6 @@ from dask.dataframe.utils import (
     has_known_categories,
 )
 
-X86 = platform.machine().lower() in ("x86_64", "amd64")
-
 
 def test_merge_indexed_dataframe_to_indexed_dataframe():
     A = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6]}, index=[1, 2, 3, 4, 6, 7])
@@ -1898,7 +1896,7 @@ def test_concat5():
 
 
 xfail_10558 = pytest.mark.xfail(
-    PANDAS_GE_220 and X86,
+    PANDAS_GE_220 and platform.machine().lower() in ("x86_64", "amd64"),
     reason="https://github.com/dask/dask/issues/10558",
 )
 

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1903,10 +1903,7 @@ def test_concat5():
             False,
             True,
             marks=pytest.mark.xfail(
-                PANDAS_GE_220,
-                reason="https://github.com/dask/dask/issues/10558",
-                raises=AssertionError,
-                strict=False,
+                PANDAS_GE_220, reason="https://github.com/dask/dask/issues/10558"
             ),
         ),
         (True, False, False),
@@ -1916,10 +1913,7 @@ def test_concat5():
             False,
             True,
             marks=pytest.mark.xfail(
-                PANDAS_GE_220,
-                reason="https://github.com/dask/dask/issues/10558",
-                raises=AssertionError,
-                strict=False,
+                PANDAS_GE_220, reason="https://github.com/dask/dask/issues/10558"
             ),
         ),
         (False, False, False),

--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1903,7 +1903,6 @@ xfail_10558 = pytest.mark.xfail(
 )
 
 
-@pytest.mark.repeat(100)
 @pytest.mark.parametrize(
     "known, cat_index, divisions",
     [

--- a/dask/dataframe/tests/test_shuffle.py
+++ b/dask/dataframe/tests/test_shuffle.py
@@ -225,9 +225,9 @@ def test_set_index_self_index(shuffle_method):
     assert_eq(b, df.set_index(df.index))
 
 
-def test_set_index_names(shuffle_method):
+def test_set_index_names(xfail, shuffle_method):
     if shuffle_method == "disk":
-        pytest.xfail("dsk names in disk shuffle are not deterministic")
+        xfail("dsk names in disk shuffle are not deterministic")
 
     df = pd.DataFrame(
         {"x": np.random.random(100), "y": np.random.random(100) // 0.2},

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import dask.array as da
 import dask.dataframe as dd
-from dask._pandas_compat import PANDAS_GE_300
+from dask._pandas_compat import PANDAS_GE_230, PANDAS_GE_300
 from dask.dataframe.utils import assert_eq
 
 if da._array_expr_enabled():
@@ -524,13 +524,13 @@ def test_ufunc_with_reduction(xfail, redfunc, ufunc, pandas):
     np_redfunc = getattr(np, redfunc)
     np_ufunc = getattr(np, ufunc)
 
-    if (
-        redfunc == "prod"
-        and ufunc in ["conj", "square", "negative", "absolute"]
-        and isinstance(pandas, pd.DataFrame)
-        and not PANDAS_GE_300
-    ):
-        xfail("'prod' overflowing with integer columns")
+    if redfunc == "prod" and isinstance(pandas, pd.DataFrame):
+        if not PANDAS_GE_300 and ufunc in ("conj", "square", "negative", "absolute"):
+            xfail("'prod' overflowing with integer columns")
+        elif (
+            PANDAS_GE_230 and not PANDAS_GE_300 and ufunc in ("ceil", "floor", "trunc")
+        ):
+            xfail("?")
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", RuntimeWarning)

--- a/dask/dataframe/tests/test_ufunc.py
+++ b/dask/dataframe/tests/test_ufunc.py
@@ -4,14 +4,13 @@ import warnings
 
 import pytest
 
-from dask.array.numpy_compat import NUMPY_GE_200
-
 pd = pytest.importorskip("pandas")
 
 import numpy as np
 
 import dask.array as da
 import dask.dataframe as dd
+from dask._pandas_compat import PANDAS_GE_300
 from dask.dataframe.utils import assert_eq
 
 if da._array_expr_enabled():
@@ -159,7 +158,12 @@ def test_ufunc(pandas_input, ufunc):
         "real",
         "imag",
         "angle",
-        "fix",
+        pytest.param(
+            "fix",
+            marks=pytest.mark.xfail(
+                reason="fix calls floor in a way that we do not yet support"
+            ),
+        ),
         "i0",
         "sinc",
         "nan_to_num",
@@ -176,9 +180,6 @@ def test_ufunc_wrapped(ufunc):
     - np.ufunc(pd.Series) => np.ndarray
     """
     from dask.array.utils import assert_eq as da_assert_eq
-
-    if ufunc == "fix":
-        pytest.skip("fix calls floor in a way that we do not yet support")
 
     dafunc = getattr(da, ufunc)
     npfunc = getattr(np, ufunc)
@@ -517,30 +518,19 @@ def test_2args_with_array(ufunc, pandas, darray):
         ),
     ],
 )
-def test_ufunc_with_reduction(redfunc, ufunc, pandas):
+def test_ufunc_with_reduction(xfail, redfunc, ufunc, pandas):
     dask = dd.from_pandas(pandas, 3)
 
     np_redfunc = getattr(np, redfunc)
     np_ufunc = getattr(np, ufunc)
 
     if (
-        NUMPY_GE_200
-        and redfunc == "prod"
-        and ufunc in ("floor", "ceil", "trunc")
-        and isinstance(pandas, pd.DataFrame)
-    ):
-        pytest.skip("Numpy started overflowing while we are casting to float")
-
-    if (
         redfunc == "prod"
         and ufunc in ["conj", "square", "negative", "absolute"]
         and isinstance(pandas, pd.DataFrame)
+        and not PANDAS_GE_300
     ):
-        # TODO(pandas) follow pandas behaviour?
-        # starting with pandas 1.2.0, the ufunc is applied column-wise, and therefore
-        # applied on the integer columns separately, overflowing for those columns
-        # (instead of being applied on 2D ndarray that was converted to float)
-        pytest.xfail("'prod' overflowing with integer columns in pandas 1.2.0")
+        xfail("'prod' overflowing with integer columns")
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", RuntimeWarning)

--- a/dask/dataframe/tseries/tests/test_resample.py
+++ b/dask/dataframe/tseries/tests/test_resample.py
@@ -35,10 +35,10 @@ ME = "ME" if PANDAS_GE_220 else "M"
         )
     ),
 )
-def test_series_resample(obj, method, npartitions, freq, closed, label):
+def test_series_resample(xfail, obj, method, npartitions, freq, closed, label):
     if PANDAS_GE_300 and freq == "D" and closed == "right":
         # Temporary xfail until the upstream issue is resolved
-        pytest.xfail("https://github.com/pandas-dev/pandas/issues/62200")
+        xfail("https://github.com/pandas-dev/pandas/issues/62200")
 
     index = pd.date_range("1-1-2000", "2-15-2000", freq="h")
     index = index.union(pd.date_range("4-15-2000", "5-15-2000", freq="h"))

--- a/dask/dataframe/tseries/tests/test_resample_expr.py
+++ b/dask/dataframe/tseries/tests/test_resample_expr.py
@@ -82,10 +82,10 @@ def test_resample_apis(df, pdf, api, kwargs):
         )
     ),
 )
-def test_series_resample(obj, method, npartitions, freq, closed, label):
+def test_series_resample(xfail, obj, method, npartitions, freq, closed, label):
     if PANDAS_GE_300 and freq == "D" and closed == "right":
         # Temporary xfail until the upstream issue is resolved
-        pytest.xfail("https://github.com/pandas-dev/pandas/issues/62200")
+        xfail("https://github.com/pandas-dev/pandas/issues/62200")
 
     index = pd.date_range("1-1-2000", "2-15-2000", freq="h")
     index = index.union(pd.date_range("4-15-2000", "5-15-2000", freq="h"))

--- a/dask/tests/test_distributed.py
+++ b/dask/tests/test_distributed.py
@@ -288,13 +288,13 @@ def test_to_hdf_distributed(c):
         ),
     ],
 )
-def test_to_hdf_scheduler_distributed(npartitions, c):
+def test_to_hdf_scheduler_distributed(xfail, npartitions, c):
     pytest.importorskip("numpy")
     pytest.importorskip("pandas")
     from dask._pandas_compat import PANDAS_GE_220, PANDAS_GE_230
 
     if PANDAS_GE_220 and not PANDAS_GE_230:
-        pytest.xfail(reason="Poor support for StringDtype")
+        xfail(reason="Poor support for StringDtype")
 
     from dask.dataframe.io.tests.test_hdf import test_to_hdf_schedulers
 
@@ -754,6 +754,7 @@ def test_futures_in_subgraphs(loop_in_thread):
         ddf.compute()
 
 
+@pytest.mark.xfail(reason="roundtripping through arrays doesn't work yet")
 @gen_cluster(client=True)
 async def test_map_partitions_da_input(c, s, a, b):
     """Check that map_partitions can handle a dask array input"""
@@ -762,7 +763,6 @@ async def test_map_partitions_da_input(c, s, a, b):
     da = pytest.importorskip("dask.array")
     pytest.importorskip("dask.dataframe")
     datasets = pytest.importorskip("dask.datasets")
-    pytest.xfail("roundtripping through arrays doesn't work yet")
 
     def f(d, a):
         assert isinstance(d, pd.DataFrame)
@@ -781,7 +781,6 @@ def test_map_partitions_df_input():
     """
     pd = pytest.importorskip("pandas")
     dd = pytest.importorskip("dask.dataframe")
-    pytest.xfail("map partitions can't deal with delayed properly")
 
     def f(d, a):
         assert isinstance(d, pd.DataFrame)

--- a/dask/tests/test_dot.py
+++ b/dask/tests/test_dot.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import copy
 import os
 import re
-import sys
 from functools import partial
 from operator import add, neg
 
@@ -230,11 +229,6 @@ def test_to_graphviz_with_unconnected_node():
         ("svg", SVG),
     ],
 )
-@pytest.mark.xfail(
-    sys.platform == "win32",
-    reason="graphviz/pango on conda-forge currently broken for windows",
-    strict=False,
-)
 def test_dot_graph(tmpdir, format, typ):
     # Use a name that the shell would interpret specially to ensure that we're
     # not vulnerable to shell injection when interacting with `dot`.
@@ -262,11 +256,6 @@ def test_dot_graph(tmpdir, format, typ):
         ("svg", SVG),
     ],
 )
-@pytest.mark.xfail(
-    sys.platform == "win32",
-    reason="graphviz/pango on conda-forge currently broken for windows",
-    strict=False,
-)
 def test_dot_graph_no_filename(tmpdir, format, typ):
     before = tmpdir.listdir()
     result = dot_graph(dsk, filename=None, format=format)
@@ -276,11 +265,6 @@ def test_dot_graph_no_filename(tmpdir, format, typ):
     assert isinstance(result, typ)
 
 
-@pytest.mark.xfail(
-    sys.platform == "win32",
-    reason="graphviz/pango on conda-forge currently broken for windows",
-    strict=False,
-)
 def test_dot_graph_defaults():
     # Test with default args.
     default_name = "mydask"
@@ -316,11 +300,6 @@ def test_cytoscape_graph(tmpdir):
         ("mydaskpdf", None, "mydaskpdf.png", Image),
         ("mydask.pdf.svg", None, "mydask.pdf.svg", SVG),
     ],
-)
-@pytest.mark.xfail(
-    sys.platform == "win32",
-    reason="graphviz/pango on conda-forge currently broken for windows",
-    strict=False,
 )
 def test_filenames_and_formats(tmpdir, filename, format, target, expected_result_type):
     result = dot_graph(dsk, filename=str(tmpdir.join(filename)), format=format)


### PR DESCRIPTION
Remove most cases of
- `pytest.mark.xfail(strict=False)`
- `pytest.xfail` (terminates test immediately, unlike `pytest.mark.xfail`)
- `pytest.skip`
- `pytest.mark.skip`

Instead make the tests run until the end and assert that they do fail.
This PR effectively re-enables _a lot_ of tests that used to be broken a long time ago; later the use case was fixed in dask or upstream but nobody noticed.