### PR TITLE
Support composite expressions with `__dask_exprs__` protocol

### DIFF
--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -36,10 +36,15 @@ def _unpack_collections(o):
     if isinstance(o, Expr):
         return o
 
-    if hasattr(o, "expr") and not isinstance(o, Delayed):
-        return o.expr
-    else:
-        return o
+    if not isinstance(o, Delayed):
+        try:
+            expr = o.expr
+        except AttributeError:
+            pass
+        else:
+            if isinstance(expr, Expr):
+                return expr
+    return o
 
 
 class Expr:
@@ -1272,6 +1277,38 @@ class _ExprSequence(Expr):
         return _HLGExprSequence(*hlgs)
 
 
+class CompositeExpr(Expr):
+    """Private expression grouping many child expressions into one collection."""
+
+    _parameters = ["collection"]
+
+    @property
+    def collection(self):
+        return self.operand("collection")
+
+    @property
+    def exprs(self):
+        return tuple(self.operands[1:])
+
+    def dependencies(self):
+        return self.exprs
+
+    def _layer(self) -> dict:
+        return {}
+
+    def __dask_keys__(self) -> list:
+        return [expr.__dask_keys__() for expr in self.exprs]
+
+    def _operands_for_repr(self):
+        return [
+            f"collection={type(self.collection).__name__}",
+            f"nexprs={len(self.exprs)}",
+        ]
+
+    def finalize_compute(self):
+        return CompositeFinalizeCompute(self.collection, *self.exprs)
+
+
 class _AnnotationsTombstone: ...
 
 
@@ -1348,6 +1385,23 @@ class HLGFinalizeCompute(HLGExpr):
 
     def __dask_keys__(self):
         return [self._name]
+
+
+class CompositeFinalizeCompute(CompositeExpr):
+    def __dask_keys__(self):
+        return [self._name]
+
+    def _layer(self) -> dict:
+        func, extra_args = self.collection.__dask_postcompute__()
+        keys = [expr.__dask_keys__() for expr in self.exprs]
+        return {
+            self._name: Task(
+                self._name,
+                func,
+                _convert_dask_keys(keys),
+                *extra_args,
+            )
+        }
 
 
 class ProhibitReuse(Expr):

--- a/dask/base.py
+++ b/dask/base.py
@@ -658,9 +658,7 @@ def optimize(*args, traverse=True, **kwargs):
     for a, aexpr in zip(collections, collection_exprs, strict=True):
         if isinstance(aexpr, CompositeExpr):
             postpersists.append(
-                _rebuild_composite_collection(
-                    a, aexpr, graph, cull_to_child_keys=False
-                )
+                _rebuild_composite_collection(a, aexpr, graph, cull_to_child_keys=False)
             )
         else:
             r, s = a.__dask_postpersist__()

--- a/dask/base.py
+++ b/dask/base.py
@@ -239,14 +239,16 @@ def is_dask_collection(x) -> bool:
         # is published, we hope to be able to rewrite this method completely.
         # Read: https://github.com/dask/dask/pull/10676
         return True
-    elif pkg_name.startswith("dask.dataframe.dask_expr"):
-        return True
-    elif pkg_name.startswith("dask.array._array_expr"):
-        return True
-    elif pkg_name == "dask_array._collection":
-        return True
-    elif pkg_name.startswith("dask_array"):
-        return False
+
+    try:
+        expr = x.expr
+    except AttributeError:
+        pass
+    else:
+        from dask._expr import Expr
+
+        if isinstance(expr, Expr):
+            return True
 
     # xarray, pint, and possibly other wrappers always define a __dask_graph__ method,
     # but it may return None if they wrap around a non-dask object.

--- a/dask/base.py
+++ b/dask/base.py
@@ -240,13 +240,16 @@ def is_dask_collection(x) -> bool:
         # Read: https://github.com/dask/dask/pull/10676
         return True
 
+    from dask._expr import Expr
+
+    if isinstance(x, Expr):
+        return True
+
     try:
         expr = x.expr
     except AttributeError:
         pass
     else:
-        from dask._expr import Expr
-
         if isinstance(expr, Expr):
             return True
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -435,21 +435,69 @@ def collections_to_expr(
         collections = [collections]
     if not collections:
         raise ValueError("No collections provided")
-    from dask._expr import HLGExpr, _ExprSequence
+    from dask._expr import CompositeExpr, Expr, HLGExpr, _ExprSequence
 
     graphs = []
     for coll in collections:
         from dask.delayed import Delayed
 
-        if isinstance(coll, Delayed) or not hasattr(coll, "expr"):
+        if isinstance(coll, Delayed):
             graphs.append(HLGExpr.from_collection(coll, optimize_graph=optimize_graph))
         else:
-            graphs.append(coll.expr)
+            expr = getattr(coll, "expr", None)
+            if isinstance(expr, Expr):
+                graphs.append(expr)
+                continue
+
+            dask_exprs = getattr(coll, "__dask_exprs__", None)
+            if dask_exprs is not None:
+                exprs = dask_exprs()
+                if exprs is not None:
+                    exprs = tuple(exprs)
+                    if exprs:
+                        graphs.append(CompositeExpr(coll, *exprs))
+                        continue
+            graphs.append(HLGExpr.from_collection(coll, optimize_graph=optimize_graph))
 
     if len(graphs) > 1 or is_iterable:
         return _ExprSequence(*graphs)
     else:
         return graphs[0]
+
+
+def _exprs_for_collections(expr: Expr, ncollections: int) -> list[Expr]:
+    from dask._expr import _ExprSequence
+
+    if isinstance(expr, _ExprSequence):
+        exprs = list(expr.operands)
+    else:
+        exprs = [expr]
+    if len(exprs) != ncollections:
+        raise RuntimeError(
+            "Expression collection count does not match input collection count"
+        )
+    return exprs
+
+
+def _rebuild_composite_collection(
+    collection, expr: Expr, dsk: dict, *, cull_to_child_keys: bool
+):
+    from dask._collections import new_collection
+
+    rebuilt_exprs = []
+    for child_expr in expr.exprs:
+        child = new_collection(child_expr)
+        rebuild, state = child.__dask_postpersist__()
+        child_keys = list(flatten(child_expr.__dask_keys__()))
+        if cull_to_child_keys:
+            child_dsk = {key: dsk[key] for key in child_keys}
+        else:
+            from dask.optimization import cull
+
+            child_dsk, _ = cull(dsk, child_keys)
+        rebuilt = rebuild(child_dsk, *state)
+        rebuilt_exprs.append(rebuilt.expr)
+    return collection.__dask_rebuild_from_exprs__(rebuilt_exprs)
 
 
 def unpack_collections(*args, traverse=True):
@@ -589,11 +637,30 @@ def optimize(*args, traverse=True, **kwargs):
         return args
 
     dsk = collections_to_expr(collections)
+    collection_exprs = _exprs_for_collections(dsk, len(collections))
+
+    from dask._expr import CompositeExpr
+
+    if any(isinstance(expr, CompositeExpr) for expr in collection_exprs):
+        dsk = dsk.optimize()
+        try:
+            collection_exprs = _exprs_for_collections(dsk, len(collections))
+        except RuntimeError:
+            collection_exprs = [None] * len(collections)
+
+    graph = dsk.__dask_graph__()
 
     postpersists = []
-    for a in collections:
-        r, s = a.__dask_postpersist__()
-        postpersists.append(r(dsk.__dask_graph__(), *s))
+    for a, aexpr in zip(collections, collection_exprs, strict=True):
+        if isinstance(aexpr, CompositeExpr):
+            postpersists.append(
+                _rebuild_composite_collection(
+                    a, aexpr, graph, cull_to_child_keys=False
+                )
+            )
+        else:
+            r, s = a.__dask_postpersist__()
+            postpersists.append(r(graph, *s))
 
     return repack(postpersists)
 
@@ -1003,20 +1070,46 @@ def persist(*args, traverse=True, optimize_graph=True, scheduler=None, **kwargs)
         results = client.persist(collections, optimize_graph=optimize_graph, **kwargs)
         return repack(results)
 
+    from dask._expr import CompositeExpr
+
     expr = collections_to_expr(collections, optimize_graph)
+    collection_exprs = _exprs_for_collections(expr, len(collections))
+    has_composite = any(isinstance(expr, CompositeExpr) for expr in collection_exprs)
     expr = expr.optimize()
+    if has_composite:
+        try:
+            collection_exprs = _exprs_for_collections(expr, len(collections))
+        except RuntimeError:
+            collection_exprs = [None] * len(collections)
+    else:
+        collection_exprs = [None] * len(collections)
+
     keys, postpersists = [], []
-    for a, akeys in zip(collections, expr.__dask_keys__(), strict=True):
+    for a, aexpr, akeys in zip(
+        collections, collection_exprs, expr.__dask_keys__(), strict=True
+    ):
         a_keys = list(flatten(akeys))
-        rebuild, state = a.__dask_postpersist__()
         keys.extend(a_keys)
-        postpersists.append((rebuild, a_keys, state))
+        if isinstance(aexpr, CompositeExpr):
+            postpersists.append((a, aexpr, None))
+        else:
+            rebuild, state = a.__dask_postpersist__()
+            postpersists.append((rebuild, a_keys, state))
 
     with shorten_traceback():
         results = schedule(expr, keys, **kwargs)
 
     d = dict(zip(keys, results))
-    results2 = [r({k: d[k] for k in ks}, *s) for r, ks, s in postpersists]
+    results2 = []
+    for rebuild, a_keys, state in postpersists:
+        if state is None:
+            results2.append(
+                _rebuild_composite_collection(
+                    rebuild, a_keys, d, cull_to_child_keys=True
+                )
+            )
+        else:
+            results2.append(rebuild({k: d[k] for k in a_keys}, *state))
     return repack(results2)
 
 

--- a/dask/base.py
+++ b/dask/base.py
@@ -474,17 +474,20 @@ def collections_to_expr(
         return graphs[0]
 
 
-def _exprs_for_collections(expr: Expr) -> list[Expr]:
-    from dask._expr import _ExprSequence
-
-    if isinstance(expr, _ExprSequence):
-        return list(expr.operands)
-    return [expr]
-
-
 def _rebuild_composite_collection(
     collection, expr: Expr, dsk: dict, *, cull_to_child_keys: bool
 ):
+    """Rebuild a collection that is represented by several child expressions.
+
+    Collections using ``__dask_exprs__`` expose their children separately so the
+    expression optimizer can still see and rewrite each child graph. After
+    optimization or persistence, rebuild each child collection from the new graph
+    and ask the original collection to assemble an equivalent composite object.
+
+    ``persist`` passes only computed key results and can select the child keys
+    directly. ``optimize`` passes a full optimized graph, so each child graph must
+    be culled from that graph before rebuilding the child collection.
+    """
     from dask._collections import new_collection
 
     rebuilt_exprs = []
@@ -639,8 +642,10 @@ def optimize(*args, traverse=True, **kwargs):
     if not collections:
         return args
 
+    from dask._expr import CompositeExpr, _ExprSequence
+
     dsk = collections_to_expr(collections)
-    collection_exprs = _exprs_for_collections(dsk)
+    collection_exprs = list(dsk.operands) if isinstance(dsk, _ExprSequence) else [dsk]
     if len(collection_exprs) != len(collections):
         raise RuntimeError(
             "Expression collection count does not match input collection count: "
@@ -648,11 +653,11 @@ def optimize(*args, traverse=True, **kwargs):
             "collections"
         )
 
-    from dask._expr import CompositeExpr
-
     if any(isinstance(expr, CompositeExpr) for expr in collection_exprs):
         dsk = dsk.optimize()
-        collection_exprs = _exprs_for_collections(dsk)
+        collection_exprs = (
+            list(dsk.operands) if isinstance(dsk, _ExprSequence) else [dsk]
+        )
         if len(collection_exprs) != len(collections):
             collection_exprs = [None] * len(collections)
 
@@ -1076,10 +1081,12 @@ def persist(*args, traverse=True, optimize_graph=True, scheduler=None, **kwargs)
         results = client.persist(collections, optimize_graph=optimize_graph, **kwargs)
         return repack(results)
 
-    from dask._expr import CompositeExpr
+    from dask._expr import CompositeExpr, _ExprSequence
 
     expr = collections_to_expr(collections, optimize_graph)
-    collection_exprs = _exprs_for_collections(expr)
+    collection_exprs = (
+        list(expr.operands) if isinstance(expr, _ExprSequence) else [expr]
+    )
     if len(collection_exprs) != len(collections):
         raise RuntimeError(
             "Expression collection count does not match input collection count: "
@@ -1089,7 +1096,9 @@ def persist(*args, traverse=True, optimize_graph=True, scheduler=None, **kwargs)
     has_composite = any(isinstance(expr, CompositeExpr) for expr in collection_exprs)
     expr = expr.optimize()
     if has_composite:
-        collection_exprs = _exprs_for_collections(expr)
+        collection_exprs = (
+            list(expr.operands) if isinstance(expr, _ExprSequence) else [expr]
+        )
         if len(collection_exprs) != len(collections):
             collection_exprs = [None] * len(collections)
     else:

--- a/dask/base.py
+++ b/dask/base.py
@@ -243,6 +243,10 @@ def is_dask_collection(x) -> bool:
         return True
     elif pkg_name.startswith("dask.array._array_expr"):
         return True
+    elif pkg_name == "dask_array._collection":
+        return True
+    elif pkg_name.startswith("dask_array"):
+        return False
 
     # xarray, pint, and possibly other wrappers always define a __dask_graph__ method,
     # but it may return None if they wrap around a non-dask object.

--- a/dask/base.py
+++ b/dask/base.py
@@ -469,18 +469,12 @@ def collections_to_expr(
         return graphs[0]
 
 
-def _exprs_for_collections(expr: Expr, ncollections: int) -> list[Expr]:
+def _exprs_for_collections(expr: Expr) -> list[Expr]:
     from dask._expr import _ExprSequence
 
     if isinstance(expr, _ExprSequence):
-        exprs = list(expr.operands)
-    else:
-        exprs = [expr]
-    if len(exprs) != ncollections:
-        raise RuntimeError(
-            "Expression collection count does not match input collection count"
-        )
-    return exprs
+        return list(expr.operands)
+    return [expr]
 
 
 def _rebuild_composite_collection(
@@ -641,15 +635,20 @@ def optimize(*args, traverse=True, **kwargs):
         return args
 
     dsk = collections_to_expr(collections)
-    collection_exprs = _exprs_for_collections(dsk, len(collections))
+    collection_exprs = _exprs_for_collections(dsk)
+    if len(collection_exprs) != len(collections):
+        raise RuntimeError(
+            "Expression collection count does not match input collection count: "
+            f"got {len(collection_exprs)} expressions for {len(collections)} "
+            "collections"
+        )
 
     from dask._expr import CompositeExpr
 
     if any(isinstance(expr, CompositeExpr) for expr in collection_exprs):
         dsk = dsk.optimize()
-        try:
-            collection_exprs = _exprs_for_collections(dsk, len(collections))
-        except RuntimeError:
+        collection_exprs = _exprs_for_collections(dsk)
+        if len(collection_exprs) != len(collections):
             collection_exprs = [None] * len(collections)
 
     graph = dsk.__dask_graph__()
@@ -1075,13 +1074,18 @@ def persist(*args, traverse=True, optimize_graph=True, scheduler=None, **kwargs)
     from dask._expr import CompositeExpr
 
     expr = collections_to_expr(collections, optimize_graph)
-    collection_exprs = _exprs_for_collections(expr, len(collections))
+    collection_exprs = _exprs_for_collections(expr)
+    if len(collection_exprs) != len(collections):
+        raise RuntimeError(
+            "Expression collection count does not match input collection count: "
+            f"got {len(collection_exprs)} expressions for {len(collections)} "
+            "collections"
+        )
     has_composite = any(isinstance(expr, CompositeExpr) for expr in collection_exprs)
     expr = expr.optimize()
     if has_composite:
-        try:
-            collection_exprs = _exprs_for_collections(expr, len(collections))
-        except RuntimeError:
+        collection_exprs = _exprs_for_collections(expr)
+        if len(collection_exprs) != len(collections):
             collection_exprs = [None] * len(collections)
     else:
         collection_exprs = [None] * len(collections)

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -21,6 +21,7 @@ from dask.base import (
     clone_key,
     compute,
     compute_as_if_collection,
+    collections_to_expr,
     get_collection_names,
     get_name_from_key,
     get_scheduler,
@@ -33,6 +34,8 @@ from dask.base import (
     unpack_collections,
     visualize,
 )
+from dask._dispatch import get_collection_type
+from dask._expr import Expr
 from dask.core import validate_key
 from dask.delayed import Delayed, delayed
 from dask.diagnostics import Profiler
@@ -269,6 +272,118 @@ class Tuple(DaskMethodsMixin):
         return Tuple(dsk, keys)
 
 
+class CompositeScalarMeta: ...
+
+
+class LiteralExpr(Expr):
+    _parameters = ["name", "value"]
+
+    @property
+    def name(self):
+        return self.operand("name")
+
+    @property
+    def value(self):
+        return self.operand("value")
+
+    @property
+    def _name(self):
+        return self.name
+
+    @property
+    def _meta(self):
+        return CompositeScalarMeta()
+
+    def _layer(self):
+        return {self._name: self.value}
+
+    def __dask_keys__(self):
+        return [self._name]
+
+
+class ExprScalar(DaskMethodsMixin):
+    __dask_scheduler__ = staticmethod(dask.threaded.get)
+    __dask_optimize__ = None
+
+    def __init__(self, expr):
+        self._expr = expr
+
+    @property
+    def expr(self):
+        return self._expr
+
+    def __dask_graph__(self):
+        return self.expr.__dask_graph__()
+
+    def __dask_keys__(self):
+        return self.expr.__dask_keys__()
+
+    def __dask_layers__(self):
+        return (self.expr._name,)
+
+    def __dask_tokenize__(self):
+        return self.expr
+
+    def __dask_postcompute__(self):
+        return _first, ()
+
+    def __dask_postpersist__(self):
+        return ExprScalar._rebuild, (self.expr,)
+
+    @staticmethod
+    def _rebuild(dsk, expr):
+        return ExprScalar(LiteralExpr(expr.name, dsk[expr.__dask_keys__()[0]]))
+
+
+@get_collection_type.register(CompositeScalarMeta)
+def get_collection_type_composite_scalar(_):
+    return ExprScalar
+
+
+def _first(results):
+    return results[0]
+
+
+def _finalize_expr_tuple(results):
+    return tuple(result[0] for result in results)
+
+
+class ExprTuple(DaskMethodsMixin):
+    __dask_scheduler__ = staticmethod(dask.threaded.get)
+    __dask_optimize__ = None
+
+    def __init__(self, *children):
+        self.children = tuple(children)
+
+    def __dask_exprs__(self):
+        return tuple(child.expr for child in self.children)
+
+    def __dask_rebuild_from_exprs__(self, exprs):
+        return ExprTuple(*(ExprScalar(expr) for expr in exprs))
+
+    def __dask_graph__(self):
+        return merge(*(child.__dask_graph__() for child in self.children))
+
+    def __dask_keys__(self):
+        return [child.__dask_keys__() for child in self.children]
+
+    def __dask_layers__(self):
+        return tuple(child.expr._name for child in self.children)
+
+    def __dask_tokenize__(self):
+        return self.children
+
+    def __dask_postcompute__(self):
+        return _finalize_expr_tuple, ()
+
+    def __dask_postpersist__(self):
+        return ExprTuple._rebuild, (self.children,)
+
+    @staticmethod
+    def _rebuild(dsk, children):
+        return ExprTuple(*(ExprScalar._rebuild(dsk, child.expr) for child in children))
+
+
 def test_custom_collection():
     dsk = {("x", h1): 1, ("x", h2): 2}
     dsk2 = {("y", h1): (add, ("x", h1), ("x", h2)), ("y", h2): (add, ("y", h1), 1)}
@@ -345,6 +460,111 @@ def test_custom_collection():
     rebuild, args = z.__dask_postpersist__()
     z3 = rebuild({"z3": 70}, *args, rename={"z": "z3"})
     assert z3.compute() == (70,)
+
+
+def test_collections_to_expr_uses_composite_protocol():
+    from dask._expr import CompositeExpr
+
+    coll = ExprTuple(ExprScalar(LiteralExpr("a", 1)), ExprScalar(LiteralExpr("b", 2)))
+
+    expr = collections_to_expr(coll)
+
+    assert isinstance(expr, CompositeExpr)
+    assert expr.__dask_keys__() == [["a"], ["b"]]
+    assert expr.__dask_graph__() == {"a": 1, "b": 2}
+
+
+def test_collections_to_expr_ignores_non_dask_expr_attribute():
+    from dask._expr import CompositeExpr
+
+    class ExprAttributeTuple(ExprTuple):
+        @property
+        def expr(self):
+            return "not-a-dask-expression"
+
+    coll = ExprAttributeTuple(
+        ExprScalar(LiteralExpr("a", 1)), ExprScalar(LiteralExpr("b", 2))
+    )
+
+    expr = collections_to_expr(coll)
+
+    assert isinstance(expr, CompositeExpr)
+    assert dask.compute(coll) == ((1, 2),)
+
+
+def test_composite_expr_compute_returns_one_collection_result():
+    coll = ExprTuple(ExprScalar(LiteralExpr("a", 1)), ExprScalar(LiteralExpr("b", 2)))
+    raw = ExprScalar(LiteralExpr("raw", 3))
+
+    assert dask.compute(coll) == ((1, 2),)
+    assert dask.compute(coll, raw) == ((1, 2), 3)
+
+
+def test_composite_expr_persist_rebuilds_collection():
+    coll = ExprTuple(ExprScalar(LiteralExpr("a", 1)), ExprScalar(LiteralExpr("b", 2)))
+    raw = ExprScalar(LiteralExpr("raw", 3))
+    legacy = Tuple({"legacy": 4}, ["legacy"])
+
+    (persisted,) = dask.persist(coll, scheduler="single-threaded")
+
+    assert isinstance(persisted, ExprTuple)
+    assert [child.expr.value for child in persisted.children] == [1, 2]
+    assert persisted.compute(scheduler="single-threaded") == (1, 2)
+
+    persisted_coll, persisted_raw = dask.persist(
+        coll, raw, scheduler="single-threaded"
+    )
+    assert isinstance(persisted_coll, ExprTuple)
+    assert isinstance(persisted_raw, ExprScalar)
+    assert persisted_coll.compute(scheduler="single-threaded") == (1, 2)
+    assert persisted_raw.compute(scheduler="single-threaded") == 3
+
+    persisted_coll, persisted_legacy = dask.persist(
+        coll, legacy, scheduler="single-threaded"
+    )
+    assert isinstance(persisted_coll, ExprTuple)
+    assert isinstance(persisted_legacy, Tuple)
+    assert persisted_coll.compute(scheduler="single-threaded") == (1, 2)
+    assert persisted_legacy.compute(scheduler="single-threaded") == (4,)
+
+
+def test_composite_expr_optimize_rebuilds_collection():
+    coll = ExprTuple(ExprScalar(LiteralExpr("a", 1)), ExprScalar(LiteralExpr("b", 2)))
+    raw = ExprScalar(LiteralExpr("raw", 3))
+    legacy = Tuple({"legacy": 4}, ["legacy"])
+
+    (optimized,) = dask.optimize(coll)
+
+    assert isinstance(optimized, ExprTuple)
+    assert [child.expr.value for child in optimized.children] == [1, 2]
+    assert optimized.compute(scheduler="single-threaded") == (1, 2)
+
+    optimized_coll, optimized_raw = dask.optimize(coll, raw)
+    assert isinstance(optimized_coll, ExprTuple)
+    assert isinstance(optimized_raw, ExprScalar)
+    assert optimized_coll.compute(scheduler="single-threaded") == (1, 2)
+    assert optimized_raw.compute(scheduler="single-threaded") == 3
+
+    optimized_coll, optimized_legacy = dask.optimize(coll, legacy)
+    assert isinstance(optimized_coll, ExprTuple)
+    assert isinstance(optimized_legacy, Tuple)
+    assert optimized_coll.compute(scheduler="single-threaded") == (1, 2)
+    assert optimized_legacy.compute(scheduler="single-threaded") == (4,)
+
+
+def test_collections_to_expr_falls_back_for_empty_composite_protocol():
+    from dask._expr import HLGExpr
+
+    class FallbackTuple(Tuple):
+        def __dask_exprs__(self):
+            return None
+
+    coll = FallbackTuple({"x": 1}, ["x"])
+
+    expr = collections_to_expr(coll)
+
+    assert isinstance(expr, HLGExpr)
+    assert expr.__dask_keys__() == ["x"]
 
 
 def test_compute_no_opt():

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -21,7 +21,6 @@ from dask.base import (
     clone_key,
     compute,
     compute_as_if_collection,
-    collections_to_expr,
     get_collection_names,
     get_name_from_key,
     get_scheduler,
@@ -34,8 +33,6 @@ from dask.base import (
     unpack_collections,
     visualize,
 )
-from dask._dispatch import get_collection_type
-from dask._expr import Expr
 from dask.core import validate_key
 from dask.delayed import Delayed, delayed
 from dask.diagnostics import Profiler
@@ -272,118 +269,6 @@ class Tuple(DaskMethodsMixin):
         return Tuple(dsk, keys)
 
 
-class CompositeScalarMeta: ...
-
-
-class LiteralExpr(Expr):
-    _parameters = ["name", "value"]
-
-    @property
-    def name(self):
-        return self.operand("name")
-
-    @property
-    def value(self):
-        return self.operand("value")
-
-    @property
-    def _name(self):
-        return self.name
-
-    @property
-    def _meta(self):
-        return CompositeScalarMeta()
-
-    def _layer(self):
-        return {self._name: self.value}
-
-    def __dask_keys__(self):
-        return [self._name]
-
-
-class ExprScalar(DaskMethodsMixin):
-    __dask_scheduler__ = staticmethod(dask.threaded.get)
-    __dask_optimize__ = None
-
-    def __init__(self, expr):
-        self._expr = expr
-
-    @property
-    def expr(self):
-        return self._expr
-
-    def __dask_graph__(self):
-        return self.expr.__dask_graph__()
-
-    def __dask_keys__(self):
-        return self.expr.__dask_keys__()
-
-    def __dask_layers__(self):
-        return (self.expr._name,)
-
-    def __dask_tokenize__(self):
-        return self.expr
-
-    def __dask_postcompute__(self):
-        return _first, ()
-
-    def __dask_postpersist__(self):
-        return ExprScalar._rebuild, (self.expr,)
-
-    @staticmethod
-    def _rebuild(dsk, expr):
-        return ExprScalar(LiteralExpr(expr.name, dsk[expr.__dask_keys__()[0]]))
-
-
-@get_collection_type.register(CompositeScalarMeta)
-def get_collection_type_composite_scalar(_):
-    return ExprScalar
-
-
-def _first(results):
-    return results[0]
-
-
-def _finalize_expr_tuple(results):
-    return tuple(result[0] for result in results)
-
-
-class ExprTuple(DaskMethodsMixin):
-    __dask_scheduler__ = staticmethod(dask.threaded.get)
-    __dask_optimize__ = None
-
-    def __init__(self, *children):
-        self.children = tuple(children)
-
-    def __dask_exprs__(self):
-        return tuple(child.expr for child in self.children)
-
-    def __dask_rebuild_from_exprs__(self, exprs):
-        return ExprTuple(*(ExprScalar(expr) for expr in exprs))
-
-    def __dask_graph__(self):
-        return merge(*(child.__dask_graph__() for child in self.children))
-
-    def __dask_keys__(self):
-        return [child.__dask_keys__() for child in self.children]
-
-    def __dask_layers__(self):
-        return tuple(child.expr._name for child in self.children)
-
-    def __dask_tokenize__(self):
-        return self.children
-
-    def __dask_postcompute__(self):
-        return _finalize_expr_tuple, ()
-
-    def __dask_postpersist__(self):
-        return ExprTuple._rebuild, (self.children,)
-
-    @staticmethod
-    def _rebuild(dsk, children):
-        return ExprTuple(*(ExprScalar._rebuild(dsk, child.expr) for child in children))
-
-
 def test_custom_collection():
     dsk = {("x", h1): 1, ("x", h2): 2}
     dsk2 = {("y", h1): (add, ("x", h1), ("x", h2)), ("y", h2): (add, ("y", h1), 1)}
@@ -460,111 +345,6 @@ def test_custom_collection():
     rebuild, args = z.__dask_postpersist__()
     z3 = rebuild({"z3": 70}, *args, rename={"z": "z3"})
     assert z3.compute() == (70,)
-
-
-def test_collections_to_expr_uses_composite_protocol():
-    from dask._expr import CompositeExpr
-
-    coll = ExprTuple(ExprScalar(LiteralExpr("a", 1)), ExprScalar(LiteralExpr("b", 2)))
-
-    expr = collections_to_expr(coll)
-
-    assert isinstance(expr, CompositeExpr)
-    assert expr.__dask_keys__() == [["a"], ["b"]]
-    assert expr.__dask_graph__() == {"a": 1, "b": 2}
-
-
-def test_collections_to_expr_ignores_non_dask_expr_attribute():
-    from dask._expr import CompositeExpr
-
-    class ExprAttributeTuple(ExprTuple):
-        @property
-        def expr(self):
-            return "not-a-dask-expression"
-
-    coll = ExprAttributeTuple(
-        ExprScalar(LiteralExpr("a", 1)), ExprScalar(LiteralExpr("b", 2))
-    )
-
-    expr = collections_to_expr(coll)
-
-    assert isinstance(expr, CompositeExpr)
-    assert dask.compute(coll) == ((1, 2),)
-
-
-def test_composite_expr_compute_returns_one_collection_result():
-    coll = ExprTuple(ExprScalar(LiteralExpr("a", 1)), ExprScalar(LiteralExpr("b", 2)))
-    raw = ExprScalar(LiteralExpr("raw", 3))
-
-    assert dask.compute(coll) == ((1, 2),)
-    assert dask.compute(coll, raw) == ((1, 2), 3)
-
-
-def test_composite_expr_persist_rebuilds_collection():
-    coll = ExprTuple(ExprScalar(LiteralExpr("a", 1)), ExprScalar(LiteralExpr("b", 2)))
-    raw = ExprScalar(LiteralExpr("raw", 3))
-    legacy = Tuple({"legacy": 4}, ["legacy"])
-
-    (persisted,) = dask.persist(coll, scheduler="single-threaded")
-
-    assert isinstance(persisted, ExprTuple)
-    assert [child.expr.value for child in persisted.children] == [1, 2]
-    assert persisted.compute(scheduler="single-threaded") == (1, 2)
-
-    persisted_coll, persisted_raw = dask.persist(
-        coll, raw, scheduler="single-threaded"
-    )
-    assert isinstance(persisted_coll, ExprTuple)
-    assert isinstance(persisted_raw, ExprScalar)
-    assert persisted_coll.compute(scheduler="single-threaded") == (1, 2)
-    assert persisted_raw.compute(scheduler="single-threaded") == 3
-
-    persisted_coll, persisted_legacy = dask.persist(
-        coll, legacy, scheduler="single-threaded"
-    )
-    assert isinstance(persisted_coll, ExprTuple)
-    assert isinstance(persisted_legacy, Tuple)
-    assert persisted_coll.compute(scheduler="single-threaded") == (1, 2)
-    assert persisted_legacy.compute(scheduler="single-threaded") == (4,)
-
-
-def test_composite_expr_optimize_rebuilds_collection():
-    coll = ExprTuple(ExprScalar(LiteralExpr("a", 1)), ExprScalar(LiteralExpr("b", 2)))
-    raw = ExprScalar(LiteralExpr("raw", 3))
-    legacy = Tuple({"legacy": 4}, ["legacy"])
-
-    (optimized,) = dask.optimize(coll)
-
-    assert isinstance(optimized, ExprTuple)
-    assert [child.expr.value for child in optimized.children] == [1, 2]
-    assert optimized.compute(scheduler="single-threaded") == (1, 2)
-
-    optimized_coll, optimized_raw = dask.optimize(coll, raw)
-    assert isinstance(optimized_coll, ExprTuple)
-    assert isinstance(optimized_raw, ExprScalar)
-    assert optimized_coll.compute(scheduler="single-threaded") == (1, 2)
-    assert optimized_raw.compute(scheduler="single-threaded") == 3
-
-    optimized_coll, optimized_legacy = dask.optimize(coll, legacy)
-    assert isinstance(optimized_coll, ExprTuple)
-    assert isinstance(optimized_legacy, Tuple)
-    assert optimized_coll.compute(scheduler="single-threaded") == (1, 2)
-    assert optimized_legacy.compute(scheduler="single-threaded") == (4,)
-
-
-def test_collections_to_expr_falls_back_for_empty_composite_protocol():
-    from dask._expr import HLGExpr
-
-    class FallbackTuple(Tuple):
-        def __dask_exprs__(self):
-            return None
-
-    coll = FallbackTuple({"x": 1}, ["x"])
-
-    expr = collections_to_expr(coll)
-
-    assert isinstance(expr, HLGExpr)
-    assert expr.__dask_keys__() == ["x"]
 
 
 def test_compute_no_opt():

--- a/dask/tests/test_composite_expr.py
+++ b/dask/tests/test_composite_expr.py
@@ -6,7 +6,7 @@ from tlz import merge
 import dask
 from dask._dispatch import get_collection_type
 from dask._expr import CompositeExpr, Expr, HLGExpr
-from dask.base import DaskMethodsMixin, collections_to_expr
+from dask.base import DaskMethodsMixin, collections_to_expr, is_dask_collection
 
 
 class LegacyTuple(DaskMethodsMixin):
@@ -161,6 +161,16 @@ def test_collections_to_expr_uses_composite_protocol():
     assert isinstance(expr, CompositeExpr)
     assert expr.__dask_keys__() == [["a"], ["b"]]
     assert expr.__dask_graph__() == {"a": 1, "b": 2}
+
+
+def test_is_dask_collection_uses_expr_attribute_without_materializing():
+    class ExprBackedCollection(ExprScalar):
+        def __dask_graph__(self):
+            raise AssertionError("must not materialize")
+
+    coll = ExprBackedCollection(LiteralExpr("a", 1))
+
+    assert is_dask_collection(coll)
 
 
 def test_collections_to_expr_ignores_non_dask_expr_attribute():

--- a/dask/tests/test_composite_expr.py
+++ b/dask/tests/test_composite_expr.py
@@ -173,6 +173,14 @@ def test_is_dask_collection_uses_expr_attribute_without_materializing():
     assert is_dask_collection(coll)
 
 
+def test_is_dask_collection_uses_expr_without_materializing():
+    class AbstractExpr(LiteralExpr):
+        def __dask_graph__(self):
+            raise AssertionError("must not materialize")
+
+    assert is_dask_collection(AbstractExpr("a", 1))
+
+
 def test_collections_to_expr_ignores_non_dask_expr_attribute():
     class ExprAttributeTuple(ExprTuple):
         @property

--- a/dask/tests/test_composite_expr.py
+++ b/dask/tests/test_composite_expr.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import pytest
+from tlz import merge
+
+import dask
+from dask._dispatch import get_collection_type
+from dask._expr import CompositeExpr, Expr, HLGExpr
+from dask.base import DaskMethodsMixin, collections_to_expr
+
+
+class LegacyTuple(DaskMethodsMixin):
+    __slots__ = ("_dask", "_keys")
+    __dask_scheduler__ = staticmethod(dask.threaded.get)
+    __dask_optimize__ = None
+
+    def __init__(self, dsk, keys):
+        self._dask = dsk
+        self._keys = keys
+
+    def __dask_graph__(self):
+        return self._dask
+
+    def __dask_keys__(self):
+        return self._keys
+
+    def __dask_layers__(self):
+        return ("legacy-tuple",)
+
+    def __dask_tokenize__(self):
+        return self._keys
+
+    def __dask_postcompute__(self):
+        return tuple, ()
+
+    def __dask_postpersist__(self):
+        return LegacyTuple._rebuild, (self._keys,)
+
+    @staticmethod
+    def _rebuild(dsk, keys):
+        return LegacyTuple(dsk, keys)
+
+
+class CompositeScalarMeta: ...
+
+
+class LiteralExpr(Expr):
+    _parameters = ["name", "value"]
+
+    @property
+    def name(self):
+        return self.operand("name")
+
+    @property
+    def value(self):
+        return self.operand("value")
+
+    @property
+    def _name(self):
+        return self.name
+
+    @property
+    def _meta(self):
+        return CompositeScalarMeta()
+
+    def _layer(self):
+        return {self._name: self.value}
+
+    def __dask_keys__(self):
+        return [self._name]
+
+
+class ExprScalar(DaskMethodsMixin):
+    __dask_scheduler__ = staticmethod(dask.threaded.get)
+    __dask_optimize__ = None
+
+    def __init__(self, expr):
+        self._expr = expr
+
+    @property
+    def expr(self):
+        return self._expr
+
+    def __dask_graph__(self):
+        return self.expr.__dask_graph__()
+
+    def __dask_keys__(self):
+        return self.expr.__dask_keys__()
+
+    def __dask_layers__(self):
+        return (self.expr._name,)
+
+    def __dask_tokenize__(self):
+        return self.expr
+
+    def __dask_postcompute__(self):
+        return _first, ()
+
+    def __dask_postpersist__(self):
+        return ExprScalar._rebuild, (self.expr,)
+
+    @staticmethod
+    def _rebuild(dsk, expr):
+        return ExprScalar(LiteralExpr(expr.name, dsk[expr.__dask_keys__()[0]]))
+
+
+@get_collection_type.register(CompositeScalarMeta)
+def get_collection_type_composite_scalar(_):
+    return ExprScalar
+
+
+def _first(results):
+    return results[0]
+
+
+def _finalize_expr_tuple(results):
+    return tuple(result[0] for result in results)
+
+
+class ExprTuple(DaskMethodsMixin):
+    __dask_scheduler__ = staticmethod(dask.threaded.get)
+    __dask_optimize__ = None
+
+    def __init__(self, *children):
+        self.children = tuple(children)
+
+    def __dask_exprs__(self):
+        return tuple(child.expr for child in self.children)
+
+    def __dask_rebuild_from_exprs__(self, exprs):
+        return ExprTuple(*(ExprScalar(expr) for expr in exprs))
+
+    def __dask_graph__(self):
+        return merge(*(child.__dask_graph__() for child in self.children))
+
+    def __dask_keys__(self):
+        return [child.__dask_keys__() for child in self.children]
+
+    def __dask_layers__(self):
+        return tuple(child.expr._name for child in self.children)
+
+    def __dask_tokenize__(self):
+        return self.children
+
+    def __dask_postcompute__(self):
+        return _finalize_expr_tuple, ()
+
+    def __dask_postpersist__(self):
+        return ExprTuple._rebuild, (self.children,)
+
+    @staticmethod
+    def _rebuild(dsk, children):
+        return ExprTuple(*(ExprScalar._rebuild(dsk, child.expr) for child in children))
+
+
+def test_collections_to_expr_uses_composite_protocol():
+    coll = ExprTuple(ExprScalar(LiteralExpr("a", 1)), ExprScalar(LiteralExpr("b", 2)))
+
+    expr = collections_to_expr(coll)
+
+    assert isinstance(expr, CompositeExpr)
+    assert expr.__dask_keys__() == [["a"], ["b"]]
+    assert expr.__dask_graph__() == {"a": 1, "b": 2}
+
+
+def test_collections_to_expr_ignores_non_dask_expr_attribute():
+    class ExprAttributeTuple(ExprTuple):
+        @property
+        def expr(self):
+            return "not-a-dask-expression"
+
+    coll = ExprAttributeTuple(
+        ExprScalar(LiteralExpr("a", 1)), ExprScalar(LiteralExpr("b", 2))
+    )
+
+    expr = collections_to_expr(coll)
+
+    assert isinstance(expr, CompositeExpr)
+    assert dask.compute(coll) == ((1, 2),)
+
+
+def test_composite_expr_compute_returns_one_collection_result():
+    coll = ExprTuple(ExprScalar(LiteralExpr("a", 1)), ExprScalar(LiteralExpr("b", 2)))
+    raw = ExprScalar(LiteralExpr("raw", 3))
+
+    assert dask.compute(coll) == ((1, 2),)
+    assert dask.compute(coll, raw) == ((1, 2), 3)
+
+
+def test_composite_expr_persist_rebuilds_collection():
+    coll = ExprTuple(ExprScalar(LiteralExpr("a", 1)), ExprScalar(LiteralExpr("b", 2)))
+    raw = ExprScalar(LiteralExpr("raw", 3))
+    legacy = LegacyTuple({"legacy": 4}, ["legacy"])
+
+    (persisted,) = dask.persist(coll, scheduler="single-threaded")
+
+    assert isinstance(persisted, ExprTuple)
+    assert [child.expr.value for child in persisted.children] == [1, 2]
+    assert persisted.compute(scheduler="single-threaded") == (1, 2)
+
+    persisted_coll, persisted_raw = dask.persist(coll, raw, scheduler="single-threaded")
+    assert isinstance(persisted_coll, ExprTuple)
+    assert isinstance(persisted_raw, ExprScalar)
+    assert persisted_coll.compute(scheduler="single-threaded") == (1, 2)
+    assert persisted_raw.compute(scheduler="single-threaded") == 3
+
+    with pytest.warns(UserWarning, match="Computing mixed collections"):
+        persisted_coll, persisted_legacy = dask.persist(
+            coll, legacy, scheduler="single-threaded"
+        )
+    assert isinstance(persisted_coll, ExprTuple)
+    assert isinstance(persisted_legacy, LegacyTuple)
+    assert persisted_coll.compute(scheduler="single-threaded") == (1, 2)
+    assert persisted_legacy.compute(scheduler="single-threaded") == (4,)
+
+
+def test_composite_expr_optimize_rebuilds_collection():
+    coll = ExprTuple(ExprScalar(LiteralExpr("a", 1)), ExprScalar(LiteralExpr("b", 2)))
+    raw = ExprScalar(LiteralExpr("raw", 3))
+    legacy = LegacyTuple({"legacy": 4}, ["legacy"])
+
+    (optimized,) = dask.optimize(coll)
+
+    assert isinstance(optimized, ExprTuple)
+    assert [child.expr.value for child in optimized.children] == [1, 2]
+    assert optimized.compute(scheduler="single-threaded") == (1, 2)
+
+    optimized_coll, optimized_raw = dask.optimize(coll, raw)
+    assert isinstance(optimized_coll, ExprTuple)
+    assert isinstance(optimized_raw, ExprScalar)
+    assert optimized_coll.compute(scheduler="single-threaded") == (1, 2)
+    assert optimized_raw.compute(scheduler="single-threaded") == 3
+
+    with pytest.warns(UserWarning, match="Computing mixed collections"):
+        optimized_coll, optimized_legacy = dask.optimize(coll, legacy)
+    assert isinstance(optimized_coll, ExprTuple)
+    assert isinstance(optimized_legacy, LegacyTuple)
+    assert optimized_coll.compute(scheduler="single-threaded") == (1, 2)
+    assert optimized_legacy.compute(scheduler="single-threaded") == (4,)
+
+
+def test_collections_to_expr_falls_back_for_empty_composite_protocol():
+    class FallbackTuple(LegacyTuple):
+        def __dask_exprs__(self):
+            return None
+
+    coll = FallbackTuple({"x": 1}, ["x"])
+
+    expr = collections_to_expr(coll)
+
+    assert isinstance(expr, HLGExpr)
+    assert expr.__dask_keys__() == ["x"]


### PR DESCRIPTION
I was playing earlier this week with getting dask array expressions to work with xarray.  Xarray is tricky because it holds a variety of expressions and we want to gather those expressions, compute/persist, and then reconstruct the xarray dataset afterwards.  One way to do that is by adding a `__dask_exprs__` protocol to the Dask contract.  

Additionally, Xarray has a strange `map_blocks` operation that breaks the normal pattern.  That led to the CompositeExpr class below.

Overall this stuff is general purpose, but mostly just for xarray.  There is a companion PR to Xarray here: https://github.com/pydata/xarray/pull/11382.

## Example

```python
import dask
import dask_array
import xarray as xr
from xarray.namedarray.parallelcompat import get_chunked_array_type


ds = xr.tutorial.scatter_example_dataset(seed=42).chunk({"x": 1, "y": 1, "z": 2, "w": 2})

# The slice and rechunk start above the elementwise operation.  dask-array's
# optimizer can push them down so it only builds the small requested window.
window = (ds.A + ds.B).chunk({"y": 3}).isel(x=slice(0, 1), y=slice(0, 3))

tasks_before = len(window.__dask_graph__())
(optimized_window,) = dask.optimize(window)
optimized_data = window.data.optimize()
tasks_after = len(optimized_data.__dask_graph__())

manager = get_chunked_array_type(ds.A.data)

print(f"xarray chunk manager: {type(manager).__name__}")
print(f"dask.optimize result: {type(optimized_window).__name__}")
print(f"array type: {type(window.data).__module__}.{type(window.data).__name__}")
print(f"graph tasks before optimize: {tasks_before}")
print(f"graph tasks after optimize:  {tasks_after}")
print()
print("Before optimize:")
window.data.pprint()
print()
print("After optimize:")
optimized_data.pprint()
```

## Output

```
xarray chunk manager: DaskArrayExprManager
dask.optimize result: DataArray
array type: dask_array._collection.Array
graph tasks before optimize: 448
graph tasks after optimize:  12

Before optimize:
  Operation                Shape    Bytes   Chunks
  Getitem           (1, 3, 4, 4)    384 B  1×3×2×2
  └ Rechunk        (3, 11, 4, 4)  4.1 kiB  1×3×2×2
    └ Add          (3, 11, 4, 4)  4.1 kiB  1×1×2×2
      ├ FromArray  (3, 11, 4, 4)  4.1 kiB  1×1×2×2
      └ FromArray  (3, 11, 4, 4)  4.1 kiB  1×1×2×2

After optimize:
  Operation           Shape  Bytes   Chunks
  Add          (1, 3, 4, 4)  384 B  1×3×2×2
  ├ FromArray  (1, 3, 4, 4)  384 B  1×3×2×2
  └ FromArray  (1, 3, 4, 4)  384 B  1×3×2×2
```