### PR TITLE
fix: support compute=False in array.to_hdf5

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5706,7 +5706,7 @@ def concatenate_axes(arrays, axes):
     return concatenate3(transposelist(arrays, axes, extradims=extradims))
 
 
-def to_hdf5(filename, *args, chunks=True, **kwargs):
+def to_hdf5(filename, *args, chunks=True, compute=True, **kwargs):
     """Store arrays in HDF5 file
 
     This saves several dask arrays into several datapaths in an HDF5 file.
@@ -5717,6 +5717,9 @@ def to_hdf5(filename, *args, chunks=True, **kwargs):
     chunks: tuple or ``True``
         Chunk shape, or ``True`` to pass the chunks from the dask array.
         Defaults to ``True``.
+    compute: bool, optional
+        If True (default), compute immediately. If False, return a
+        ``dask.delayed.Delayed`` object that can be computed later.
 
     Examples
     --------
@@ -5751,7 +5754,21 @@ def to_hdf5(filename, *args, chunks=True, **kwargs):
 
     import h5py
 
-    with h5py.File(filename, mode="a") as f:
+    if compute:
+        with h5py.File(filename, mode="a") as f:
+            dsets = [
+                f.require_dataset(
+                    dp,
+                    shape=x.shape,
+                    dtype=x.dtype,
+                    chunks=tuple(c[0] for c in x.chunks) if chunks is True else chunks,
+                    **kwargs,
+                )
+                for dp, x in data.items()
+            ]
+            store(list(data.values()), dsets)
+    else:
+        f = h5py.File(filename, mode="a")
         dsets = [
             f.require_dataset(
                 dp,
@@ -5762,7 +5779,7 @@ def to_hdf5(filename, *args, chunks=True, **kwargs):
             )
             for dp, x in data.items()
         ]
-        store(list(data.values()), dsets)
+        return store(list(data.values()), dsets, compute=False)
 
 
 def interleave_none(a, b):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2500,9 +2500,9 @@ def test_to_hdf5_compute_false():
 
     with tmpfile(".hdf5") as fn:
         result = x.to_hdf5(fn, "/x", compute=False)
-        assert isinstance(result, tuple)
+        assert hasattr(result, "compute")
 
-        result[0].compute()
+        result.compute()
 
         with h5py.File(fn, mode="r") as f:
             assert_eq(f["/x"][:], x)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -2494,6 +2494,20 @@ def test_to_hdf5():
             assert f["/y"].chunks == (2,)
 
 
+def test_to_hdf5_compute_false():
+    h5py = pytest.importorskip("h5py")
+    x = da.ones((4, 4), chunks=(2, 2))
+
+    with tmpfile(".hdf5") as fn:
+        result = x.to_hdf5(fn, "/x", compute=False)
+        assert isinstance(result, tuple)
+
+        result[0].compute()
+
+        with h5py.File(fn, mode="r") as f:
+            assert_eq(f["/x"][:], x)
+
+
 def test_to_dask_dataframe():
     pytest.importorskip("pandas")
     dd = pytest.importorskip("dask.dataframe")


### PR DESCRIPTION
When `compute=False` is passed to `array.to_hdf5`, the function now returns a `dask.delayed` object instead of computing immediately. This allows users to build larger task graphs that include HDF5 writes.

The HDF5 file is kept open so the delayed graph can reference the dataset objects. When `compute=True` (default), existing behavior is unchanged.

A previous attempt (#6405) was closed.

Closes #1296