### PR TITLE
Add tests for the array `assert_eq` helper

### DIFF
--- a/dask/array/tests/test_testing.py
+++ b/dask/array/tests/test_testing.py
@@ -30,15 +30,13 @@ def test_assert_eq_array():
         assert_eq(d, x + 1)
 
 
-@pytest.mark.skipif(bool(sys.flags.optimize), reason="Assertions disabled.")
 def test_assert_eq_checks_shape():
     a = da.ones(3, chunks=2)
     assert_eq(a, a)
     with pytest.raises(AssertionError):
-        assert_eq(da.ones(2, chunks=2), da.ones(3, chunks=2))
+        assert_eq(da.ones(2), da.ones(3))
 
 
-@pytest.mark.skipif(bool(sys.flags.optimize), reason="Assertions disabled.")
 def test_assert_eq_check_dtype():
     a = da.ones(3, chunks=2, dtype="i4")
     b = da.ones(3, chunks=2, dtype="f8")
@@ -48,7 +46,6 @@ def test_assert_eq_check_dtype():
     assert_eq(a, b, check_dtype=False)
 
 
-@pytest.mark.skipif(bool(sys.flags.optimize), reason="Assertions disabled.")
 def test_assert_eq_equal_nan():
     a = da.from_array(np.array([1.0, np.nan]), chunks=2)
     b = da.from_array(np.array([1.0, np.nan]), chunks=2)

--- a/dask/array/tests/test_testing.py
+++ b/dask/array/tests/test_testing.py
@@ -24,32 +24,35 @@ def test_assert_eq_checks_scalars():
 def test_assert_eq_array():
     x = np.arange(6).reshape((2, 3))
     d = da.from_array(x, chunks=(1, 3))
-    assert assert_eq(d, x)
-    assert assert_eq(x, x)
-    assert assert_eq(d, d)
+    assert_eq(d, x)
+    assert_eq(d, d)
+    with pytest.raises(AssertionError):
+        assert_eq(d, x + 1)
 
 
 @pytest.mark.skipif(bool(sys.flags.optimize), reason="Assertions disabled.")
 def test_assert_eq_checks_shape():
+    a = da.ones(3, chunks=2)
+    assert_eq(a, a)
     with pytest.raises(AssertionError):
-        assert_eq(np.array([1, 2]), np.array([1, 2, 3]))
+        assert_eq(da.ones(2, chunks=2), da.ones(3, chunks=2))
 
 
 @pytest.mark.skipif(bool(sys.flags.optimize), reason="Assertions disabled.")
 def test_assert_eq_check_dtype():
-    a = np.ones(3, dtype="i4")
-    b = np.ones(3, dtype="f8")
+    a = da.ones(3, chunks=2, dtype="i4")
+    b = da.ones(3, chunks=2, dtype="f8")
     with pytest.raises(AssertionError):
         assert_eq(a, b)
-    # values are equal, so disabling the dtype check should pass
-    assert assert_eq(a, b, check_dtype=False)
+    # values are equal, so disabling the dtype check passes
+    assert_eq(a, b, check_dtype=False)
 
 
 @pytest.mark.skipif(bool(sys.flags.optimize), reason="Assertions disabled.")
 def test_assert_eq_equal_nan():
-    a = np.array([1.0, np.nan])
-    b = np.array([1.0, np.nan])
+    a = da.from_array(np.array([1.0, np.nan]), chunks=2)
+    b = da.from_array(np.array([1.0, np.nan]), chunks=2)
     # NaNs compare equal by default
-    assert assert_eq(a, b)
+    assert_eq(a, b)
     with pytest.raises(AssertionError):
         assert_eq(a, b, equal_nan=False)

--- a/dask/array/tests/test_testing.py
+++ b/dask/array/tests/test_testing.py
@@ -19,3 +19,37 @@ def test_assert_eq_checks_scalars():
     b = np.array([1])[0]
     with pytest.raises(AssertionError):
         assert_eq(a, b)
+
+
+def test_assert_eq_array():
+    x = np.arange(6).reshape((2, 3))
+    d = da.from_array(x, chunks=(1, 3))
+    assert assert_eq(d, x)
+    assert assert_eq(x, x)
+    assert assert_eq(d, d)
+
+
+@pytest.mark.skipif(bool(sys.flags.optimize), reason="Assertions disabled.")
+def test_assert_eq_checks_shape():
+    with pytest.raises(AssertionError):
+        assert_eq(np.array([1, 2]), np.array([1, 2, 3]))
+
+
+@pytest.mark.skipif(bool(sys.flags.optimize), reason="Assertions disabled.")
+def test_assert_eq_check_dtype():
+    a = np.ones(3, dtype="i4")
+    b = np.ones(3, dtype="f8")
+    with pytest.raises(AssertionError):
+        assert_eq(a, b)
+    # values are equal, so disabling the dtype check should pass
+    assert assert_eq(a, b, check_dtype=False)
+
+
+@pytest.mark.skipif(bool(sys.flags.optimize), reason="Assertions disabled.")
+def test_assert_eq_equal_nan():
+    a = np.array([1.0, np.nan])
+    b = np.array([1.0, np.nan])
+    # NaNs compare equal by default
+    assert assert_eq(a, b)
+    with pytest.raises(AssertionError):
+        assert_eq(a, b, equal_nan=False)


### PR DESCRIPTION
The array `assert_eq` testing helper only had a scalar test. This adds tests that cover the common behaviours:

- a matching dask/numpy array pair
- shape mismatch raising `AssertionError`
- dtype mismatch (raising by default, passing with `check_dtype=False`)
- NaN handling (`equal_nan` default vs `equal_nan=False`)

Closes #2682
