### PR TITLE
Document index behaviour when merging on a column

### DIFF
--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -2962,6 +2962,12 @@ class DataFrame(FrameBase):
         an internal ``shuffle``, because shuffling places all rows that have the same
         index in the same partition. To avoid this error, make sure all rows with the
         same ``on``-column value can fit on a single partition.
+
+        When merging on a column rather than on the index, the index of the result
+        is reset within each partition. Because Dask does not know the partition
+        sizes ahead of time, the resulting index is not consecutive and may contain
+        duplicate values. Call ``reset_index`` on the result if you need a unique,
+        consecutive index (this triggers computation of the partition sizes).
         """
         return merge(
             self,

--- a/docs/source/dataframe-joins.rst
+++ b/docs/source/dataframe-joins.rst
@@ -82,3 +82,17 @@ maintains that index, like Parquet.
         right_one, how="left", left_index=True, right_index=True)
     result = result.merge(
         right_two, how="left", left_index=True, right_index=True)
+
+A Note on the Index
+-------------------
+
+When you join or merge on a column rather than on the index, the index of the
+result is not meaningful and is reset within each partition.  Because Dask does
+not know the sizes of the partitions ahead of time, it cannot produce a single
+consecutive index across the whole result without computing the data.  As a
+consequence the resulting index may contain duplicate values, with each
+partition starting its index over from ``0``.
+
+If you need a unique, consecutive index you can call ``reset_index`` on the
+result, but be aware that this requires Dask to compute the partition sizes and
+is therefore not free.


### PR DESCRIPTION
When merging or joining on a column (rather than on the index), the resulting index is reset within each partition and may contain duplicate values. As discussed in #6659 this is expected behaviour, since Dask doesn't know the partition sizes ahead of time.

This documents it in the joins guide and in `DataFrame.merge`'s docstring, and points users to `reset_index` when a unique, consecutive index is needed. Documentation-only change.

Closes #6659
