### PR TITLE
Document rot90 view inconsistency

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -238,7 +238,13 @@ def fliplr(m):
     return flip(m, 1)
 
 
-@derived_from(np)
+@derived_from(
+    np,
+    inconsistencies=(
+        "NumPy describes the result as a view. Dask arrays are lazy, so this "
+        "function returns a new Dask Array graph instead of an in-memory view."
+    ),
+)
 def rot90(m, k=1, axes=(0, 1)):
     axes = tuple(axes)
     if len(axes) != 2:

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -283,6 +283,11 @@ def test_rot90(kwargs, shape):
                 assert_eq(np_r, da_r)
 
 
+def test_rot90_docstring_notes_view_inconsistency():
+    assert "Known inconsistencies" in da.rot90.__doc__
+    assert "returns a new Dask Array graph" in da.rot90.__doc__
+
+
 @pytest.mark.parametrize(
     "x_shape, y_shape, x_chunks, y_chunks",
     [


### PR DESCRIPTION
- [x] Closes #9576
- [x] Tests added / passed
- [ ] Passes `pixi run lint` (not run: `pixi` is not available in my local environment)

This adds a `derived_from(..., inconsistencies=...)` note to `dask.array.rot90` clarifying that the NumPy docstring describes a view, while Dask returns a lazy Dask Array graph rather than an in-memory view.

I also added a regression test that checks the generated `rot90` docstring includes this known inconsistency.

Tests run:
- `PYTHONPATH=/tmp/stubreadline /tmp/dask-test-venv/bin/python -m pytest dask/array/tests/test_routines.py -q -k 'rot90'`
- `PYTHONPATH=/tmp/stubreadline /tmp/dask-test-venv/bin/python -m pytest dask/tests/test_utils.py -q -k 'derived_from'`
- `PYTHONPATH=/tmp/stubreadline /tmp/dask-test-venv/bin/python -m py_compile dask/array/routines.py dask/array/tests/test_routines.py`
- `git diff --check`

AI assistance disclosure: I used an AI coding assistant to help prepare this patch and reviewed the resulting change.