### PR TITLE
Add PyPI release workflow

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,13 +4,183 @@ on:
   push:
     tags:
       - "*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version to rehearse, in x.x.x form"
+        required: true
+        type: string
 
 permissions:
   contents: read
 
+env:
+  RELEASE_VERSION: ${{ github.event.inputs.version || github.ref_name }}
+
 jobs:
+  build_pypi:
+    name: Build PyPI distributions
+    if: github.repository == 'dask/dask' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v8.2.0
+      - name: Check tag version
+        run: |
+          release_version="$RELEASE_VERSION"
+          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Release versions must use x.x.x form, got $release_version"
+              exit 1
+          fi
+      - name: Build distributions
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+              export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_DASK="$RELEASE_VERSION"
+          fi
+          uv build --sdist --wheel
+      - name: Check built versions
+        run: |
+          python - <<'PY'
+          import email
+          import glob
+          import os
+          import tarfile
+          import zipfile
+
+          release_version = os.environ["RELEASE_VERSION"]
+          major, minor, patch = release_version.split(".")
+          next_patch_version = f"{major}.{minor}.{int(patch) + 1}"
+
+          wheel_paths = glob.glob("dist/*.whl")
+          sdist_paths = glob.glob("dist/*.tar.gz")
+          if len(wheel_paths) != 1 or len(sdist_paths) != 1:
+              raise SystemExit("Expected exactly one wheel and one sdist")
+
+          with zipfile.ZipFile(wheel_paths[0]) as wheel:
+              metadata_path = next(name for name in wheel.namelist() if name.endswith(".dist-info/METADATA"))
+              wheel_metadata = email.message_from_bytes(wheel.read(metadata_path))
+              wheel_version = wheel_metadata["Version"]
+
+          with tarfile.open(sdist_paths[0], "r:gz") as sdist:
+              pkg_info_path = next(name for name in sdist.getnames() if name.endswith("/PKG-INFO"))
+              pkg_info = sdist.extractfile(pkg_info_path)
+              if pkg_info is None:
+                  raise SystemExit("Could not read sdist PKG-INFO")
+              sdist_metadata = email.message_from_binary_file(pkg_info)
+              sdist_version = sdist_metadata["Version"]
+
+          for artifact, version in {"wheel": wheel_version, "sdist": sdist_version}.items():
+              if version != release_version:
+                  raise SystemExit(f"{artifact} version {version} does not match release {release_version}")
+
+          for artifact, metadata in {"wheel": wheel_metadata, "sdist": sdist_metadata}.items():
+              requirements = metadata.get_all("Requires-Dist") or []
+              distributed_requirements = [
+                  requirement
+                  for requirement in requirements
+                  if requirement.startswith("distributed") and 'extra == "distributed"' in requirement
+              ]
+              if len(distributed_requirements) != 1:
+                  raise SystemExit(
+                      f"{artifact} should declare exactly one distributed extra requirement, "
+                      f"got {distributed_requirements}"
+                  )
+              requirement = distributed_requirements[0].replace(" ", "")
+              if f">={release_version}" not in requirement or f"<{next_patch_version}" not in requirement:
+                  raise SystemExit(
+                      f"{artifact} distributed extra should require distributed>={release_version},"
+                      f"<{next_patch_version}, got {distributed_requirements[0]}"
+                  )
+          PY
+      - run: uvx twine check dist/*
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/*
+          if-no-files-found: error
+
+  smoke_test_pypi:
+    name: Smoke-test distributions on Python ${{ matrix.python-version }}
+    needs: build_pypi
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: astral-sh/setup-uv@v8.2.0
+        with:
+          enable-cache: false
+          ignore-empty-workdir: true
+      - uses: actions/download-artifact@v7
+        with:
+          name: dist
+          path: dist
+      - run: uv venv --python ${{ matrix.python-version }} .venv
+      - run: uv pip install --python .venv/bin/python dist/*.whl
+      - run: |
+          .venv/bin/python - <<'PY'
+          from dask import delayed
+
+          result = delayed(lambda x: x + 1)(1).compute(scheduler="sync")
+          assert result == 2
+          PY
+      - run: uv venv --python ${{ matrix.python-version }} .venv-sdist
+      - run: uv pip install --python .venv-sdist/bin/python dist/*.tar.gz
+      - run: |
+          .venv-sdist/bin/python - <<'PY'
+          from dask import delayed
+
+          result = delayed(lambda x: x + 1)(1).compute(scheduler="sync")
+          assert result == 2
+          PY
+
+  dry_run_publish_pypi:
+    name: Dry-run PyPI publish
+    needs: smoke_test_pypi
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          name: dist
+          path: dist
+      - name: Confirm publish skipped
+        run: |
+          ls -l dist
+          echo "Dry run only; not publishing dask==$RELEASE_VERSION to PyPI."
+
+  publish_pypi:
+    name: Publish PyPI distributions
+    needs: smoke_test_pypi
+    if: github.repository == 'dask/dask' && github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/dask/
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          name: dist
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+
   publish_release:
-    if: github.repository == 'dask/dask'
+    needs: publish_pypi
+    if: github.repository == 'dask/dask' && github.event_name != 'workflow_dispatch'
     permissions:
       # Write permission is required to publish a GitHub release
       contents: write

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -4,23 +4,17 @@ on:
   push:
     tags:
       - "*.*.*"
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Release version to rehearse, in x.x.x form"
-        required: true
-        type: string
 
 permissions:
   contents: read
 
 env:
-  RELEASE_VERSION: ${{ github.event.inputs.version || github.ref_name }}
+  RELEASE_VERSION: ${{ github.ref_name }}
 
 jobs:
   build_pypi:
     name: Build PyPI distributions
-    if: github.repository == 'dask/dask' || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'dask/dask'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -30,73 +24,21 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@v8.2.0
-      - name: Check tag version
+      - name: Check release version and dependency bounds
         run: |
-          release_version="$RELEASE_VERSION"
-          if [[ ! "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "::error::Release versions must use x.x.x form, got $release_version"
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Release versions must use x.x.x form, got $RELEASE_VERSION"
+              exit 1
+          fi
+          major_minor="${RELEASE_VERSION%.*}"
+          patch="${RELEASE_VERSION##*.}"
+          next_patch_version="${major_minor}.$((10#$patch + 1))"
+          if ! grep -Eq "distributed[[:space:]]*>=[[:space:]]*${RELEASE_VERSION},[[:space:]]*<${next_patch_version}" pyproject.toml; then
+              echo "::error::pyproject.toml must pin distributed >=${RELEASE_VERSION},<${next_patch_version}"
               exit 1
           fi
       - name: Build distributions
-        run: |
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-              export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_DASK="$RELEASE_VERSION"
-          fi
-          uv build --sdist --wheel
-      - name: Check built versions
-        run: |
-          python - <<'PY'
-          import email
-          import glob
-          import os
-          import tarfile
-          import zipfile
-
-          release_version = os.environ["RELEASE_VERSION"]
-          major, minor, patch = release_version.split(".")
-          next_patch_version = f"{major}.{minor}.{int(patch) + 1}"
-
-          wheel_paths = glob.glob("dist/*.whl")
-          sdist_paths = glob.glob("dist/*.tar.gz")
-          if len(wheel_paths) != 1 or len(sdist_paths) != 1:
-              raise SystemExit("Expected exactly one wheel and one sdist")
-
-          with zipfile.ZipFile(wheel_paths[0]) as wheel:
-              metadata_path = next(name for name in wheel.namelist() if name.endswith(".dist-info/METADATA"))
-              wheel_metadata = email.message_from_bytes(wheel.read(metadata_path))
-              wheel_version = wheel_metadata["Version"]
-
-          with tarfile.open(sdist_paths[0], "r:gz") as sdist:
-              pkg_info_path = next(name for name in sdist.getnames() if name.endswith("/PKG-INFO"))
-              pkg_info = sdist.extractfile(pkg_info_path)
-              if pkg_info is None:
-                  raise SystemExit("Could not read sdist PKG-INFO")
-              sdist_metadata = email.message_from_binary_file(pkg_info)
-              sdist_version = sdist_metadata["Version"]
-
-          for artifact, version in {"wheel": wheel_version, "sdist": sdist_version}.items():
-              if version != release_version:
-                  raise SystemExit(f"{artifact} version {version} does not match release {release_version}")
-
-          for artifact, metadata in {"wheel": wheel_metadata, "sdist": sdist_metadata}.items():
-              requirements = metadata.get_all("Requires-Dist") or []
-              distributed_requirements = [
-                  requirement
-                  for requirement in requirements
-                  if requirement.startswith("distributed") and 'extra == "distributed"' in requirement
-              ]
-              if len(distributed_requirements) != 1:
-                  raise SystemExit(
-                      f"{artifact} should declare exactly one distributed extra requirement, "
-                      f"got {distributed_requirements}"
-                  )
-              requirement = distributed_requirements[0].replace(" ", "")
-              if f">={release_version}" not in requirement or f"<{next_patch_version}" not in requirement:
-                  raise SystemExit(
-                      f"{artifact} distributed extra should require distributed>={release_version},"
-                      f"<{next_patch_version}, got {distributed_requirements[0]}"
-                  )
-          PY
+        run: uv build --sdist --wheel
       - run: uvx twine check dist/*
       - uses: actions/upload-artifact@v7
         with:
@@ -128,7 +70,18 @@ jobs:
       - run: uv pip install --python .venv/bin/python dist/*.whl
       - run: |
           .venv/bin/python - <<'PY'
+          import importlib.metadata
+          import os
+
+          import dask
           from dask import delayed
+
+          expected_version = os.environ["RELEASE_VERSION"]
+          if dask.__version__ != expected_version:
+              raise SystemExit(f"Expected dask.__version__ {expected_version}, got {dask.__version__}")
+          installed_version = importlib.metadata.version("dask")
+          if installed_version != expected_version:
+              raise SystemExit(f"Expected installed dask {expected_version}, got {installed_version}")
 
           result = delayed(lambda x: x + 1)(1).compute(scheduler="sync")
           assert result == 2
@@ -137,31 +90,27 @@ jobs:
       - run: uv pip install --python .venv-sdist/bin/python dist/*.tar.gz
       - run: |
           .venv-sdist/bin/python - <<'PY'
+          import importlib.metadata
+          import os
+
+          import dask
           from dask import delayed
+
+          expected_version = os.environ["RELEASE_VERSION"]
+          if dask.__version__ != expected_version:
+              raise SystemExit(f"Expected dask.__version__ {expected_version}, got {dask.__version__}")
+          installed_version = importlib.metadata.version("dask")
+          if installed_version != expected_version:
+              raise SystemExit(f"Expected installed dask {expected_version}, got {installed_version}")
 
           result = delayed(lambda x: x + 1)(1).compute(scheduler="sync")
           assert result == 2
           PY
 
-  dry_run_publish_pypi:
-    name: Dry-run PyPI publish
-    needs: smoke_test_pypi
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v7
-        with:
-          name: dist
-          path: dist
-      - name: Confirm publish skipped
-        run: |
-          ls -l dist
-          echo "Dry run only; not publishing dask==$RELEASE_VERSION to PyPI."
-
   publish_pypi:
     name: Publish PyPI distributions
     needs: smoke_test_pypi
-    if: github.repository == 'dask/dask' && github.event_name != 'workflow_dispatch'
+    if: github.repository == 'dask/dask'
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -180,7 +129,7 @@ jobs:
 
   publish_release:
     needs: publish_pypi
-    if: github.repository == 'dask/dask' && github.event_name != 'workflow_dispatch'
+    if: github.repository == 'dask/dask'
     permissions:
       # Write permission is required to publish a GitHub release
       contents: write

--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -8,6 +8,19 @@ Releasing dask and distributed:
     are any remaining blockers. If not, comment on the issue signalling that you
     are starting the release
 
+*   Optional: rehearse the PyPI release workflows from GitHub Actions without
+    publishing to PyPI:
+
+    *   In `dask/dask`, run the `Release Publisher` workflow manually with the
+        version to rehearse.
+    *   In `dask/distributed`, run the `Release Publisher` workflow manually
+        with the Distributed version to rehearse and a Dask version that is
+        already available on PyPI.
+
+    Manual runs build distributions, check versions, run `twine check`, upload
+    and download workflow artifacts, run wheel and source-distribution smoke
+    tests, and run a dry-run publish job. They do not enter the protected PyPI
+    environment, upload to PyPI, or publish GitHub Releases.
 
 *   Update release notes in docs/source/changelog.rst
     Start by using this script to autogenerate some of the changelog entries:
@@ -23,10 +36,10 @@ Releasing dask and distributed:
     Add any new contributors' github links to the end of the file
     (``gh pr view --json author <PR>`` is helpful for getting their usernames).
 
-*   Update the versions in all pyproject.toml
-    *   distributed version in pyproject.toml of dask/dask
-    *   dask version in distributed/pyproject.toml
-    *   pins should be >= the current version but < the next version to allow 
+*   Update dependency bounds in all pyproject.toml files
+    *   `distributed` dependency in pyproject.toml of dask/dask
+    *   `dask` dependency in distributed/pyproject.toml
+    *   pins should be >= the current version but < the next version to allow
         for development installs to resolve correctly
 
 *   Commit
@@ -37,17 +50,55 @@ Releasing dask and distributed:
 
         git tag -a YYYY.M.X -m 'Version YYYY.M.X'
 
-*   Push to GitHub
+*   Push the Dask and Distributed commits and tags to GitHub. You may push both
+    tags together; the Distributed workflow waits until the matching Dask
+    release is available on PyPI before smoke-testing and publishing.
 
         git push https://github.com/dask/dask main --tags
         git push https://github.com/dask/distributed main --tags
 
-*   Upload to PyPI
+*   Wait for the Dask `Release Publisher` workflow to complete successfully.
+    This workflow builds the wheel and source distribution, verifies that their
+    versions match the tag, verifies that the `distributed` extra points at the
+    matching Distributed release, smoke-tests both artifacts on supported Python
+    versions, publishes them to PyPI with Trusted Publishing, and publishes the
+    GitHub Release.
 
-        git clean -xfd
-        python -m pip install build twine
-        pyproject-build
-        twine upload dist/*
+    GitHub Actions pauses at the `pypi` environment for manual approval. Open
+    the Dask `Release Publisher` workflow at
+    https://github.com/dask/dask/actions/workflows/release-publish.yml, select
+    the active release run, and use the `Review deployments` button to approve
+    the PyPI publishing job after the build, checks, and smoke tests are green.
+
+*   Wait for the Distributed `Release Publisher` workflow to complete
+    successfully. The Distributed workflow builds and checks artifacts, waits
+    until both `dask==YYYY.M.X` PyPI artifacts are available, verifies that the
+    Distributed metadata points at the matching Dask release, smoke-tests both
+    artifacts, publishes them to PyPI with Trusted Publishing, and publishes the
+    GitHub Release.
+
+    GitHub Actions pauses at the `pypi` environment for manual approval. Open
+    the Distributed `Release Publisher` workflow at
+    https://github.com/dask/distributed/actions/workflows/release-publish.yml,
+    select the active release run, and use the `Review deployments` button to
+    approve the PyPI publishing job after the build, checks, PyPI wait, and
+    smoke tests are green.
+
+    During the interval between the Dask and Distributed uploads,
+    `dask[distributed]` for the new version may not resolve from PyPI because
+    the matching Distributed package is not available yet. The Distributed
+    workflow keeps this window short by waiting on PyPI before publishing. If
+    the PyPI wait times out or the Distributed publish fails, rerun it after
+    fixing the issue and before announcing the release or proceeding to
+    conda-forge.
+
+    The Dask workflow deliberately checks only the `dask[distributed]` metadata;
+    it does not install that extra before Distributed has been published.
+
+    PyPI publishing skips files that already exist, so rerunning the workflow
+    can recover after a partial success such as a GitHub Release failure.
+    Inspect the PyPI publish logs on reruns to distinguish expected skipped
+    files from unexpected duplicate uploads.
 
 *   AUTOMATED PATH: Wait for [conda-forge](https://conda-forge.github.io) bots to track the
     change to PyPI. This will typically happen in an hour or two.

--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -8,20 +8,6 @@ Releasing dask and distributed:
     are any remaining blockers. If not, comment on the issue signalling that you
     are starting the release
 
-*   Optional: rehearse the PyPI release workflows from GitHub Actions without
-    publishing to PyPI:
-
-    *   In `dask/dask`, run the `Release Publisher` workflow manually with the
-        version to rehearse.
-    *   In `dask/distributed`, run the `Release Publisher` workflow manually
-        with the Distributed version to rehearse and a Dask version that is
-        already available on PyPI.
-
-    Manual runs build distributions, check versions, run `twine check`, upload
-    and download workflow artifacts, run wheel and source-distribution smoke
-    tests, and run a dry-run publish job. They do not enter the protected PyPI
-    environment, upload to PyPI, or publish GitHub Releases.
-
 *   Update release notes in docs/source/changelog.rst
     Start by using this script to autogenerate some of the changelog entries:
 
@@ -37,10 +23,27 @@ Releasing dask and distributed:
     (``gh pr view --json author <PR>`` is helpful for getting their usernames).
 
 *   Update dependency bounds in all pyproject.toml files
-    *   `distributed` dependency in pyproject.toml of dask/dask
-    *   `dask` dependency in distributed/pyproject.toml
+    *   In `dask/pyproject.toml`, set the optional Distributed extra. For
+        example, for a `2026.6.0` release:
+
+            [project.optional-dependencies]
+            distributed = ["distributed >=2026.6.0,<2026.6.1"]
+
+    *   In `distributed/pyproject.toml`, set the required Dask dependency. For
+        example, for a `2026.6.0` release:
+
+            dependencies = [
+                "dask >=2026.6.0,<2026.6.1",
+                ...
+            ]
+
     *   pins should be >= the current version but < the next version to allow
         for development installs to resolve correctly
+
+    Dask can be released while its optional `distributed` extra points at the
+    not-yet-published matching Distributed release. Distributed cannot be
+    published before the matching Dask release is available, because Dask is a
+    required dependency.
 
 *   Commit
 
@@ -58,24 +61,25 @@ Releasing dask and distributed:
         git push https://github.com/dask/distributed main --tags
 
 *   Wait for the Dask `Release Publisher` workflow to complete successfully.
-    This workflow builds the wheel and source distribution, verifies that their
-    versions match the tag, verifies that the `distributed` extra points at the
-    matching Distributed release, smoke-tests both artifacts on supported Python
-    versions, publishes them to PyPI with Trusted Publishing, and publishes the
-    GitHub Release.
+    This workflow builds the wheel and source distribution, verifies that
+    `pyproject.toml` points the `distributed` extra at the matching Distributed
+    release, smoke-tests both artifacts on supported Python versions, publishes
+    them to PyPI with Trusted Publishing, and publishes the GitHub Release.
 
     GitHub Actions pauses at the `pypi` environment for manual approval. Open
     the Dask `Release Publisher` workflow at
     https://github.com/dask/dask/actions/workflows/release-publish.yml, select
     the active release run, and use the `Review deployments` button to approve
     the PyPI publishing job after the build, checks, and smoke tests are green.
+    This approval gate is configured explicitly by the `publish_pypi` job's
+    `environment: pypi` setting.
 
 *   Wait for the Distributed `Release Publisher` workflow to complete
     successfully. The Distributed workflow builds and checks artifacts, waits
-    until both `dask==YYYY.M.X` PyPI artifacts are available, verifies that the
-    Distributed metadata points at the matching Dask release, smoke-tests both
-    artifacts, publishes them to PyPI with Trusted Publishing, and publishes the
-    GitHub Release.
+    until both `dask==YYYY.M.X` PyPI artifacts are available, verifies that
+    `distributed/pyproject.toml` points at the matching Dask release,
+    smoke-tests both artifacts, publishes them to PyPI with Trusted Publishing,
+    and publishes the GitHub Release.
 
     GitHub Actions pauses at the `pypi` environment for manual approval. Open
     the Distributed `Release Publisher` workflow at
@@ -92,13 +96,14 @@ Releasing dask and distributed:
     fixing the issue and before announcing the release or proceeding to
     conda-forge.
 
-    The Dask workflow deliberately checks only the `dask[distributed]` metadata;
-    it does not install that extra before Distributed has been published.
+    The Dask workflow deliberately checks only the `dask[distributed]`
+    dependency bound; it does not install that extra before Distributed has
+    been published.
 
-    PyPI publishing skips files that already exist, so rerunning the workflow
-    can recover after a partial success such as a GitHub Release failure.
-    Inspect the PyPI publish logs on reruns to distinguish expected skipped
-    files from unexpected duplicate uploads.
+    PyPI publishing uses `skip-existing`, so rerunning the workflow after PyPI
+    succeeds can skip the already-uploaded wheel and source distribution and
+    continue to the GitHub Release step. Inspect the PyPI publish logs on reruns
+    to distinguish expected skipped files from unexpected duplicate uploads.
 
 *   AUTOMATED PATH: Wait for [conda-forge](https://conda-forge.github.io) bots to track the
     change to PyPI. This will typically happen in an hour or two.


### PR DESCRIPTION
This moves the release procedure from a manual process done on a laptop to automated on GitHub Actions.  This uses the Trusted Publisher functionality on PyPI that has, I think, become somewhat standard.  There's still a manual approval process in the chain.  

When reviewing I recommend looking at the release procedure doc.  

For an example run see https://github.com/mrocklin/dask/actions/runs/27209613416

See https://github.com/dask/community/issues/444

Sibling PR for distributed at https://github.com/dask/distributed/pull/9297