### PR TITLE
Fix flaky `test_interrupt`

### DIFF
--- a/dask/tests/test_threaded.py
+++ b/dask/tests/test_threaded.py
@@ -153,7 +153,20 @@ def test_thread_safety():
     assert L == [1] * 20
 
 
-def test_interrupt():
+@pytest.mark.parametrize(
+    "use_barrier",
+    [
+        True,
+        pytest.param(
+            False,
+            marks=pytest.mark.skipif(
+                sys.version_info >= (3, 13) and not sys._is_gil_enabled(),
+                reason="hangs on free-threading python/cpython#150873",
+            ),
+        ),
+    ],
+)
+def test_interrupt(use_barrier):
     # Windows implements `queue.get` using polling,
     # which means we can set an exception to interrupt the call to `get`.
     # Python 3 on other platforms requires sending SIGINT to the main thread.
@@ -165,30 +178,28 @@ def test_interrupt():
         def interrupt_main() -> None:
             signal.pthread_kill(main_thread, signal.SIGINT)
 
-    in_clog_event = threading.Event()
-    clog_event = threading.Event()
+    barrier = threading.Barrier(20) if use_barrier else None
+    tasks_can_end = threading.Event()
 
-    def clog(in_clog_event: threading.Event, clog_event: threading.Event) -> None:
-        in_clog_event.set()
-        clog_event.wait()
+    def f() -> None:
+        if barrier:
+            barrier.wait()
+        tasks_can_end.wait()
 
-    def interrupt(in_clog_event: threading.Event) -> None:
-        in_clog_event.wait()
+    def interrupt() -> None:
+        if barrier:
+            barrier.wait()
         interrupt_main()
 
-    dsk = {("x", i): (clog, in_clog_event, clog_event) for i in range(20)}
-    dsk["x"] = (len, list(dsk.keys()))
-
-    interrupter = threading.Thread(target=interrupt, args=(in_clog_event,))
-    interrupter.start()
+    dsk = {("f", i): (f,) for i in range(19)}
+    dsk["interrupt"] = (interrupt,)
 
     # Use explicitly created ThreadPoolExecutor to avoid leaking threads after
     # the KeyboardInterrupt
-    with ThreadPoolExecutor(CPU_COUNT) as pool:
+    with ThreadPoolExecutor(20) as pool:
         with pytest.raises(KeyboardInterrupt):
-            get(dsk, "x", pool=pool)
-        clog_event.set()
-    interrupter.join()
+            get(dsk, list(dsk), pool=pool)
+        tasks_can_end.set()
 
 
 def warm_up_thread_pool(num_workers: int | None) -> None:


### PR DESCRIPTION
Add conditional skip on free-threading to avoid hitting https://github.com/python/cpython/issues/150873