### PR TITLE
Fix release publisher warnings

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -141,11 +141,11 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - uses: release-drafter/release-drafter@v7
         with:
-          disable-autolabeler: true
           # Override the Release name/tag/version with the actual tag name
           name: ${{ env.RELEASE_VERSION }}
           tag: ${{ env.RELEASE_VERSION }}
           version: ${{ env.RELEASE_VERSION }}
+          commitish: ${{ github.sha }}
           # Publish the Release
           publish: true
         env:


### PR DESCRIPTION
Release Drafter v7 no longer accepts disable-autolabeler, so remove that stale input.

Pass github.sha as commitish so tag-triggered releases target the release commit instead of falling back to the default branch.