### PR TITLE
`test_concat_categorical` is still flaky on Pandas 2.0

### DIFF
--- a/dask/dataframe/tests/test_multi.py
+++ b/dask/dataframe/tests/test_multi.py
@@ -1896,8 +1896,13 @@ def test_concat5():
 
 
 xfail_10558 = pytest.mark.xfail(
-    PANDAS_GE_220 and platform.machine().lower() in ("x86_64", "amd64"),
+    # Always fails on Pandas >=2.2 x64 (not on ARM)
+    # Mildly flaky on Pandas 2.0
+    PANDAS_GE_220
+    and platform.machine().lower() in ("x86_64", "amd64")
+    or not PANDAS_GE_210,
     reason="https://github.com/dask/dask/issues/10558",
+    strict=PANDAS_GE_210,
 )
 
 


### PR DESCRIPTION
xref #10558