### PR TITLE
Pandas 3.1: The inplace keyword in DataFrame.drop is deprecated

### DIFF
--- a/dask/dataframe/dask_expr/_expr.py
+++ b/dask/dataframe/dask_expr/_expr.py
@@ -48,7 +48,6 @@ from dask.dataframe.rolling import CombinedOutput, _head_timedelta, overlap_chun
 from dask.dataframe.shuffle import drop_overlap, get_overlap
 from dask.dataframe.utils import (
     clear_known_categories,
-    drop_by_shallow_copy,
     is_scalar,
     raise_on_meta_error,
     valid_divisions,
@@ -1945,7 +1944,6 @@ class ExplodeFrame(ExplodeSeries):
 class Drop(Elemwise):
     _parameters = ["frame", "columns", "errors"]
     _defaults = {"errors": "raise"}
-    operation = staticmethod(drop_by_shallow_copy)
     _preserves_partitioning_information = True
 
     def _simplify_down(self):
@@ -1954,6 +1952,10 @@ class Drop(Elemwise):
             col_op = [col_op]
         columns = [col for col in self.frame.columns if col not in col_op]
         return Projection(self.frame, columns)
+
+    @staticmethod
+    def operation(df, columns, errors):
+        return df.drop(columns=columns, errors=errors)
 
 
 def assign(df, *pairs):

--- a/dask/dataframe/dask_expr/tests/test_describe.py
+++ b/dask/dataframe/dask_expr/tests/test_describe.py
@@ -50,7 +50,7 @@ def _drop_mean(df, col=None):
         df.at["mean", col] = np.nan
         df.dropna(how="all", inplace=True)
     elif isinstance(df, pd.Series):
-        df.drop(labels=["mean"], inplace=True, errors="ignore")
+        df = df.drop(labels=["mean"], errors="ignore")
     else:
         raise NotImplementedError("Expected Series or DataFrame with mean")
     return df

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -75,7 +75,7 @@ def _drop_mean(df, col=None):
         df.at["mean", col] = np.nan
         df.dropna(how="all", inplace=True)
     elif isinstance(df, pd.Series):
-        df.drop(labels=["mean"], inplace=True, errors="ignore")
+        df = df.drop(labels=["mean"], errors="ignore")
     else:
         raise NotImplementedError("Expected Series or DataFrame with mean")
     return df

--- a/dask/dataframe/utils.py
+++ b/dask/dataframe/utils.py
@@ -713,15 +713,6 @@ def valid_divisions(divisions):
     return divisions[-2] <= divisions[-1]
 
 
-def drop_by_shallow_copy(df, columns, errors="raise"):
-    """Use shallow copy to drop columns in place"""
-    df2 = df.copy(deep=False)
-    if not pd.api.types.is_list_like(columns):
-        columns = [columns]
-    df2.drop(columns=columns, inplace=True, errors=errors)
-    return df2
-
-
 class AttributeNotImplementedError(NotImplementedError, AttributeError):
     """NotImplementedError and AttributeError"""
 


### PR DESCRIPTION
Closes #12444

I can't replicate the need for the original hack.
It looks like drop() is always deep, hack or not, with pandas 2.x and always shallow in pandas 3. Maybe it's a legacy of pandas 1.x?

poc.py
```python
import pandas as pd
import numpy as np


def get_np(df):
    arr = df._mgr.blocks[0].values[0]
    while arr.base is not None:
        arr = arr.base
    return arr

def is_shallow(a, b, n):
    np_a = get_np(a)
    np_b = get_np(b)
    np_a[0, 0] = n
    return np_b[0, 0] == n

print(pd.__version__)
a = pd.DataFrame({"x": np.arange(100, dtype=np.int32), "y": np.arange(100, dtype=np.float64)})

b = a.drop(columns="y")
print("DataFrame.drop() is shallow:", is_shallow(a, b, 123))

c = a.copy(deep=False)
c.drop(columns=["y"], inplace=True)
print("drop_by_shallow_copy() is shallow:", is_shallow(a, c, 456))
print("---")
```
```bash
$ for e in mindeps-dataframe py310 py311 py312 py313 nightly; do pixi r -e $e python poc.py; done
2.0.3
DataFrame.drop() is shallow: False
drop_by_shallow_copy() is shallow: False
---
2.1.4
DataFrame.drop() is shallow: False
drop_by_shallow_copy() is shallow: False
---
2.2.3
DataFrame.drop() is shallow: False
drop_by_shallow_copy() is shallow: False
---
2.3.3
DataFrame.drop() is shallow: False
drop_by_shallow_copy() is shallow: False
---
3.0.3
DataFrame.drop() is shallow: True
drop_by_shallow_copy() is shallow: True
---
3.1.0.dev0+1006.g7ecdde9b8e
DataFrame.drop() is shallow: True
/home/crusaderky/github/dask/poc.py:24: Pandas4Warning: The inplace keyword in DataFrame.drop is deprecated and will be removed in a future version. See PDEP-8 for more details:https://pandas.pydata.org/pdeps/0008-inplace-methods-in-pandas.html
  c.drop(columns=["y"], inplace=True)
drop_by_shallow_copy() is shallow: True
---
```