### PR TITLE
Fix #12293: Fix wrong dtype when using masked_array with Python float

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -5167,7 +5167,9 @@ def elemwise(op, *args, out=None, where=True, dtype=None, name=None, **kwargs):
         # to match.
         vals = [
             (
-                np.empty((1,) * max(1, a.ndim), dtype=a.dtype)
+                np.zeros_like(
+                    meta_from_array(a), shape=((1,) * max(1, a.ndim)), dtype=a.dtype
+                )
                 if not is_scalar_for_elemwise(a)
                 else a
             )


### PR DESCRIPTION
Fixes #12293

Minimal fix for the linked issue.

Local test infra unavailable in CI sandbox.

---
This change was prepared with AI assistance under human direction and review.