### PR TITLE
Fix randomly failing s3fs checkouts in nightly CI

### DIFF
--- a/continuous_integration/pixi-recipes/s3fs/recipe.yaml
+++ b/continuous_integration/pixi-recipes/s3fs/recipe.yaml
@@ -4,7 +4,22 @@ package:
   version: "9999"
 
 source:
-  git: https://github.com/fsspec/s3fs
+  # NOTE: deliberately not using a git source. On GitHub Actions runners this
+  # recipe intermittently fails at the source-fetch step with:
+  #   "Error fetching Git repository: No such file or directory (os error 2)"
+  # That message is emitted by pixi's git source resolver
+  # (pixi/crates/pixi_git/src/resolver.rs) and by rattler-build's source cache
+  # (rattler-build/crates/rattler_build_source_cache/src/cache.rs), which both
+  # fetch git sources through libgit2 / the rattler_git crate. No dedicated
+  # upstream issue tracks this exact failure; the closest related precedent is
+  # libgit2/libgit2#6417 (intermittent git fetch failures on CI runners).
+  # The transient nature breaks the nightly CI at random with no code change.
+  #
+  # Workaround: fetch the GitHub codeload tarball over plain HTTPS, which is
+  # reliable. The package uses versioneer, which falls back to "0+unknown"
+  # without a .git directory; that's harmless here because the conda package
+  # version is forced to "9999" above.
+  url: https://github.com/fsspec/s3fs/archive/refs/heads/main.tar.gz
 
 build:
   noarch: python
@@ -15,8 +30,7 @@ requirements:
   host:
     - python
     - pip
-    - hatchling
-    - hatch-vcs
+    - setuptools
   run:
     - python
     - aiobotocore

--- a/pixi.lock
+++ b/pixi.lock
@@ -67,8 +67,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/lzo-2.10-h280c20c_1002.conda
       - conda: https://prefix.dev/conda-forge/linux-64/markupsafe-3.0.3-py314h67df5f8_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mbedtls-3.6.3.1-h5888daf_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/menuinst-2.5.0-py314hdafbbf9_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py314h9891dd4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/menuinst-2.5.0-py314h9e666f3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py314h9891dd4_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
@@ -80,12 +80,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://prefix.dev/conda-forge/linux-64/py-lief-0.17.6-py314ha160325_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/py-rattler-0.25.0-py310h70157a2_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/py-rattler-build-0.66.1-py310hb823017_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/py-rattler-build-0.67.0-py310hb823017_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pycosat-0.6.6-py314h5bd0f2a_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pydantic-core-2.46.4-py314h2e6c369_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pyyaml-6.0.3-py314h67df5f8_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/rattler-build-0.66.2-ha759004_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/rattler-build-0.67.0-ha759004_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/reproc-14.2.7.post0-hb03c661_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/reproc-cpp-14.2.7.post0-hecca717_1.conda
@@ -117,7 +117,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.6.0-py314h680f03e_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/beautifulsoup4-4.15.0-pyha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/boltons-26.0.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -175,7 +175,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyjwt-2.13.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
@@ -272,8 +272,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/lzo-2.10-h80f16a2_1002.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/markupsafe-3.0.3-py314hb76de3f_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mbedtls-3.6.3.1-h5ad3122_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/menuinst-2.5.0-py314h28a4750_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py314hd7d8586_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/menuinst-2.5.0-py314h064b4d9_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.1-py314hd7d8586_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
@@ -285,12 +285,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pthread-stubs-0.4-h86ecc28_1002.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/py-lief-0.17.6-py314h02b5315_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/py-rattler-0.25.0-py310h45743d3_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/py-rattler-build-0.66.1-py310h160093b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/py-rattler-build-0.67.0-py310h160093b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pycosat-0.6.6-py314h51f160d_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pydantic-core-2.46.4-py314h451b6cc_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/python-3.14.6-hc679e19_100_cp314.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pyyaml-6.0.3-py314h807365f_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/rattler-build-0.66.2-h1d7f6d8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/rattler-build-0.67.0-h1d7f6d8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/reproc-14.2.7.post0-he30d5cf_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/reproc-cpp-14.2.7.post0-hfae3067_1.conda
@@ -322,7 +322,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.6.0-py314h680f03e_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/beautifulsoup4-4.15.0-pyha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/boltons-26.0.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -380,7 +380,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyjwt-2.13.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
@@ -433,7 +433,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.6.0-py314h680f03e_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/beautifulsoup4-4.15.0-pyha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/boltons-26.0.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -490,7 +490,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyjwt-2.13.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
@@ -584,8 +584,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/lzo-2.10-h925e9cb_1002.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/markupsafe-3.0.3-py314h6e9b3f0_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mbedtls-3.6.3.1-h286801f_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/menuinst-2.5.0-py314h4dc9dd8_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py314h6cfcd04_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/menuinst-2.5.0-py314hcec6336_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py314h6cfcd04_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
@@ -595,12 +595,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/py-lief-0.17.5-py314h4ed92d5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/py-rattler-0.25.0-py310hbaa5893_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/py-rattler-build-0.66.1-py310he76dbf2_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/py-rattler-build-0.67.0-py310he76dbf2_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pycosat-0.6.6-py314hb84d1df_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pydantic-core-2.46.4-py314h54f3292_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pyyaml-6.0.3-py314h6e9b3f0_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/rattler-build-0.66.2-h20b3172_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/rattler-build-0.67.0-h20b3172_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/reproc-14.2.7.post0-h84a0fba_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/reproc-cpp-14.2.7.post0-hf6b4638_1.conda
@@ -634,7 +634,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.6.0-py314h680f03e_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/beautifulsoup4-4.15.0-pyha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/boltons-26.0.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -693,7 +693,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyjwt-2.13.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyproject_hooks-1.2.0-pyhd8ed1ab_1.conda
@@ -779,8 +779,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/m2-conda-epoch-20250515-0_x86_64.conda
       - conda: https://prefix.dev/conda-forge/win-64/markupsafe-3.0.3-py314h2359020_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/mbedtls-3.6.3.1-he0c23c2_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/menuinst-2.5.0-py314h13fbf68_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.0-py314h909e829_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/menuinst-2.5.0-py314hb98de8c_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.1-py314h909e829_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/openjpeg-2.5.4-h0e57b4f_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/pillow-12.2.0-py314h61b30b5_0.conda
@@ -788,14 +788,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
       - conda: https://prefix.dev/conda-forge/win-64/py-lief-0.17.6-py314h13fbf68_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/py-rattler-0.25.0-py310hb39080a_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/py-rattler-build-0.66.1-py310hdba2031_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/py-rattler-build-0.67.0-py310hdba2031_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/pycosat-0.6.6-py314h5a2d7ad_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/pydantic-core-2.46.4-py314h9f07db2_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/python-3.14.6-h4b44e0e_100_cp314.conda
       - conda: https://prefix.dev/conda-forge/win-64/pywin32-312-py314hcaaf0b2_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/pywin32-ctypes-0.2.3-py314h86ab7b2_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/pyyaml-6.0.3-py314h2359020_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/rattler-build-0.66.2-he94b42d_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/rattler-build-0.67.0-he94b42d_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/reproc-14.2.7.post0-hfd05255_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/reproc-cpp-14.2.7.post0-hac47afa_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/ripgrep-15.1.0-h77a83cd_0.conda
@@ -827,19 +827,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.3-hea842a7_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.3-hd2277e8_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.14-h78948cc_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.14.0-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-haa0cbde_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-event-stream-0.7.1-h9cf6be0_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.11.0-h6488f85_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-h3bf836e_5.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.15.2-h0d2f46f_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.5-hb916526_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-haa0cbde_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.16.0-h0d2f46f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.6-hb916526_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.5-haa0cbde_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-haa0cbde_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.40.0-h41299d8_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.747-h6154047_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.40.1-h7a9a9d6_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.747-hf4c7647_7.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-core-cpp-1.16.3-h206d751_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-identity-cpp-1.13.3-h71f81a8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-storage-blobs-cpp-12.18.0-h74b55db_1.conda
@@ -859,7 +859,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/cffi-2.0.0-py314h4a8dc5f_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/charls-2.4.4-hecca717_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/contourpy-1.3.3-py314h97ea11e_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py314h67df5f8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py314h67df5f8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cramjam-2.11.0-py314haf003cf_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cryptography-49.0.0-py314h7fe84b3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
@@ -887,10 +887,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
       - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py314hddf7a69_102.conda
       - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h735b18d_107.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h7d5651c_108.conda
       - conda: https://prefix.dev/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py314h834e057_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py314h8570d32_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/kiwisolver-1.5.0-py314h97ea11e_0.conda
@@ -901,11 +901,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-24.0.0-h157cd41_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-24.0.0-h635bf11_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-24.0.0-h53684a4_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-24.0.0-h635bf11_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-24.0.0-hb4dd7c2_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-24.0.0-hb642ee7_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-24.0.0-h635bf11_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-24.0.0-h53684a4_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-24.0.0-h635bf11_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-24.0.0-hb4dd7c2_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.2-hf998032_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
@@ -939,8 +939,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-3.5.0-h8d2ee43_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-3.5.0-hdbdcf42_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-3.6.0-h8d2ee43_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-3.6.0-hdbdcf42_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgrpc-1.78.1-h1d1128b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libhwy-1.4.0-h10be129_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
@@ -956,7 +956,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-1.27.0-h9692893_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libparquet-24.0.0-h7376487_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libparquet-24.0.0-h7376487_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpq-18.4-hd5a49e9_0.conda
@@ -992,7 +992,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/mmh3-5.2.1-py314ha160325_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py314h9891dd4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py314h9891dd4_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/numba-0.65.1-py314h8169c2f_1.conda
@@ -1000,7 +1000,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/numexpr-2.14.1-py314heb044ea_102.conda
       - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.6-py314h2b28147_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.29.0-h8d634f6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.30.1-h8d634f6_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/orc-2.3.0-h21090e2_0.conda
@@ -1032,7 +1032,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.4-h92489ea_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/scikit-image-0.26.0-np2py314hda1ea4c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/scikit-learn-1.9.0-np2py314hf09ca88_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.17.1-py314hf07bd8e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/sqlalchemy-2.0.51-py314h0f05182_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
@@ -1040,14 +1040,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.7-py314h5bd0f2a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/unicodedata2-17.0.1-py314h5bd0f2a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.1-py314h5bd0f2a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.2-py314h5bd0f2a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
@@ -1099,6 +1099,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -1188,12 +1189,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -1248,8 +1249,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zarr-3.2.1-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[cfea4cc3] @ .
-      - conda_source: distributed[f47febc1] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[f391cbf4] @ .
+      - conda_source: distributed[45a1d59d] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-he30d5cf_0.conda
@@ -1257,19 +1258,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/at-spi2-atk-2.38.0-h1f2db35_3.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/at-spi2-core-2.40.3-h1f2db35_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.3-hc916f7b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.3-h5c394e5_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-cal-0.9.14-h343fa25_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-common-0.14.0-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h5b0efec_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-event-stream-0.7.1-h70cbb06_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-http-0.11.0-h9bcd1b7_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-io-0.26.3-hacd6ab7_5.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-mqtt-0.15.2-h3479d1b_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.12.5-hdd40dfe_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h5b0efec_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-mqtt-0.16.0-h3479d1b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.12.6-hdd40dfe_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.5-h5b0efec_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-checksums-0.2.10-h5b0efec_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-crt-cpp-0.40.0-hf7c79f2_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.747-hf48beb8_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-crt-cpp-0.40.1-h0495e26_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.747-h6aa9b71_7.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-core-cpp-1.16.3-h412bcfc_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-identity-cpp-1.13.3-hd0001b6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-storage-blobs-cpp-12.18.0-h2e50874_1.conda
@@ -1289,7 +1290,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cffi-2.0.0-py314h0bd77cf_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/charls-2.4.4-hfae3067_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/contourpy-1.3.3-py314ha0cc70f_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.1-py314hb76de3f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.3-py314hb76de3f_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cramjam-2.11.0-py314h614ea8d_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cryptography-49.0.0-py314hbfac26c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6598af7_1.conda
@@ -1317,10 +1318,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py314h96887de_102.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/harfbuzz-14.2.1-h1134a53_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h02c88d6_107.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h0973965_108.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py314h790143f_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py314h9dc542c_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/jxrlib-1.1-h31becfc_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/kiwisolver-1.5.0-py314h4702e76_0.conda
@@ -1331,11 +1332,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libabseil-20260107.1-cxx17_h6983b43_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libaec-1.1.5-hff7e48a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-24.0.0-h5dfeb67_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-24.0.0-hb326ee9_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-compute-24.0.0-hdd99842_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-24.0.0-hb326ee9_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-24.0.0-hf29bd21_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-24.0.0-h6b18018_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-24.0.0-hb326ee9_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-compute-24.0.0-hdd99842_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-24.0.0-hb326ee9_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-24.0.0-hf29bd21_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libavif16-1.4.2-h1641d3b_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlicommon-1.2.0-he30d5cf_1.conda
@@ -1369,8 +1370,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-3.5.0-h235f271_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-storage-3.5.0-h66d5b86_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-3.6.0-h235f271_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-storage-3.6.0-h66d5b86_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libgrpc-1.78.1-heab1e18_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libhwy-1.4.0-h0626a34_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
@@ -1386,7 +1387,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopengl-1.7.0-hd24410f_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopentelemetry-cpp-1.27.0-hd82aec3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopentelemetry-cpp-headers-1.27.0-h8af1aa0_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpciaccess-0.19-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpq-18.4-hccacd55_0.conda
@@ -1422,7 +1423,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mmh3-5.2.1-py314h02b5315_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mpc-1.4.0-he6dc3fb_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mpfr-4.2.2-h3faef18_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py314hd7d8586_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.1-py314hd7d8586_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/nlohmann_json-3.12.0-h7ac5ae9_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/numba-0.65.1-py314h8873072_1.conda
@@ -1430,7 +1431,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/numexpr-2.14.1-py314h3f24ac4_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-2.4.6-py314he1698a1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/openjph-0.29.0-h55827e0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/openjph-0.30.1-h55827e0_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openldap-2.6.13-h2fb54aa_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/orc-2.3.0-hce1ac79_0.conda
@@ -1462,7 +1463,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/s2n-1.7.4-h5288e76_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/scikit-image-0.26.0-np2py314h018c8c3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/scikit-learn-1.9.0-np2py314hcefaf23_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.17.1-py314h052a9b3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.18.0-py314h052a9b3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/snappy-1.2.2-he774c54_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/sqlalchemy-2.0.51-py314hf8f541d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/svt-av1-4.0.1-hfae3067_0.conda
@@ -1470,14 +1471,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/tornado-6.5.7-py314hafb4487_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/unicodedata2-17.0.1-py314h51f160d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/wayland-1.25.0-h4f8a99f_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.1-py314h51f160d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.2-py314h51f160d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-0.4.1-hca56bd8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-cursor-0.1.6-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.47-h80f16a2_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.48-h80f16a2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
@@ -1529,6 +1530,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -1617,12 +1619,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -1677,8 +1679,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zarr-3.2.1-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[058df287] @ .
-      - conda_source: distributed[208732bf] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[f372236f] @ .
+      - conda_source: distributed[298b9d04] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
@@ -1708,6 +1710,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -1796,12 +1799,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -1859,19 +1862,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aom-3.14.1-pl5321h513545f_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/atk-1.0-2.38.0-hd03087b_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.3-hceed5df_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-cal-0.9.14-h81c6212_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-common-0.14.0-h84a0fba_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-compression-0.3.2-h61d3404_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-event-stream-0.7.1-h7e6a3cf_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-http-0.11.0-h0a63974_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_5.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-mqtt-0.15.2-ha70999f_4.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.12.5-h43def2a_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h61d3404_6.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-mqtt-0.16.0-ha70999f_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-checksums-0.2.10-h61d3404_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-crt-cpp-0.40.0-hd6eb0f7_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h55dad5a_6.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-crt-cpp-0.40.1-hb87031f_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h4e95165_7.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-core-cpp-1.16.3-he5ae378_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-identity-cpp-1.13.3-h05177fb_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.18.0-h409340b_1.conda
@@ -1891,7 +1894,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/cffi-2.0.0-py314h44086f9_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/charls-2.4.4-hf6b4638_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/contourpy-1.3.3-py314hf8a3a22_4.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py314h6e9b3f0_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py314h6e9b3f0_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cramjam-2.11.0-py314he20b14d_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cryptography-49.0.0-py314h0d331bb_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cytoolz-1.1.0-py314h6c2aa35_2.conda
@@ -1916,10 +1919,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py314h658a3ac_102.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/harfbuzz-14.2.1-h3103d1b_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_h9bfbf6c_107.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hb7e0c14_108.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/hicolor-icon-theme-0.17-hce30654_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py314hcca8607_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py314hdaaf36e_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/jxrlib-1.1-h93a5062_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/kiwisolver-1.5.0-py314hf8a3a22_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
@@ -1928,11 +1931,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/lerc-4.1.0-h1eee2c3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libaec-1.1.5-h8664d51_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-24.0.0-hc887bfb_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-24.0.0-ha4f4840_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-compute-24.0.0-h8d10c55_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-24.0.0-ha4f4840_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-24.0.0-h05be00f_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-24.0.0-h6045e8e_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-24.0.0-ha4f4840_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-compute-24.0.0-h8d10c55_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-24.0.0-ha4f4840_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-24.0.0-h05be00f_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libavif16-1.4.2-h1c659b6_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
@@ -1955,8 +1958,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libglib-2.88.1-ha08bb59_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-3.5.0-h688a705_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-storage-3.5.0-ha114238_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-3.6.0-h688a705_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-storage-3.6.0-ha114238_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libhwy-1.4.0-ha332bbd_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
@@ -1970,7 +1973,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h08d5cc3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libparquet-24.0.0-h840b369_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libparquet-24.0.0-h840b369_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libprotobuf-6.33.5-h2d4b707_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libraqm-0.10.5-h29bd36a_0.conda
@@ -1998,7 +2001,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/mmh3-5.2.1-py314h4ed92d5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py314h6cfcd04_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py314h6cfcd04_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/numba-0.65.1-py314hb38061f_1.conda
@@ -2006,7 +2009,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/numexpr-2.14.1-py314hac0e451_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.4.6-py314hb79c6fa_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/openjph-0.29.0-h2a4d681_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/openjph-0.30.1-h2a4d681_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/orc-2.3.0-hd11884d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pandas-3.0.3-py314he609de1_0.conda
@@ -2034,14 +2037,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/rpds-py-2026.5.1-py314he1d1ac0_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/scikit-image-0.26.0-np2py314hc49a259_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/scikit-learn-1.9.0-np2py314h15f0f0f_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.17.1-py314h18e1515_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.18.0-py314h18e1515_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/sqlalchemy-2.0.51-py314ha14b1ff_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/svt-av1-4.0.1-h0cb729a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tornado-6.5.7-py314h6c2aa35_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/unicodedata2-17.0.1-py314h6c2aa35_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.1-py314h6c2aa35_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.2-py314h6c2aa35_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xxhash-0.8.3-haa4e116_0.conda
@@ -2051,8 +2054,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - conda_source: dask-core[4daf6a12] @ .
-      - conda_source: distributed[a8efca05] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[ac39bd18] @ .
+      - conda_source: distributed[de5a2f6f] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda
@@ -2167,12 +2170,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -2232,19 +2235,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/_libavif_api-1.4.2-h57928b3_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/win-64/aom-3.14.1-pl5321h06fc181_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.3-h75b6777_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.3-h4ad2c79_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-cal-0.9.14-h270aff2_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-common-0.14.0-hfd05255_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-compression-0.3.2-h1f21522_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-event-stream-0.7.1-hfbf5bbe_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-http-0.11.0-h4721ae0_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-io-0.26.3-h1a62f66_5.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-mqtt-0.15.2-h10b66d2_4.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.12.5-h425879c_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.4-h1f21522_6.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-mqtt-0.16.0-h10b66d2_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.12.6-h425879c_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.5-h1f21522_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-checksums-0.2.10-h1f21522_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-crt-cpp-0.40.0-hcaec180_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.747-h5d5b8b4_6.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-crt-cpp-0.40.1-hccacdf3_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.747-h042817b_7.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-core-cpp-1.16.3-h49e36cd_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-identity-cpp-1.13.3-hf9fdf8e_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-storage-blobs-cpp-12.18.0-h4fb3251_1.conda
@@ -2263,7 +2266,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/cffi-2.0.0-py314h5a2d7ad_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/charls-2.4.4-h7cafa3a_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/contourpy-1.3.3-py314hf309875_4.conda
-      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py314h2359020_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py314h2359020_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cramjam-2.11.0-py314h8a07082_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/cryptography-49.0.0-py314he884d78_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cytoolz-1.1.0-py314h5a2d7ad_2.conda
@@ -2284,9 +2287,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/gts-0.7.6-h6b5321d_4.conda
       - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py314h02517ec_102.conda
       - conda: https://prefix.dev/conda-forge/win-64/harfbuzz-14.2.1-h5a1b470_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_h693361b_107.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_ha9ae7cf_108.conda
       - conda: https://prefix.dev/conda-forge/win-64/icu-78.3-h637d24d_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py314h1bed58d_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py314h37ae81f_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/jxrlib-1.1-hcfcfb64_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/kiwisolver-1.5.0-py314hf309875_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/krb5-1.22.2-h719d79b_1.conda
@@ -2295,11 +2298,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/lerc-4.1.0-hd936e49_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libabseil-20260107.1-cxx17_h0eb2380_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libaec-1.1.5-haf901d7_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-24.0.0-hbef6419_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-24.0.0-h7d8d6a5_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-compute-24.0.0-h081cd8e_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-24.0.0-h7d8d6a5_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-24.0.0-h524e9bd_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-24.0.0-h9dce539_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-24.0.0-h7d8d6a5_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-compute-24.0.0-h081cd8e_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-24.0.0-h7d8d6a5_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-24.0.0-h524e9bd_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/win-64/libavif16-1.4.2-h7e7b026_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libblas-3.11.0-8_h8455456_mkl.conda
       - conda: https://prefix.dev/conda-forge/win-64/libbrotlicommon-1.2.0-hfd05255_1.conda
@@ -2319,8 +2322,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libgd-2.3.3-h4974f7c_12.conda
       - conda: https://prefix.dev/conda-forge/win-64/libglib-2.88.1-h7ce1215_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libgomp-15.2.0-h8ee18e1_19.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-3.5.0-he22669a_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-storage-3.5.0-he04ea4c_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-3.6.0-he22669a_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-storage-3.6.0-he04ea4c_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libgrpc-1.78.1-h9ff2b3e_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://prefix.dev/conda-forge/win-64/libhwy-1.4.0-h172a326_0.conda
@@ -2333,7 +2336,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libopentelemetry-cpp-1.27.0-hc88f397_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libopentelemetry-cpp-headers-1.27.0-h57928b3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libparquet-24.0.0-h7051d1f_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libparquet-24.0.0-h7051d1f_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/win-64/libpng-1.6.58-h7351971_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libprotobuf-6.33.5-h6cf2d3c_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libraqm-0.10.5-h781ae3c_0.conda
@@ -2364,7 +2367,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/mmh3-5.2.1-py314h13fbf68_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mpc-1.4.0-hc817d3a_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mpfr-4.2.2-h883a981_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.0-py314h909e829_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.1-py314h909e829_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/nlohmann_json-3.12.0-h5112557_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/numba-0.65.1-py314h36f8cf2_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/numcodecs-0.16.5-py314hd8fd7ce_0.conda
@@ -2372,7 +2375,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/numpy-2.4.6-py314h02f10f6_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/onemkl-license-2026.0.0-h57928b3_908.conda
       - conda: https://prefix.dev/conda-forge/win-64/openjpeg-2.5.4-h0e57b4f_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/openjph-0.29.0-hf13a347_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/openjph-0.30.1-hf13a347_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/orc-2.3.0-h8fc0eb6_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/pandas-3.0.3-py314hf700ef7_0.conda
@@ -2402,7 +2405,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/rpds-py-2026.5.1-py314hc980628_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/scikit-image-0.26.0-np2py314he3c5115_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/scikit-learn-1.9.0-np2py314h1b5b07a_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/scipy-1.17.1-py314h221f224_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/scipy-1.18.0-py314h221f224_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/snappy-1.2.2-h7fa0ca8_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/sqlalchemy-2.0.51-py314hc5dbbe4_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/svt-av1-4.0.1-hac47afa_0.conda
@@ -2415,7 +2418,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda
-      - conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.1-py314h5a2d7ad_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.2-py314h5a2d7ad_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libice-1.1.2-h0e40799_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libsm-1.2.6-h0e40799_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libx11-1.8.13-hfa52320_0.conda
@@ -2431,8 +2434,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/zlib-ng-2.3.3-h0261ad2_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - conda_source: dask-core[e7cea6b0] @ .
-      - conda_source: distributed[2f8bebff] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[7581a683] @ .
+      - conda_source: distributed[ae0f1589] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
   lint:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -2601,7 +2604,7 @@ environments:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py310h3406613_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py310h3406613_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-8_h0358290_openblas.conda
@@ -2660,11 +2663,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[cfea4cc3] @ .
+      - conda_source: dask-core[f391cbf4] @ .
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.1-py310h3b5aacf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.3-py310h3b5aacf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
@@ -2724,7 +2727,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[058df287] @ .
+      - conda_source: dask-core[f372236f] @ .
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
@@ -2757,7 +2760,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py310hb46c203_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py310hb46c203_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libcblas-3.11.0-8_hb0561ab_openblas.conda
@@ -2781,7 +2784,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
-      - conda_source: dask-core[4daf6a12] @ .
+      - conda_source: dask-core[ac39bd18] @ .
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
@@ -2813,7 +2816,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
-      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py310hdb0e946_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py310hdb0e946_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libblas-3.11.0-8_h8455456_mkl.conda
       - conda: https://prefix.dev/conda-forge/win-64/libcblas-3.11.0-8_h2a3cdd5_mkl.conda
       - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
@@ -2842,7 +2845,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
-      - conda_source: dask-core[e7cea6b0] @ .
+      - conda_source: dask-core[7581a683] @ .
   mindeps-dataframe:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -2864,7 +2867,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.267-h51dfee4_8.conda
       - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py310h3406613_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py310h3406613_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
       - conda: https://prefix.dev/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
@@ -2961,7 +2964,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[cfea4cc3] @ .
+      - conda_source: dask-core[f391cbf4] @ .
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.7.20-haea164f_0.conda
@@ -2979,7 +2982,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.267-he30cb05_8.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.1-py310h3b5aacf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.3-py310h3b5aacf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gflags-2.2.2-h5ad3122_1005.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/glog-0.7.1-h468a4a4_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
@@ -3077,7 +3080,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[058df287] @ .
+      - conda_source: dask-core[f372236f] @ .
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
@@ -3127,7 +3130,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.267-h108e708_8.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py310hb46c203_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py310hb46c203_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
@@ -3185,7 +3188,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - conda_source: dask-core[4daf6a12] @ .
+      - conda_source: dask-core[ac39bd18] @ .
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
@@ -3234,7 +3237,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.267-h12f3f85_8.conda
       - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://prefix.dev/conda-forge/win-64/c-ares-1.34.6-hfd05255_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py310hdb0e946_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py310hdb0e946_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/krb5-1.22.2-h719d79b_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libabseil-20240116.2-cxx17_he0c23c2_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libarrow-16.0.0-h107e38f_1_cpu.conda
@@ -3292,7 +3295,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - conda_source: dask-core[e7cea6b0] @ .
+      - conda_source: dask-core[7581a683] @ .
   mindeps-distributed:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -3300,7 +3303,7 @@ environments:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py310h3406613_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py310h3406613_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
@@ -3315,7 +3318,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/markupsafe-3.0.3-py310h3406613_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py310h03d9f68_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py310h03d9f68_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/psutil-7.2.2-py310h139afa4_0.conda
@@ -3359,12 +3362,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[cfea4cc3] @ .
-      - conda_source: distributed[f47febc1] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[f391cbf4] @ .
+      - conda_source: distributed[45a1d59d] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.1-py310h3b5aacf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.3-py310h3b5aacf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
@@ -3380,7 +3383,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libzlib-1.3.2-hdc9db2a_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/markupsafe-3.0.3-py310h3b5aacf_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py310h0992a49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.1-py310h0992a49_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/psutil-7.2.2-py310hef25091_0.conda
@@ -3424,8 +3427,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[058df287] @ .
-      - conda_source: distributed[208732bf] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[f372236f] @ .
+      - conda_source: distributed[298b9d04] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
@@ -3461,7 +3464,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py310hb46c203_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py310hb46c203_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
@@ -3470,7 +3473,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/markupsafe-3.0.3-py310hb46c203_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py310h1c35771_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py310h1c35771_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/psutil-7.2.2-py310haea493c_0.conda
@@ -3480,8 +3483,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tornado-6.5.7-py310h72544b6_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
-      - conda_source: dask-core[4daf6a12] @ .
-      - conda_source: distributed[a8efca05] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[ac39bd18] @ .
+      - conda_source: distributed[de5a2f6f] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
@@ -3517,14 +3520,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
-      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py310hdb0e946_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py310hdb0e946_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.53.2-hf5d6505_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/markupsafe-3.0.3-py310hdb0e946_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.0-py310he9f1925_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.1-py310he9f1925_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/psutil-7.2.2-py310h1637853_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/python-3.10.20-hc20f281_1_cpython.conda
@@ -3537,8 +3540,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
-      - conda_source: dask-core[e7cea6b0] @ .
-      - conda_source: distributed[2f8bebff] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[7581a683] @ .
+      - conda_source: distributed[ae0f1589] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
   mindeps-non-optional:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -3546,7 +3549,7 @@ environments:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py310h3406613_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py310h3406613_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
@@ -3596,11 +3599,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[cfea4cc3] @ .
+      - conda_source: dask-core[f391cbf4] @ .
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.1-py310h3b5aacf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.3-py310h3b5aacf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libexpat-2.8.1-hfae3067_1.conda
@@ -3652,7 +3655,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[058df287] @ .
+      - conda_source: dask-core[f372236f] @ .
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.1.8-pyh707e725_0.conda
@@ -3684,7 +3687,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py310hb46c203_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py310hb46c203_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
@@ -3698,7 +3701,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
-      - conda_source: dask-core[4daf6a12] @ .
+      - conda_source: dask-core[ac39bd18] @ .
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.1.8-pyh7428d3b_0.conda
@@ -3730,7 +3733,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
-      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py310hdb0e946_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py310hdb0e946_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
@@ -3746,7 +3749,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
-      - conda_source: dask-core[e7cea6b0] @ .
+      - conda_source: dask-core[7581a683] @ .
   mindeps-optional:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -3784,7 +3787,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cffi-2.0.0-py310he7384ee_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/contourpy-1.3.2-py310h3788b33_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py310h3406613_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py310h3406613_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cramjam-2.11.0-py310hc73f283_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/crick-0.0.5-py310h91a95bf_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
@@ -3917,7 +3920,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/matplotlib-base-3.5.0-py310h23f4a51_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/mmh3-3.0.0-py310hd8f1fbe_3.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py310h03d9f68_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py310h03d9f68_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/multidict-6.7.1-py310h3406613_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/nbconvert-6.4.4-py310hff52083_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
@@ -3969,13 +3972,13 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.7-py310h7c4b9e2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/unicodedata2-17.0.1-py310h7c4b9e2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.1-py310h7c4b9e2_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.2-py310h7c4b9e2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
@@ -4134,8 +4137,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zarr-2.12.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[cfea4cc3] @ .
-      - conda_source: distributed[f47febc1] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[f391cbf4] @ .
+      - conda_source: distributed[45a1d59d] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiobotocore-1.4.1-pyhd8ed1ab_0.tar.bz2
@@ -4299,7 +4302,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/cairo-1.18.4-h6a3b0d2_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cffi-2.0.0-py310hf5b66c1_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/contourpy-1.3.2-py310h7f4e7e6_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py310hb46c203_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py310hb46c203_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cramjam-2.11.0-py310h65fda45_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/crick-0.0.5-py310hb3e58dc_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cytoolz-0.11.2-py310hf8d0d8f_2.tar.bz2
@@ -4393,7 +4396,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/matplotlib-3.5.0-py310hb6292c7_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-arm64/matplotlib-base-3.5.0-py310hacb9267_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-arm64/mmh3-3.0.0-py310h0f1eb42_3.tar.bz2
-      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py310h1c35771_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py310h1c35771_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/multidict-6.7.1-py310h53a546b_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/nbconvert-6.4.4-py310hbe9552e_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
@@ -4436,7 +4439,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tornado-6.5.7-py310h72544b6_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/unicodedata2-17.0.1-py310h72544b6_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.1-py310h72544b6_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.2-py310h72544b6_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xxhash-0.8.0-h27ca646_3.tar.bz2
@@ -4445,8 +4448,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/zeromq-4.3.5-h10816f8_11.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - conda_source: dask-core[4daf6a12] @ .
-      - conda_source: distributed[a8efca05] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[ac39bd18] @ .
+      - conda_source: distributed[de5a2f6f] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/aiobotocore-1.4.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.2-pyhd8ed1ab_0.conda
@@ -4612,7 +4615,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/cffi-2.0.0-py310h29418f3_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/charls-2.4.4-h7cafa3a_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/contourpy-1.3.2-py310hc19bc0b_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py310hdb0e946_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py310hdb0e946_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cramjam-2.11.0-py310h806c824_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/crick-0.0.5-py310hb0944cc_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/cytoolz-0.11.2-py310he2412df_2.tar.bz2
@@ -4713,7 +4716,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/matplotlib-base-3.5.0-py310h79a7439_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/win-64/mkl-2024.2.2-h57928b3_16.conda
       - conda: https://prefix.dev/conda-forge/win-64/mmh3-3.0.0-py310h00ffb61_3.tar.bz2
-      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.0-py310he9f1925_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.1-py310he9f1925_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
       - conda: https://prefix.dev/conda-forge/win-64/multidict-6.7.1-py310hdb0e946_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/nbconvert-6.4.4-py310h5588dad_0.tar.bz2
@@ -4770,7 +4773,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.1-py310h29418f3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.2-py310h29418f3_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-kbproto-1.0.7-hcd874cb_1002.tar.bz2
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libice-1.1.1-hcd874cb_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libsm-1.2.4-hcd874cb_0.conda
@@ -4792,8 +4795,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/zlib-ng-2.2.5-h32d8bfd_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - conda_source: dask-core[e7cea6b0] @ .
-      - conda_source: distributed[2f8bebff] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[7581a683] @ .
+      - conda_source: distributed[ae0f1589] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
   nightly:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -4805,7 +4808,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/brotli-python-1.2.0-py314h3de4e8d_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py314h67df5f8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py314h67df5f8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
@@ -4827,7 +4830,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/markupsafe-3.0.3-py314h67df5f8_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py314h9891dd4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py314h9891dd4_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/nodejs-26.3.1-he4ff34a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
@@ -4837,7 +4840,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.7-py314h5bd0f2a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.1-py314h5bd0f2a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.2-py314h5bd0f2a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda
@@ -4852,6 +4855,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
@@ -4870,7 +4874,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/propcache-0.5.2-pyh7db6752_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -4890,12 +4894,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/yarl-1.24.2-pyh7db6752_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
-      - conda_source: dask-core[cfea4cc3] @ .
-      - conda_source: distributed[f47febc1] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
-      - conda_source: fsspec[c3b6eeef] @ continuous_integration/pixi-recipes/fsspec
-      - conda_source: s3fs[cf1e09ba] @ continuous_integration/pixi-recipes/s3fs
+      - conda_source: dask-core[f391cbf4] @ .
+      - conda_source: distributed[45a1d59d] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
+      - conda_source: fsspec[871d8b59] @ continuous_integration/pixi-recipes/fsspec
+      - conda_source: s3fs[4eac6e49] @ continuous_integration/pixi-recipes/s3fs
       - pypi: git+https://github.com/bokeh/bokeh#9eeb3e083fa27285cfc81c3867efcb7cd17e1b08
-      - pypi: git+https://github.com/zarr-developers/zarr-python#4e79f1bca6cb0fb4a1e763ae8b2706a17d0fde7e
+      - pypi: git+https://github.com/zarr-developers/zarr-python#a63ebd5390c2ddcc145f41c9baba70ec70225358
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl
@@ -4905,9 +4909,9 @@ environments:
       - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/h5py/3.16.0/h5py-3.16.0-cp314-cp314-manylinux_2_28_x86_64.whl
       - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/numpy/2.6.0.dev0/numpy-2.6.0.dev0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/pandas/3.1.0.dev0+1043.gaee9241b41/pandas-3.1.0.dev0+1043.gaee9241b41-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/pyarrow/25.0.0.dev168/pyarrow-25.0.0.dev168-cp314-cp314-manylinux_2_28_x86_64.whl
+      - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/pyarrow/25.0.0.dev174/pyarrow-25.0.0.dev174-cp314-cp314-manylinux_2_28_x86_64.whl
       - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/scipy/1.19.0.dev0/scipy-1.19.0.dev0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/xarray/2026.4.1.dev23+g214450fd5/xarray-2026.4.1.dev23+g214450fd5-py3-none-any.whl
+      - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/xarray/2026.4.1.dev25+g12fc7628d/xarray-2026.4.1.dev25+g12fc7628d-py3-none-any.whl
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.2-pyhd8ed1ab_0.conda
@@ -4921,6 +4925,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
@@ -4939,7 +4944,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/propcache-0.5.2-pyh7db6752_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -4962,7 +4967,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/brotli-python-1.2.0-py314h3daef5d_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py314h6e9b3f0_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py314h6e9b3f0_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
@@ -4979,7 +4984,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/markupsafe-3.0.3-py314h6e9b3f0_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py314h6cfcd04_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py314h6cfcd04_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/nodejs-26.3.1-h7039424_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
@@ -4989,15 +4994,15 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tornado-6.5.7-py314h6c2aa35_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.1-py314h6c2aa35_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.2-py314h6c2aa35_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - conda_source: dask-core[4daf6a12] @ .
-      - conda_source: distributed[a8efca05] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
-      - conda_source: fsspec[d78c3b1e] @ continuous_integration/pixi-recipes/fsspec
-      - conda_source: s3fs[45be35c0] @ continuous_integration/pixi-recipes/s3fs
+      - conda_source: dask-core[ac39bd18] @ .
+      - conda_source: distributed[de5a2f6f] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
+      - conda_source: fsspec[4d3e4f2e] @ continuous_integration/pixi-recipes/fsspec
+      - conda_source: s3fs[f7deada0] @ continuous_integration/pixi-recipes/s3fs
       - pypi: git+https://github.com/bokeh/bokeh#9eeb3e083fa27285cfc81c3867efcb7cd17e1b08
-      - pypi: git+https://github.com/zarr-developers/zarr-python#4e79f1bca6cb0fb4a1e763ae8b2706a17d0fde7e
+      - pypi: git+https://github.com/zarr-developers/zarr-python#a63ebd5390c2ddcc145f41c9baba70ec70225358
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl
@@ -5007,9 +5012,9 @@ environments:
       - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/h5py/3.16.0/h5py-3.16.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/numpy/2.6.0.dev0/numpy-2.6.0.dev0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/pandas/3.1.0.dev0+1043.gaee9241b41/pandas-3.1.0.dev0+1043.gaee9241b41-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/pyarrow/25.0.0.dev168/pyarrow-25.0.0.dev168-cp314-cp314-macosx_12_0_arm64.whl
+      - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/pyarrow/25.0.0.dev174/pyarrow-25.0.0.dev174-cp314-cp314-macosx_12_0_arm64.whl
       - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/scipy/1.19.0.dev0/scipy-1.19.0.dev0-cp314-cp314-macosx_12_0_arm64.whl
-      - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/xarray/2026.4.1.dev23+g214450fd5/xarray-2026.4.1.dev23+g214450fd5-py3-none-any.whl
+      - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/xarray/2026.4.1.dev25+g12fc7628d/xarray-2026.4.1.dev25+g12fc7628d-py3-none-any.whl
   py310:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -5055,7 +5060,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/cffi-2.0.0-py310he7384ee_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/charls-2.4.4-hecca717_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/contourpy-1.3.2-py310h3788b33_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py310h3406613_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py310h3406613_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cramjam-2.11.0-py310hc73f283_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/crick-0.0.8-py310hf462985_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cryptography-49.0.0-py310hb288b08_0.conda
@@ -5187,7 +5192,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/mmh3-5.2.1-py310hea6c23e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py310h03d9f68_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py310h03d9f68_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/multidict-6.7.1-py310h3406613_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/numba-0.65.1-py310h225f558_1.conda
@@ -5239,14 +5244,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.7-py310h7c4b9e2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/unicodedata2-17.0.1-py310h7c4b9e2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.1-py310h7c4b9e2_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.2-py310h7c4b9e2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
@@ -5300,6 +5305,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.10.20-py310hd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -5384,12 +5390,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -5444,8 +5450,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[cfea4cc3] @ .
-      - conda_source: distributed[f47febc1] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[f391cbf4] @ .
+      - conda_source: distributed[45a1d59d] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aiohttp-3.14.1-py310h37690e7_0.conda
@@ -5487,7 +5493,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cffi-2.0.0-py310h0826a50_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/charls-2.4.4-hfae3067_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/contourpy-1.3.2-py310hf54e67a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.1-py310h3b5aacf_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.3-py310h3b5aacf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cramjam-2.11.0-py310h1584b54_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cryptography-49.0.0-py310hd689a9d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6c5dea3_0.conda
@@ -5618,7 +5624,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mmh3-5.2.1-py310h57cea71_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mpc-1.4.0-he6dc3fb_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mpfr-4.2.2-h3faef18_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py310h0992a49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.1-py310h0992a49_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/multidict-6.7.1-py310h2d8da20_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/numba-0.65.1-py310h7515470_1.conda
@@ -5669,14 +5675,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/tornado-6.5.7-py310ha7967c6_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/unicodedata2-17.0.1-py310h5b55623_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/wayland-1.25.0-h4f8a99f_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.1-py310h5b55623_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.2-py310h5b55623_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-0.4.1-hca56bd8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-cursor-0.1.6-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.47-h80f16a2_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.48-h80f16a2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
@@ -5730,6 +5736,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.10.20-py310hd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -5813,12 +5820,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -5873,8 +5880,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zarr-2.18.3-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[058df287] @ .
-      - conda_source: distributed[208732bf] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[f372236f] @ .
+      - conda_source: distributed[298b9d04] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda
@@ -5902,6 +5909,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.10.20-py310hd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -5985,12 +5993,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -6082,7 +6090,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/cffi-2.0.0-py310hf5b66c1_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/charls-2.4.4-hf6b4638_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/contourpy-1.3.2-py310h7f4e7e6_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py310hb46c203_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py310hb46c203_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cramjam-2.11.0-py310h65fda45_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/crick-0.0.8-py310hc12b6d3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cryptography-49.0.0-py310hd8a2500_0.conda
@@ -6187,7 +6195,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/mmh3-5.2.1-py310h8616463_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py310h1c35771_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py310h1c35771_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/multidict-6.7.1-py310h53a546b_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/numba-0.65.1-py310h71bca05_1.conda
@@ -6234,7 +6242,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tornado-6.5.7-py310h72544b6_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/unicodedata2-17.0.1-py310h72544b6_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.1-py310h72544b6_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.2-py310h72544b6_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xxhash-0.8.3-haa4e116_0.conda
@@ -6248,8 +6256,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-ng-2.2.5-h3470cca_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstandard-0.25.0-py310hf151d32_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - conda_source: dask-core[4daf6a12] @ .
-      - conda_source: distributed[a8efca05] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[ac39bd18] @ .
+      - conda_source: distributed[de5a2f6f] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.2-pyhd8ed1ab_0.conda
@@ -6356,12 +6364,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -6452,7 +6460,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/cffi-2.0.0-py310h29418f3_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/charls-2.4.4-h7cafa3a_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/contourpy-1.3.2-py310hc19bc0b_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py310hdb0e946_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py310hdb0e946_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cramjam-2.11.0-py310h806c824_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/crick-0.0.8-py310hb0944cc_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cryptography-49.0.0-py310hff68572_0.conda
@@ -6552,7 +6560,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/mmh3-5.2.1-py310h73ae2b4_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mpc-1.4.0-hc817d3a_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mpfr-4.2.2-h883a981_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.0-py310he9f1925_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.1-py310he9f1925_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/multidict-6.7.1-py310hdb0e946_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/numba-0.65.1-py310h04bad52_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/numcodecs-0.13.1-py310hb4db72f_0.conda
@@ -6607,7 +6615,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda
-      - conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.1-py310h29418f3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.2-py310h29418f3_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libice-1.1.2-h0e40799_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libsm-1.2.6-h0e40799_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libx11-1.8.13-hfa52320_0.conda
@@ -6627,8 +6635,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/zlib-ng-2.2.5-h32d8bfd_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstandard-0.25.0-py310h1637853_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - conda_source: dask-core[e7cea6b0] @ .
-      - conda_source: distributed[2f8bebff] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[7581a683] @ .
+      - conda_source: distributed[ae0f1589] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
   py311:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -6675,7 +6683,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/cffi-2.0.0-py311h03d9500_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/charls-2.4.4-hecca717_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/contourpy-1.3.3-py311h724c32c_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py311h3778330_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py311h3778330_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cramjam-2.11.0-py311hc665cac_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/crick-0.0.8-py311h9f3472d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cryptography-49.0.0-py311h2005dd1_0.conda
@@ -6811,7 +6819,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/mmh3-5.2.1-py311h1ddb823_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py311hdf67eae_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py311hdf67eae_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/multidict-6.7.1-py311h3778330_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
@@ -6865,14 +6873,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.7-py311h49ec1c0_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/unicodedata2-17.0.1-py311h49ec1c0_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.1-py311h49ec1c0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.2-py311h49ec1c0_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
@@ -6921,6 +6929,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.11.15-py311hd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -7006,12 +7015,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -7066,8 +7075,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zarr-3.1.6-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[cfea4cc3] @ .
-      - conda_source: distributed[f47febc1] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[f391cbf4] @ .
+      - conda_source: distributed[45a1d59d] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aiohttp-3.14.1-py311hf076524_0.conda
@@ -7110,7 +7119,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cffi-2.0.0-py311h460c349_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/charls-2.4.4-hfae3067_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/contourpy-1.3.3-py311h04741b4_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.1-py311h2dad8b0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.3-py311h2dad8b0_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cramjam-2.11.0-py311heff485a_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cryptography-49.0.0-py311h53955a0_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6598af7_1.conda
@@ -7245,7 +7254,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mmh3-5.2.1-py311h2cb90db_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mpc-1.4.0-he6dc3fb_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mpfr-4.2.2-h3faef18_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py311hfca10b7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.1-py311hfca10b7_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/multidict-6.7.1-py311h164a683_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/nlohmann_json-3.12.0-h7ac5ae9_1.conda
@@ -7298,14 +7307,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/tornado-6.5.7-py311hb9158a3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/unicodedata2-17.0.1-py311h19352d5_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/wayland-1.25.0-h4f8a99f_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.1-py311h19352d5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.2-py311h19352d5_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-0.4.1-hca56bd8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-cursor-0.1.6-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.47-h80f16a2_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.48-h80f16a2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
@@ -7354,6 +7363,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.11.15-py311hd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -7438,12 +7448,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -7498,8 +7508,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zarr-3.1.6-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[058df287] @ .
-      - conda_source: distributed[208732bf] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[f372236f] @ .
+      - conda_source: distributed[298b9d04] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda
@@ -7525,6 +7535,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.11.15-py311hd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -7609,12 +7620,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -7707,7 +7718,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/cffi-2.0.0-py311hd10dc20_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/charls-2.4.4-hf6b4638_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/contourpy-1.3.3-py311h7d85929_4.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py311hc290fe0_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py311hc290fe0_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cramjam-2.11.0-py311he2d96a4_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/crick-0.0.8-py311h18599de_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cryptography-49.0.0-py311hbb43c59_0.conda
@@ -7816,7 +7827,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/mmh3-5.2.1-py311h8325047_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py311h572238d_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py311h572238d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/multidict-6.7.1-py311ha275503_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_1.conda
@@ -7865,7 +7876,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tornado-6.5.7-py311hc949640_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/unicodedata2-17.0.1-py311hc949640_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.1-py311hc949640_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.2-py311hc949640_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xxhash-0.8.3-haa4e116_0.conda
@@ -7876,8 +7887,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - conda_source: dask-core[4daf6a12] @ .
-      - conda_source: distributed[a8efca05] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[ac39bd18] @ .
+      - conda_source: distributed[de5a2f6f] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.2-pyhd8ed1ab_0.conda
@@ -7983,12 +7994,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -8081,7 +8092,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/cffi-2.0.0-py311h3485c13_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/charls-2.4.4-h7cafa3a_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/contourpy-1.3.3-py311h275cad7_4.conda
-      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py311h3f79411_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py311h3f79411_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cramjam-2.11.0-py311ha4bd366_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/crick-0.0.8-py311h0a17f05_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cryptography-49.0.0-py311h2098ed6_0.conda
@@ -8184,7 +8195,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/mmh3-5.2.1-py311h3e6a449_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mpc-1.4.0-hc817d3a_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mpfr-4.2.2-h883a981_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.0-py311h3fd045d_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.1-py311h3fd045d_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/multidict-6.7.1-py311h3f79411_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/nlohmann_json-3.12.0-h5112557_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/numba-0.65.1-py311h34437f8_1.conda
@@ -8241,7 +8252,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda
-      - conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.1-py311h3485c13_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.2-py311h3485c13_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libice-1.1.2-h0e40799_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libsm-1.2.6-h0e40799_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libx11-1.8.13-hfa52320_0.conda
@@ -8258,8 +8269,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/zlib-ng-2.3.3-h0261ad2_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - conda_source: dask-core[e7cea6b0] @ .
-      - conda_source: distributed[2f8bebff] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[7581a683] @ .
+      - conda_source: distributed[ae0f1589] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
   py312:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -8272,19 +8283,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.3-hea842a7_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.3-hd2277e8_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.14-h78948cc_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.14.0-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-haa0cbde_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-event-stream-0.7.1-h9cf6be0_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.11.0-h6488f85_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-h3bf836e_5.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.15.2-h0d2f46f_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.5-hb916526_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-haa0cbde_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.16.0-h0d2f46f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.6-hb916526_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.5-haa0cbde_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-haa0cbde_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.40.0-h41299d8_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.747-h6154047_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.40.1-h7a9a9d6_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.747-hf4c7647_7.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-core-cpp-1.16.3-h206d751_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-identity-cpp-1.13.3-h71f81a8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-storage-blobs-cpp-12.18.0-h74b55db_1.conda
@@ -8306,7 +8317,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/charls-2.4.4-hecca717_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py312h8a5da7c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py312h8a5da7c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cramjam-2.11.0-py312h848b54d_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/crick-0.0.8-py312hc0a28a1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cryptography-49.0.0-py312ha4b625e_0.conda
@@ -8338,10 +8349,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
       - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py312ha829cd9_102.conda
       - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h735b18d_107.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h7d5651c_108.conda
       - conda: https://prefix.dev/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py312h7a14548_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py312he3a1cdd_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/kiwisolver-1.5.0-py312h0a2e395_0.conda
@@ -8352,11 +8363,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-22.0.0-h157cd41_24_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-22.0.0-h635bf11_24_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-22.0.0-h53684a4_24_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-22.0.0-h635bf11_24_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-22.0.0-hb4dd7c2_24_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-22.0.0-hb646d72_25_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-22.0.0-h635bf11_25_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-22.0.0-h53684a4_25_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-22.0.0-h635bf11_25_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-22.0.0-hb4dd7c2_25_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.2-hf998032_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
@@ -8407,7 +8418,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-1.27.0-h9692893_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libparquet-22.0.0-h7376487_24_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libparquet-22.0.0-h7376487_25_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpq-18.4-hd5a49e9_0.conda
@@ -8443,7 +8454,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/mmh3-5.2.1-py312h1289d80_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py312hd9148b4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py312hd9148b4_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/multidict-6.7.1-py312h8a5da7c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
@@ -8452,7 +8463,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/numexpr-2.14.1-py312h88efc94_102.conda
       - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.2.6-py312h72c5963_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.29.0-h8d634f6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.30.1-h8d634f6_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/orc-2.3.0-h21090e2_0.conda
@@ -8486,25 +8497,25 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.4-h92489ea_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/scikit-image-0.26.0-np2py312h4ae17e4_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/scikit-learn-1.9.0-np2py312h3226591_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.18.0-py312h54fa4ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/spdlog-1.17.0-hab81395_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/sqlalchemy-2.0.51-py312h5253ce2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/tiledb-2.30.1-h83b82d1_12.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tiledb-2.30.1-h1c34289_13.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tiledb-py-0.36.1-py312h64554a1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.7-py312h4c3975b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.1-py312h4c3975b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.2-py312h4c3975b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
@@ -8554,6 +8565,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -8639,12 +8651,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -8700,8 +8712,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zarr-3.2.1-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[cfea4cc3] @ .
-      - conda_source: distributed[f47febc1] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[f391cbf4] @ .
+      - conda_source: distributed[45a1d59d] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aiohttp-3.14.1-py312he7e3343_0.conda
@@ -8710,19 +8722,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/at-spi2-atk-2.38.0-h1f2db35_3.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/at-spi2-core-2.40.3-h1f2db35_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.3-hc916f7b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.3-h5c394e5_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-cal-0.9.14-h343fa25_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-common-0.14.0-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h5b0efec_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-event-stream-0.7.1-h70cbb06_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-http-0.11.0-h9bcd1b7_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-io-0.26.3-hacd6ab7_5.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-mqtt-0.15.2-h3479d1b_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.12.5-hdd40dfe_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h5b0efec_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-mqtt-0.16.0-h3479d1b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.12.6-hdd40dfe_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.5-h5b0efec_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-checksums-0.2.10-h5b0efec_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-crt-cpp-0.40.0-hf7c79f2_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.747-hf48beb8_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-crt-cpp-0.40.1-h0495e26_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.747-h6aa9b71_7.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-core-cpp-1.16.3-h412bcfc_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-identity-cpp-1.13.3-hd0001b6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-storage-blobs-cpp-12.18.0-h2e50874_1.conda
@@ -8744,7 +8756,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cffi-2.0.0-py312h1b372e3_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/charls-2.4.4-hfae3067_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/contourpy-1.3.3-py312hf18b547_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.1-py312hd077ced_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.3-py312hd077ced_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cramjam-2.11.0-py312hf40da19_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cryptography-49.0.0-py312h96535df_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6598af7_1.conda
@@ -8775,10 +8787,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py312hfc41986_102.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/harfbuzz-14.2.1-h1134a53_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h02c88d6_107.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h0973965_108.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py312h33d290e_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py312ha5741de_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/jxrlib-1.1-h31becfc_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/kiwisolver-1.5.0-py312h1683e8e_0.conda
@@ -8789,11 +8801,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libabseil-20260107.1-cxx17_h6983b43_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libaec-1.1.5-hff7e48a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-22.0.0-h5dfeb67_24_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-22.0.0-hb326ee9_24_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-compute-22.0.0-hdd99842_24_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-22.0.0-hb326ee9_24_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-22.0.0-hf29bd21_24_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-22.0.0-h2ee4372_25_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-22.0.0-hb326ee9_25_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-compute-22.0.0-hdd99842_25_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-22.0.0-hb326ee9_25_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-22.0.0-hf29bd21_25_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libavif16-1.4.2-h1641d3b_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlicommon-1.2.0-he30d5cf_1.conda
@@ -8844,7 +8856,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopengl-1.7.0-hd24410f_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopentelemetry-cpp-1.27.0-hd82aec3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopentelemetry-cpp-headers-1.27.0-h8af1aa0_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-22.0.0-h87079af_24_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-22.0.0-h87079af_25_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpciaccess-0.19-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpq-18.4-hccacd55_0.conda
@@ -8880,7 +8892,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mmh3-5.2.1-py312h1ab2c47_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mpc-1.4.0-he6dc3fb_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mpfr-4.2.2-h3faef18_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py312h4f740d2_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.1-py312h4f740d2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/multidict-6.7.1-py312ha4530ae_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/nlohmann_json-3.12.0-h7ac5ae9_1.conda
@@ -8889,7 +8901,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/numexpr-2.14.1-py312h9d07d4d_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-2.2.6-py312hce01fe4_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/openjph-0.29.0-h55827e0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/openjph-0.30.1-h55827e0_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openldap-2.6.13-h2fb54aa_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/orc-2.3.0-hce1ac79_0.conda
@@ -8922,25 +8934,25 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/s2n-1.7.4-h5288e76_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/scikit-image-0.26.0-np2py312hf5fa608_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/scikit-learn-1.9.0-np2py312hca49013_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.17.1-py312ha7f05e0_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.18.0-py312ha7f05e0_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/snappy-1.2.2-he774c54_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/spdlog-1.17.0-h9f97df7_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/sqlalchemy-2.0.51-py312h2fc9c67_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/svt-av1-4.0.1-hfae3067_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/tiledb-2.30.1-ha20e67a_12.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/tiledb-2.30.1-h4e56350_13.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/tiledb-py-0.36.1-py312h3075569_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/tornado-6.5.7-py312hefbd42c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/unicodedata2-17.0.1-py312hcd1a082_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/wayland-1.25.0-h4f8a99f_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.1-py312hcd1a082_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.2-py312hcd1a082_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-0.4.1-hca56bd8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-cursor-0.1.6-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.47-h80f16a2_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.48-h80f16a2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
@@ -8990,6 +9002,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -9074,12 +9087,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -9135,8 +9148,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zarr-3.2.1-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[058df287] @ .
-      - conda_source: distributed[208732bf] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[f372236f] @ .
+      - conda_source: distributed[298b9d04] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
@@ -9163,6 +9176,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -9247,12 +9261,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -9312,19 +9326,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/aiohttp-3.14.1-py312h9f8c436_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aom-3.14.1-pl5321h513545f_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/atk-1.0-2.38.0-hd03087b_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.3-hceed5df_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-cal-0.9.14-h81c6212_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-common-0.14.0-h84a0fba_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-compression-0.3.2-h61d3404_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-event-stream-0.7.1-h7e6a3cf_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-http-0.11.0-h0a63974_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_5.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-mqtt-0.15.2-ha70999f_4.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.12.5-h43def2a_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h61d3404_6.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-mqtt-0.16.0-ha70999f_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-checksums-0.2.10-h61d3404_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-crt-cpp-0.40.0-hd6eb0f7_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h55dad5a_6.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-crt-cpp-0.40.1-hb87031f_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h4e95165_7.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-core-cpp-1.16.3-he5ae378_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-identity-cpp-1.13.3-h05177fb_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.18.0-h409340b_1.conda
@@ -9346,7 +9360,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/cffi-2.0.0-py312h1b4d9a2_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/charls-2.4.4-hf6b4638_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/contourpy-1.3.3-py312h3093aea_4.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py312h04c11ed_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py312h04c11ed_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cramjam-2.11.0-py312h8eba7c0_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/crick-0.0.8-py312he0011b7_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cryptography-49.0.0-py312h1238841_0.conda
@@ -9375,10 +9389,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py312h585e8c8_102.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/harfbuzz-14.2.1-h3103d1b_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_h9bfbf6c_107.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hb7e0c14_108.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/hicolor-icon-theme-0.17-hce30654_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py312h029426b_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py312he3e6aaf_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/jxrlib-1.1-h93a5062_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/kiwisolver-1.5.0-py312h3093aea_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
@@ -9387,11 +9401,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/lerc-4.1.0-h1eee2c3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libaec-1.1.5-h8664d51_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-22.0.0-h8abb18b_24_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-22.0.0-he2f0307_24_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-compute-22.0.0-h92c7015_24_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-22.0.0-he2f0307_24_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-22.0.0-h8746646_24_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-22.0.0-h2f99e73_25_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-22.0.0-he2f0307_25_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-compute-22.0.0-h92c7015_25_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-22.0.0-he2f0307_25_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-22.0.0-h8746646_25_cpu.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libavif16-1.4.2-h1c659b6_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
@@ -9428,7 +9442,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h08d5cc3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libparquet-22.0.0-h4b95741_24_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libparquet-22.0.0-h4b95741_25_cpu.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libprotobuf-6.33.5-h2d4b707_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libraqm-0.10.5-h29bd36a_0.conda
@@ -9456,7 +9470,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/mmh3-5.2.1-py312h6d95f44_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py312h766f71e_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py312h766f71e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/multidict-6.7.1-py312h43af8aa_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_1.conda
@@ -9465,7 +9479,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/numexpr-2.14.1-py312hb55a559_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.2.6-py312h7c1f314_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/openjph-0.29.0-h2a4d681_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/openjph-0.30.1-h2a4d681_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/orc-2.3.0-hd11884d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pandas-2.3.3-py312h5978115_2.conda
@@ -9495,17 +9509,17 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/rpds-py-2026.5.1-py312h8b1d842_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/scikit-image-0.26.0-np2py312ha921b1d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/scikit-learn-1.9.0-np2py312he5ca3e3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.17.1-py312h4519d97_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.18.0-py312h4519d97_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/spdlog-1.17.0-ha0f8610_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/sqlalchemy-2.0.51-py312hb3ab3e3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/svt-av1-4.0.1-h0cb729a_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/tiledb-2.30.1-h16333d0_12.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/tiledb-2.30.1-h6cfd315_13.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tiledb-py-0.36.1-py312hb757a55_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tornado-6.5.7-py312h2bbb03f_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/unicodedata2-17.0.1-py312h2bbb03f_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.1-py312h2bbb03f_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.2-py312h2bbb03f_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xxhash-0.8.3-haa4e116_0.conda
@@ -9516,8 +9530,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - conda_source: dask-core[4daf6a12] @ .
-      - conda_source: distributed[a8efca05] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[ac39bd18] @ .
+      - conda_source: distributed[de5a2f6f] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda
@@ -9625,12 +9639,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -9691,19 +9705,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/win-64/aiohttp-3.14.1-py312h6b91d65_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/aom-3.14.1-pl5321h06fc181_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.3-h75b6777_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.3-h4ad2c79_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-cal-0.9.14-h270aff2_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-common-0.14.0-hfd05255_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-compression-0.3.2-h1f21522_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-event-stream-0.7.1-hfbf5bbe_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-http-0.11.0-h4721ae0_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-io-0.26.3-h1a62f66_5.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-mqtt-0.15.2-h10b66d2_4.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.12.5-h425879c_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.4-h1f21522_6.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-mqtt-0.16.0-h10b66d2_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.12.6-h425879c_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.5-h1f21522_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-checksums-0.2.10-h1f21522_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-crt-cpp-0.40.0-hcaec180_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.747-h5d5b8b4_6.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-crt-cpp-0.40.1-hccacdf3_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.747-h042817b_7.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-core-cpp-1.16.3-h49e36cd_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-identity-cpp-1.13.3-hf9fdf8e_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-storage-blobs-cpp-12.18.0-h4fb3251_1.conda
@@ -9724,7 +9738,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/cffi-2.0.0-py312he06e257_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/charls-2.4.4-h7cafa3a_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/contourpy-1.3.3-py312h78d62e6_4.conda
-      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py312h05f76fc_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py312h05f76fc_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cramjam-2.11.0-py312h7fb921c_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/crick-0.0.8-py312h1a27103_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cryptography-49.0.0-py312h232196e_0.conda
@@ -9749,9 +9763,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/gts-0.7.6-h6b5321d_4.conda
       - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py312h5ddec8c_102.conda
       - conda: https://prefix.dev/conda-forge/win-64/harfbuzz-14.2.1-h5a1b470_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_h693361b_107.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_ha9ae7cf_108.conda
       - conda: https://prefix.dev/conda-forge/win-64/icu-78.3-h637d24d_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py312he323553_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py312h006af62_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/jxrlib-1.1-hcfcfb64_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/kiwisolver-1.5.0-py312h78d62e6_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/krb5-1.22.2-h719d79b_1.conda
@@ -9760,11 +9774,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/lerc-4.1.0-hd936e49_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libabseil-20260107.1-cxx17_h0eb2380_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libaec-1.1.5-haf901d7_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-22.0.0-hbef6419_24_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-22.0.0-h7d8d6a5_24_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-compute-22.0.0-h081cd8e_24_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-22.0.0-h7d8d6a5_24_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-22.0.0-h524e9bd_24_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-22.0.0-h54e786e_25_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-22.0.0-h7d8d6a5_25_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-compute-22.0.0-h081cd8e_25_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-22.0.0-h7d8d6a5_25_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-22.0.0-h524e9bd_25_cpu.conda
       - conda: https://prefix.dev/conda-forge/win-64/libavif16-1.4.2-h7e7b026_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libblas-3.11.0-8_h8455456_mkl.conda
       - conda: https://prefix.dev/conda-forge/win-64/libbrotlicommon-1.2.0-hfd05255_1.conda
@@ -9797,7 +9811,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libopentelemetry-cpp-1.27.0-hc88f397_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libopentelemetry-cpp-headers-1.27.0-h57928b3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libparquet-22.0.0-h7051d1f_24_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libparquet-22.0.0-h7051d1f_25_cpu.conda
       - conda: https://prefix.dev/conda-forge/win-64/libpng-1.6.58-h7351971_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libprotobuf-6.33.5-h6cf2d3c_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libraqm-0.10.5-h781ae3c_0.conda
@@ -9828,7 +9842,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/mmh3-5.2.1-py312hbb81ca0_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mpc-1.4.0-hc817d3a_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mpfr-4.2.2-h883a981_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.0-py312hf90b1b7_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.1-py312hf90b1b7_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/multidict-6.7.1-py312h05f76fc_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/nlohmann_json-3.12.0-h5112557_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/numba-0.65.1-py312h560f1c9_1.conda
@@ -9837,7 +9851,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/numpy-2.2.6-py312h3150e54_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/onemkl-license-2026.0.0-h57928b3_908.conda
       - conda: https://prefix.dev/conda-forge/win-64/openjpeg-2.5.4-h0e57b4f_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/openjph-0.29.0-hf13a347_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/openjph-0.30.1-hf13a347_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/orc-2.3.0-h8fc0eb6_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/pandas-2.3.3-py312hc128f0a_2.conda
@@ -9869,13 +9883,13 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/rpds-py-2026.5.1-py312hd944d65_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/scikit-image-0.26.0-np2py312h9ea65bc_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/scikit-learn-1.9.0-np2py312hea30aaf_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/scipy-1.17.1-py312h9b3c559_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/scipy-1.18.0-py312h9b3c559_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/snappy-1.2.2-h7fa0ca8_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/spdlog-1.17.0-h9f585f1_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/sqlalchemy-2.0.51-py312he5662c2_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/svt-av1-4.0.1-hac47afa_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/tbb-2023.0.0-hd3d4ead_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/tiledb-2.30.1-hcf33648_12.conda
+      - conda: https://prefix.dev/conda-forge/win-64/tiledb-2.30.1-h3779ff6_13.conda
       - conda: https://prefix.dev/conda-forge/win-64/tiledb-py-0.36.1-py312h401943b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/tornado-6.5.7-py312he06e257_0.conda
@@ -9885,7 +9899,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda
-      - conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.1-py312he06e257_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.2-py312he06e257_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libice-1.1.2-h0e40799_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libsm-1.2.6-h0e40799_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libx11-1.8.13-hfa52320_0.conda
@@ -9902,8 +9916,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/zlib-ng-2.3.3-h0261ad2_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - conda_source: dask-core[e7cea6b0] @ .
-      - conda_source: distributed[2f8bebff] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[7581a683] @ .
+      - conda_source: distributed[ae0f1589] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
   py313:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -9916,19 +9930,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.3-hea842a7_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.3-hd2277e8_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.14-h78948cc_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.14.0-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-haa0cbde_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-event-stream-0.7.1-h9cf6be0_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.11.0-h6488f85_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-h3bf836e_5.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.15.2-h0d2f46f_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.5-hb916526_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-haa0cbde_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.16.0-h0d2f46f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.6-hb916526_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.5-haa0cbde_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-haa0cbde_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.40.0-h41299d8_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.747-h6154047_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.40.1-h7a9a9d6_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.747-hf4c7647_7.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-core-cpp-1.16.3-h206d751_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-identity-cpp-1.13.3-h71f81a8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-storage-blobs-cpp-12.18.0-h74b55db_1.conda
@@ -9949,7 +9963,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/cffi-2.0.0-py313hf46b229_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/charls-2.4.4-hecca717_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/contourpy-1.3.3-py313hc8edb43_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py313h3dea7bd_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py313h3dea7bd_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cramjam-2.11.0-py313h7ef63f5_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cryptography-49.0.0-py313heb322e3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
@@ -9979,10 +9993,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
       - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py313h22c32d4_102.conda
       - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h735b18d_107.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h7d5651c_108.conda
       - conda: https://prefix.dev/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py313ha145c31_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py313ha402da8_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/kiwisolver-1.5.0-py313hc8edb43_0.conda
@@ -9993,11 +10007,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-24.0.0-h157cd41_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-24.0.0-h635bf11_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-24.0.0-h53684a4_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-24.0.0-h635bf11_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-24.0.0-hb4dd7c2_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-24.0.0-hb642ee7_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-24.0.0-h635bf11_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-24.0.0-h53684a4_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-24.0.0-h635bf11_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-24.0.0-hb4dd7c2_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.2-hf998032_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
@@ -10031,8 +10045,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-3.5.0-h8d2ee43_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-3.5.0-hdbdcf42_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-3.6.0-h8d2ee43_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-3.6.0-hdbdcf42_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgrpc-1.78.1-h1d1128b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libhwy-1.4.0-h10be129_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
@@ -10048,7 +10062,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-1.27.0-h9692893_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libparquet-24.0.0-h7376487_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libparquet-24.0.0-h7376487_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpq-18.4-hd5a49e9_0.conda
@@ -10084,7 +10098,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/mmh3-5.2.1-py313h7033f15_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py313h7037e92_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py313h7037e92_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/multidict-6.7.1-py313h3dea7bd_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
@@ -10093,7 +10107,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/numexpr-2.14.1-py313h24ae7f9_102.conda
       - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.6-py313hf6604e3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.29.0-h8d634f6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.30.1-h8d634f6_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/orc-2.3.0-h21090e2_0.conda
@@ -10126,21 +10140,21 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.4-h92489ea_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/scikit-image-0.26.0-np2py313hb172dc5_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/scikit-learn-1.9.0-np2py313h16d504d_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.17.1-py313h4b8bb8b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/sqlalchemy-2.0.51-py313h54dd161_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.7-py313h07c4f96_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.1-py313h07c4f96_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.2-py313h07c4f96_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
@@ -10190,6 +10204,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -10275,12 +10290,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -10334,8 +10349,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zarr-3.2.1-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[cfea4cc3] @ .
-      - conda_source: distributed[f47febc1] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[f391cbf4] @ .
+      - conda_source: distributed[45a1d59d] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aiohttp-3.14.1-py313ha60b548_0.conda
@@ -10344,19 +10359,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/at-spi2-atk-2.38.0-h1f2db35_3.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/at-spi2-core-2.40.3-h1f2db35_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.3-hc916f7b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.3-h5c394e5_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-cal-0.9.14-h343fa25_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-common-0.14.0-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h5b0efec_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-event-stream-0.7.1-h70cbb06_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-http-0.11.0-h9bcd1b7_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-io-0.26.3-hacd6ab7_5.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-mqtt-0.15.2-h3479d1b_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.12.5-hdd40dfe_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h5b0efec_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-mqtt-0.16.0-h3479d1b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.12.6-hdd40dfe_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.5-h5b0efec_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-checksums-0.2.10-h5b0efec_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-crt-cpp-0.40.0-hf7c79f2_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.747-hf48beb8_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-crt-cpp-0.40.1-h0495e26_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.747-h6aa9b71_7.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-core-cpp-1.16.3-h412bcfc_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-identity-cpp-1.13.3-hd0001b6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-storage-blobs-cpp-12.18.0-h2e50874_1.conda
@@ -10377,7 +10392,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cffi-2.0.0-py313h897158f_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/charls-2.4.4-hfae3067_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/contourpy-1.3.3-py313h75bc965_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.1-py313hfa222a2_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.3-py313hfa222a2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cramjam-2.11.0-py313h8fe519d_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cryptography-49.0.0-py313h55734c0_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6598af7_1.conda
@@ -10407,10 +10422,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py313h14703b5_102.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/harfbuzz-14.2.1-h1134a53_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h02c88d6_107.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h0973965_108.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py313h6e237fd_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py313h7daf9ad_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/jxrlib-1.1-h31becfc_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/kiwisolver-1.5.0-py313h314c631_0.conda
@@ -10421,11 +10436,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libabseil-20260107.1-cxx17_h6983b43_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libaec-1.1.5-hff7e48a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-24.0.0-h5dfeb67_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-24.0.0-hb326ee9_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-compute-24.0.0-hdd99842_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-24.0.0-hb326ee9_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-24.0.0-hf29bd21_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-24.0.0-h6b18018_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-24.0.0-hb326ee9_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-compute-24.0.0-hdd99842_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-24.0.0-hb326ee9_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-24.0.0-hf29bd21_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libavif16-1.4.2-h1641d3b_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlicommon-1.2.0-he30d5cf_1.conda
@@ -10459,8 +10474,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-3.5.0-h235f271_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-storage-3.5.0-h66d5b86_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-3.6.0-h235f271_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-storage-3.6.0-h66d5b86_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libgrpc-1.78.1-heab1e18_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libhwy-1.4.0-h0626a34_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
@@ -10476,7 +10491,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopengl-1.7.0-hd24410f_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopentelemetry-cpp-1.27.0-hd82aec3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopentelemetry-cpp-headers-1.27.0-h8af1aa0_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpciaccess-0.19-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpq-18.4-hccacd55_0.conda
@@ -10512,7 +10527,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mmh3-5.2.1-py313he352c24_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mpc-1.4.0-he6dc3fb_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mpfr-4.2.2-h3faef18_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py313he6111f0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.1-py313he6111f0_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/multidict-6.7.1-py313hd3a54cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/nlohmann_json-3.12.0-h7ac5ae9_1.conda
@@ -10521,7 +10536,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/numexpr-2.14.1-py313hc98aa87_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-2.4.6-py313h839dfd1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/openjph-0.29.0-h55827e0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/openjph-0.30.1-h55827e0_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openldap-2.6.13-h2fb54aa_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/orc-2.3.0-hce1ac79_0.conda
@@ -10554,7 +10569,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/s2n-1.7.4-h5288e76_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/scikit-image-0.26.0-np2py313h8fbd862_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/scikit-learn-1.9.0-np2py313ha4ab095_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.17.1-py313h6b7a087_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.18.0-py313h6b7a087_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/snappy-1.2.2-he774c54_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/sqlalchemy-2.0.51-py313hc37f9cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/svt-av1-4.0.1-hfae3067_0.conda
@@ -10568,7 +10583,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.47-h80f16a2_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.48-h80f16a2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
@@ -10618,6 +10633,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -10702,12 +10718,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -10761,8 +10777,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zarr-3.2.1-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[058df287] @ .
-      - conda_source: distributed[208732bf] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[f372236f] @ .
+      - conda_source: distributed[298b9d04] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
@@ -10789,6 +10805,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.13.14-py313hd8ed1ab_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -10873,12 +10890,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -10936,19 +10953,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/aiohttp-3.14.1-py313h53c0e3e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aom-3.14.1-pl5321h513545f_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/atk-1.0-2.38.0-hd03087b_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.3-hceed5df_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-cal-0.9.14-h81c6212_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-common-0.14.0-h84a0fba_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-compression-0.3.2-h61d3404_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-event-stream-0.7.1-h7e6a3cf_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-http-0.11.0-h0a63974_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_5.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-mqtt-0.15.2-ha70999f_4.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.12.5-h43def2a_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h61d3404_6.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-mqtt-0.16.0-ha70999f_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-checksums-0.2.10-h61d3404_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-crt-cpp-0.40.0-hd6eb0f7_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h55dad5a_6.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-crt-cpp-0.40.1-hb87031f_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h4e95165_7.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-core-cpp-1.16.3-he5ae378_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-identity-cpp-1.13.3-h05177fb_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.18.0-h409340b_1.conda
@@ -10969,7 +10986,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/cffi-2.0.0-py313h224173a_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/charls-2.4.4-hf6b4638_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/contourpy-1.3.3-py313h2af2deb_4.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py313h65a2061_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py313h65a2061_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cramjam-2.11.0-py313h54b25eb_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cryptography-49.0.0-py313hda5ae78_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cytoolz-1.1.0-py313h0997733_2.conda
@@ -10996,10 +11013,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py313h2c4073f_102.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/harfbuzz-14.2.1-h3103d1b_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_h9bfbf6c_107.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hb7e0c14_108.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/hicolor-icon-theme-0.17-hce30654_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py313he947694_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py313h9d12897_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/jxrlib-1.1-h93a5062_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/kiwisolver-1.5.0-py313h2af2deb_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
@@ -11008,11 +11025,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/lerc-4.1.0-h1eee2c3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libaec-1.1.5-h8664d51_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-24.0.0-hc887bfb_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-24.0.0-ha4f4840_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-compute-24.0.0-h8d10c55_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-24.0.0-ha4f4840_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-24.0.0-h05be00f_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-24.0.0-h6045e8e_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-24.0.0-ha4f4840_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-compute-24.0.0-h8d10c55_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-24.0.0-ha4f4840_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-24.0.0-h05be00f_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libavif16-1.4.2-h1c659b6_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
@@ -11035,8 +11052,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libglib-2.88.1-ha08bb59_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-3.5.0-h688a705_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-storage-3.5.0-ha114238_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-3.6.0-h688a705_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-storage-3.6.0-ha114238_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libhwy-1.4.0-ha332bbd_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
@@ -11050,7 +11067,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h08d5cc3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libparquet-24.0.0-h840b369_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libparquet-24.0.0-h840b369_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libprotobuf-6.33.5-h2d4b707_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libraqm-0.10.5-h29bd36a_0.conda
@@ -11078,7 +11095,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/mmh3-5.2.1-py313h6deaedc_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py313h5c29297_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py313h5c29297_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/multidict-6.7.1-py313haf6918d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_1.conda
@@ -11087,7 +11104,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/numexpr-2.14.1-py313h23850d5_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.4.6-py313hce9b930_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/openjph-0.29.0-h2a4d681_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/openjph-0.30.1-h2a4d681_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/orc-2.3.0-hd11884d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pandas-3.0.3-py313h1188861_0.conda
@@ -11116,13 +11133,13 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/rpds-py-2026.5.1-py313hb9d2816_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/scikit-image-0.26.0-np2py313h7c04bff_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/scikit-learn-1.9.0-np2py313h3b23316_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.17.1-py313h52f5312_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/sqlalchemy-2.0.51-py313h6688731_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/svt-av1-4.0.1-h0cb729a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tornado-6.5.7-py313h0997733_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.1-py313h0997733_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.2-py313h0997733_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xxhash-0.8.3-haa4e116_0.conda
@@ -11133,8 +11150,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - conda_source: dask-core[4daf6a12] @ .
-      - conda_source: distributed[a8efca05] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[ac39bd18] @ .
+      - conda_source: distributed[de5a2f6f] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda
@@ -11242,12 +11259,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -11307,19 +11324,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/win-64/aiohttp-3.14.1-py313h51e1470_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/aom-3.14.1-pl5321h06fc181_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.3-h75b6777_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.3-h4ad2c79_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-cal-0.9.14-h270aff2_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-common-0.14.0-hfd05255_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-compression-0.3.2-h1f21522_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-event-stream-0.7.1-hfbf5bbe_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-http-0.11.0-h4721ae0_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-io-0.26.3-h1a62f66_5.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-mqtt-0.15.2-h10b66d2_4.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.12.5-h425879c_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.4-h1f21522_6.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-mqtt-0.16.0-h10b66d2_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.12.6-h425879c_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.5-h1f21522_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-checksums-0.2.10-h1f21522_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-crt-cpp-0.40.0-hcaec180_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.747-h5d5b8b4_6.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-crt-cpp-0.40.1-hccacdf3_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.747-h042817b_7.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-core-cpp-1.16.3-h49e36cd_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-identity-cpp-1.13.3-hf9fdf8e_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-storage-blobs-cpp-12.18.0-h4fb3251_1.conda
@@ -11339,7 +11356,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/cffi-2.0.0-py313h5ea7bf4_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/charls-2.4.4-h7cafa3a_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/contourpy-1.3.3-py313h1a38498_4.conda
-      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py313hd650c13_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py313hd650c13_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cramjam-2.11.0-py313heac3b1f_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/cryptography-49.0.0-py313hf5c5e30_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cytoolz-1.1.0-py313h5ea7bf4_2.conda
@@ -11362,9 +11379,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/gts-0.7.6-h6b5321d_4.conda
       - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py313hd050a09_102.conda
       - conda: https://prefix.dev/conda-forge/win-64/harfbuzz-14.2.1-h5a1b470_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_h693361b_107.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_ha9ae7cf_108.conda
       - conda: https://prefix.dev/conda-forge/win-64/icu-78.3-h637d24d_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py313h1f6e778_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py313hf6ffc8e_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/jxrlib-1.1-hcfcfb64_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/kiwisolver-1.5.0-py313h1a38498_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/krb5-1.22.2-h719d79b_1.conda
@@ -11373,11 +11390,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/lerc-4.1.0-hd936e49_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libabseil-20260107.1-cxx17_h0eb2380_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libaec-1.1.5-haf901d7_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-24.0.0-hbef6419_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-24.0.0-h7d8d6a5_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-compute-24.0.0-h081cd8e_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-24.0.0-h7d8d6a5_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-24.0.0-h524e9bd_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-24.0.0-h9dce539_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-24.0.0-h7d8d6a5_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-compute-24.0.0-h081cd8e_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-24.0.0-h7d8d6a5_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-24.0.0-h524e9bd_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/win-64/libavif16-1.4.2-h7e7b026_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libblas-3.11.0-8_h8455456_mkl.conda
       - conda: https://prefix.dev/conda-forge/win-64/libbrotlicommon-1.2.0-hfd05255_1.conda
@@ -11397,8 +11414,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libgd-2.3.3-h4974f7c_12.conda
       - conda: https://prefix.dev/conda-forge/win-64/libglib-2.88.1-h7ce1215_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libgomp-15.2.0-h8ee18e1_19.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-3.5.0-he22669a_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-storage-3.5.0-he04ea4c_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-3.6.0-he22669a_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-storage-3.6.0-he04ea4c_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libgrpc-1.78.1-h9ff2b3e_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://prefix.dev/conda-forge/win-64/libhwy-1.4.0-h172a326_0.conda
@@ -11411,7 +11428,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libopentelemetry-cpp-1.27.0-hc88f397_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libopentelemetry-cpp-headers-1.27.0-h57928b3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libparquet-24.0.0-h7051d1f_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libparquet-24.0.0-h7051d1f_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/win-64/libpng-1.6.58-h7351971_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libprotobuf-6.33.5-h6cf2d3c_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libraqm-0.10.5-h781ae3c_0.conda
@@ -11442,7 +11459,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/mmh3-5.2.1-py313hfe59770_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mpc-1.4.0-hc817d3a_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mpfr-4.2.2-h883a981_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.0-py313hf069bd2_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.1-py313hf069bd2_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/multidict-6.7.1-py313hd650c13_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/nlohmann_json-3.12.0-h5112557_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/numba-0.65.1-py313h2da9318_1.conda
@@ -11451,7 +11468,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/numpy-2.4.6-py313ha8dc839_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/onemkl-license-2026.0.0-h57928b3_908.conda
       - conda: https://prefix.dev/conda-forge/win-64/openjpeg-2.5.4-h0e57b4f_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/openjph-0.29.0-hf13a347_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/openjph-0.30.1-hf13a347_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/orc-2.3.0-h8fc0eb6_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/pandas-3.0.3-py313h26f5e95_0.conda
@@ -11482,7 +11499,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/rpds-py-2026.5.1-py313ha9ea572_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/scikit-image-0.26.0-np2py313h33c6dc1_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/scikit-learn-1.9.0-np2py313h4ce4a18_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/scipy-1.17.1-py313he51e9a2_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/scipy-1.18.0-py313he51e9a2_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/snappy-1.2.2-h7fa0ca8_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/sqlalchemy-2.0.51-py313h5fd188c_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/svt-av1-4.0.1-hac47afa_0.conda
@@ -11494,7 +11511,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda
-      - conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.1-py313h5ea7bf4_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.2-py313h5ea7bf4_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libice-1.1.2-h0e40799_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libsm-1.2.6-h0e40799_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libx11-1.8.13-hfa52320_0.conda
@@ -11511,8 +11528,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/zlib-ng-2.3.3-h0261ad2_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - conda_source: dask-core[e7cea6b0] @ .
-      - conda_source: distributed[2f8bebff] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[7581a683] @ .
+      - conda_source: distributed[ae0f1589] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
   py314:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -11524,19 +11541,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.3-hea842a7_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.3-hd2277e8_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.14-h78948cc_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.14.0-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-haa0cbde_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-event-stream-0.7.1-h9cf6be0_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.11.0-h6488f85_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-h3bf836e_5.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.15.2-h0d2f46f_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.5-hb916526_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-haa0cbde_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.16.0-h0d2f46f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.6-hb916526_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.5-haa0cbde_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-haa0cbde_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.40.0-h41299d8_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.747-h6154047_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.40.1-h7a9a9d6_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.747-hf4c7647_7.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-core-cpp-1.16.3-h206d751_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-identity-cpp-1.13.3-h71f81a8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-storage-blobs-cpp-12.18.0-h74b55db_1.conda
@@ -11556,7 +11573,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/cffi-2.0.0-py314h4a8dc5f_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/charls-2.4.4-hecca717_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/contourpy-1.3.3-py314h97ea11e_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py314h67df5f8_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py314h67df5f8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cramjam-2.11.0-py314haf003cf_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cryptography-49.0.0-py314h7fe84b3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
@@ -11584,10 +11601,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
       - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py314hddf7a69_102.conda
       - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h735b18d_107.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h7d5651c_108.conda
       - conda: https://prefix.dev/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py314h834e057_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py314h8570d32_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/kiwisolver-1.5.0-py314h97ea11e_0.conda
@@ -11598,11 +11615,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-24.0.0-h157cd41_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-24.0.0-h635bf11_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-24.0.0-h53684a4_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-24.0.0-h635bf11_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-24.0.0-hb4dd7c2_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-24.0.0-hb642ee7_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-24.0.0-h635bf11_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-24.0.0-h53684a4_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-24.0.0-h635bf11_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-24.0.0-hb4dd7c2_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.2-hf998032_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
@@ -11636,8 +11653,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-3.5.0-h8d2ee43_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-3.5.0-hdbdcf42_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-3.6.0-h8d2ee43_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-3.6.0-hdbdcf42_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgrpc-1.78.1-h1d1128b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libhwy-1.4.0-h10be129_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
@@ -11653,7 +11670,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-1.27.0-h9692893_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libparquet-24.0.0-h7376487_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libparquet-24.0.0-h7376487_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpq-18.4-hd5a49e9_0.conda
@@ -11689,7 +11706,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/mmh3-5.2.1-py314ha160325_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py314h9891dd4_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py314h9891dd4_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/numba-0.65.1-py314h8169c2f_1.conda
@@ -11697,7 +11714,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/numexpr-2.14.1-py314heb044ea_102.conda
       - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.6-py314h2b28147_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.29.0-h8d634f6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.30.1-h8d634f6_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/orc-2.3.0-h21090e2_0.conda
@@ -11729,7 +11746,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.4-h92489ea_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/scikit-image-0.26.0-np2py314hda1ea4c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/scikit-learn-1.9.0-np2py314hf09ca88_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.17.1-py314hf07bd8e_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/sqlalchemy-2.0.51-py314h0f05182_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
@@ -11737,14 +11754,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.7-py314h5bd0f2a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/unicodedata2-17.0.1-py314h5bd0f2a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.1-py314h5bd0f2a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.2-py314h5bd0f2a_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
@@ -11796,6 +11813,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -11885,12 +11903,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -11945,8 +11963,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zarr-3.2.1-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[cfea4cc3] @ .
-      - conda_source: distributed[f47febc1] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[f391cbf4] @ .
+      - conda_source: distributed[45a1d59d] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-he30d5cf_0.conda
@@ -11954,19 +11972,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/at-spi2-atk-2.38.0-h1f2db35_3.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/at-spi2-core-2.40.3-h1f2db35_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.3-hc916f7b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.3-h5c394e5_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-cal-0.9.14-h343fa25_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-common-0.14.0-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h5b0efec_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-event-stream-0.7.1-h70cbb06_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-http-0.11.0-h9bcd1b7_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-io-0.26.3-hacd6ab7_5.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-mqtt-0.15.2-h3479d1b_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.12.5-hdd40dfe_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h5b0efec_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-mqtt-0.16.0-h3479d1b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.12.6-hdd40dfe_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.5-h5b0efec_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-checksums-0.2.10-h5b0efec_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-crt-cpp-0.40.0-hf7c79f2_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.747-hf48beb8_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-crt-cpp-0.40.1-h0495e26_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.747-h6aa9b71_7.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-core-cpp-1.16.3-h412bcfc_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-identity-cpp-1.13.3-hd0001b6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-storage-blobs-cpp-12.18.0-h2e50874_1.conda
@@ -11986,7 +12004,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cffi-2.0.0-py314h0bd77cf_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/charls-2.4.4-hfae3067_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/contourpy-1.3.3-py314ha0cc70f_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.1-py314hb76de3f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.3-py314hb76de3f_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cramjam-2.11.0-py314h614ea8d_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cryptography-49.0.0-py314hbfac26c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cyrus-sasl-2.1.28-h6598af7_1.conda
@@ -12014,10 +12032,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py314h96887de_102.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/harfbuzz-14.2.1-h1134a53_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h02c88d6_107.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h0973965_108.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py314h790143f_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py314h9dc542c_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/jxrlib-1.1-h31becfc_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/kiwisolver-1.5.0-py314h4702e76_0.conda
@@ -12028,11 +12046,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libabseil-20260107.1-cxx17_h6983b43_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libaec-1.1.5-hff7e48a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-24.0.0-h5dfeb67_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-24.0.0-hb326ee9_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-compute-24.0.0-hdd99842_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-24.0.0-hb326ee9_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-24.0.0-hf29bd21_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-24.0.0-h6b18018_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-24.0.0-hb326ee9_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-compute-24.0.0-hdd99842_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-24.0.0-hb326ee9_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-24.0.0-hf29bd21_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libavif16-1.4.2-h1641d3b_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlicommon-1.2.0-he30d5cf_1.conda
@@ -12066,8 +12084,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-3.5.0-h235f271_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-storage-3.5.0-h66d5b86_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-3.6.0-h235f271_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-storage-3.6.0-h66d5b86_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libgrpc-1.78.1-heab1e18_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libhwy-1.4.0-h0626a34_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
@@ -12083,7 +12101,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopengl-1.7.0-hd24410f_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopentelemetry-cpp-1.27.0-hd82aec3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopentelemetry-cpp-headers-1.27.0-h8af1aa0_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpciaccess-0.19-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpq-18.4-hccacd55_0.conda
@@ -12119,7 +12137,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mmh3-5.2.1-py314h02b5315_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mpc-1.4.0-he6dc3fb_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mpfr-4.2.2-h3faef18_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py314hd7d8586_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.1-py314hd7d8586_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/nlohmann_json-3.12.0-h7ac5ae9_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/numba-0.65.1-py314h8873072_1.conda
@@ -12127,7 +12145,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/numexpr-2.14.1-py314h3f24ac4_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-2.4.6-py314he1698a1_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/openjph-0.29.0-h55827e0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/openjph-0.30.1-h55827e0_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openldap-2.6.13-h2fb54aa_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/orc-2.3.0-hce1ac79_0.conda
@@ -12159,7 +12177,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/s2n-1.7.4-h5288e76_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/scikit-image-0.26.0-np2py314h018c8c3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/scikit-learn-1.9.0-np2py314hcefaf23_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.17.1-py314h052a9b3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.18.0-py314h052a9b3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/snappy-1.2.2-he774c54_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/sqlalchemy-2.0.51-py314hf8f541d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/svt-av1-4.0.1-hfae3067_0.conda
@@ -12167,14 +12185,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/tornado-6.5.7-py314hafb4487_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/unicodedata2-17.0.1-py314h51f160d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/wayland-1.25.0-h4f8a99f_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.1-py314h51f160d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.2-py314h51f160d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-0.4.1-hca56bd8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-cursor-0.1.6-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-image-0.4.0-h5c728e9_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.1-h5c728e9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.10-h5c728e9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-wm-0.4.2-h5c728e9_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.47-h80f16a2_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.48-h80f16a2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
@@ -12226,6 +12244,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -12314,12 +12333,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -12374,8 +12393,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zarr-3.2.1-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
-      - conda_source: dask-core[058df287] @ .
-      - conda_source: distributed[208732bf] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[f372236f] @ .
+      - conda_source: distributed[298b9d04] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
@@ -12405,6 +12424,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_100.conda
       - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
@@ -12493,12 +12513,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -12556,19 +12576,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aom-3.14.1-pl5321h513545f_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/atk-1.0-2.38.0-hd03087b_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.3-hceed5df_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-cal-0.9.14-h81c6212_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-common-0.14.0-h84a0fba_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-compression-0.3.2-h61d3404_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-event-stream-0.7.1-h7e6a3cf_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-http-0.11.0-h0a63974_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_5.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-mqtt-0.15.2-ha70999f_4.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.12.5-h43def2a_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h61d3404_6.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-mqtt-0.16.0-ha70999f_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-checksums-0.2.10-h61d3404_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-crt-cpp-0.40.0-hd6eb0f7_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h55dad5a_6.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-crt-cpp-0.40.1-hb87031f_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h4e95165_7.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-core-cpp-1.16.3-he5ae378_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-identity-cpp-1.13.3-h05177fb_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.18.0-h409340b_1.conda
@@ -12588,7 +12608,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/cffi-2.0.0-py314h44086f9_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/charls-2.4.4-hf6b4638_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/contourpy-1.3.3-py314hf8a3a22_4.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py314h6e9b3f0_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py314h6e9b3f0_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cramjam-2.11.0-py314he20b14d_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cryptography-49.0.0-py314h0d331bb_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/cytoolz-1.1.0-py314h6c2aa35_2.conda
@@ -12613,10 +12633,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py314h658a3ac_102.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/harfbuzz-14.2.1-h3103d1b_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_h9bfbf6c_107.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hb7e0c14_108.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/hicolor-icon-theme-0.17-hce30654_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py314hcca8607_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py314hdaaf36e_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/jxrlib-1.1-h93a5062_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/kiwisolver-1.5.0-py314hf8a3a22_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
@@ -12625,11 +12645,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/lerc-4.1.0-h1eee2c3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libaec-1.1.5-h8664d51_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-24.0.0-hc887bfb_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-24.0.0-ha4f4840_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-compute-24.0.0-h8d10c55_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-24.0.0-ha4f4840_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-24.0.0-h05be00f_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-24.0.0-h6045e8e_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-24.0.0-ha4f4840_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-compute-24.0.0-h8d10c55_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-24.0.0-ha4f4840_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-24.0.0-h05be00f_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libavif16-1.4.2-h1c659b6_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
@@ -12652,8 +12672,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libglib-2.88.1-ha08bb59_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-3.5.0-h688a705_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-storage-3.5.0-ha114238_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-3.6.0-h688a705_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-storage-3.6.0-ha114238_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libhwy-1.4.0-ha332bbd_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
@@ -12667,7 +12687,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h08d5cc3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libparquet-24.0.0-h840b369_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libparquet-24.0.0-h840b369_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libprotobuf-6.33.5-h2d4b707_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libraqm-0.10.5-h29bd36a_0.conda
@@ -12695,7 +12715,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/mmh3-5.2.1-py314h4ed92d5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py314h6cfcd04_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py314h6cfcd04_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/numba-0.65.1-py314hb38061f_1.conda
@@ -12703,7 +12723,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/numexpr-2.14.1-py314hac0e451_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.4.6-py314hb79c6fa_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/openjph-0.29.0-h2a4d681_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/openjph-0.30.1-h2a4d681_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/orc-2.3.0-hd11884d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pandas-3.0.3-py314he609de1_0.conda
@@ -12731,14 +12751,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/rpds-py-2026.5.1-py314he1d1ac0_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/scikit-image-0.26.0-np2py314hc49a259_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/scikit-learn-1.9.0-np2py314h15f0f0f_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.17.1-py314h18e1515_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.18.0-py314h18e1515_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/sqlalchemy-2.0.51-py314ha14b1ff_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/svt-av1-4.0.1-h0cb729a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tornado-6.5.7-py314h6c2aa35_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/unicodedata2-17.0.1-py314h6c2aa35_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.1-py314h6c2aa35_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.2-py314h6c2aa35_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xxhash-0.8.3-haa4e116_0.conda
@@ -12748,8 +12768,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - conda_source: dask-core[4daf6a12] @ .
-      - conda_source: distributed[a8efca05] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[ac39bd18] @ .
+      - conda_source: distributed[de5a2f6f] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda
@@ -12864,12 +12884,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pyasn1-0.6.3-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -12929,19 +12949,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/_libavif_api-1.4.2-h57928b3_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/win-64/aom-3.14.1-pl5321h06fc181_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.3-h75b6777_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.3-h4ad2c79_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-cal-0.9.14-h270aff2_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-common-0.14.0-hfd05255_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-compression-0.3.2-h1f21522_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-event-stream-0.7.1-hfbf5bbe_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-http-0.11.0-h4721ae0_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-io-0.26.3-h1a62f66_5.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-mqtt-0.15.2-h10b66d2_4.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.12.5-h425879c_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.4-h1f21522_6.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-mqtt-0.16.0-h10b66d2_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.12.6-h425879c_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.5-h1f21522_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-checksums-0.2.10-h1f21522_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-crt-cpp-0.40.0-hcaec180_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.747-h5d5b8b4_6.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-crt-cpp-0.40.1-hccacdf3_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.747-h042817b_7.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-core-cpp-1.16.3-h49e36cd_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-identity-cpp-1.13.3-hf9fdf8e_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-storage-blobs-cpp-12.18.0-h4fb3251_1.conda
@@ -12960,7 +12980,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/cffi-2.0.0-py314h5a2d7ad_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/charls-2.4.4-h7cafa3a_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/contourpy-1.3.3-py314hf309875_4.conda
-      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py314h2359020_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py314h2359020_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cramjam-2.11.0-py314h8a07082_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/cryptography-49.0.0-py314he884d78_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cytoolz-1.1.0-py314h5a2d7ad_2.conda
@@ -12981,9 +13001,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/gts-0.7.6-h6b5321d_4.conda
       - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py314h02517ec_102.conda
       - conda: https://prefix.dev/conda-forge/win-64/harfbuzz-14.2.1-h5a1b470_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_h693361b_107.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_ha9ae7cf_108.conda
       - conda: https://prefix.dev/conda-forge/win-64/icu-78.3-h637d24d_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py314h1bed58d_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py314h37ae81f_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/jxrlib-1.1-hcfcfb64_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/kiwisolver-1.5.0-py314hf309875_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/krb5-1.22.2-h719d79b_1.conda
@@ -12992,11 +13012,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/lerc-4.1.0-hd936e49_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libabseil-20260107.1-cxx17_h0eb2380_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libaec-1.1.5-haf901d7_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-24.0.0-hbef6419_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-24.0.0-h7d8d6a5_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-compute-24.0.0-h081cd8e_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-24.0.0-h7d8d6a5_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-24.0.0-h524e9bd_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-24.0.0-h9dce539_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-24.0.0-h7d8d6a5_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-compute-24.0.0-h081cd8e_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-24.0.0-h7d8d6a5_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-24.0.0-h524e9bd_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/win-64/libavif16-1.4.2-h7e7b026_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libblas-3.11.0-8_h8455456_mkl.conda
       - conda: https://prefix.dev/conda-forge/win-64/libbrotlicommon-1.2.0-hfd05255_1.conda
@@ -13016,8 +13036,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libgd-2.3.3-h4974f7c_12.conda
       - conda: https://prefix.dev/conda-forge/win-64/libglib-2.88.1-h7ce1215_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libgomp-15.2.0-h8ee18e1_19.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-3.5.0-he22669a_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-storage-3.5.0-he04ea4c_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-3.6.0-he22669a_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-storage-3.6.0-he04ea4c_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libgrpc-1.78.1-h9ff2b3e_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://prefix.dev/conda-forge/win-64/libhwy-1.4.0-h172a326_0.conda
@@ -13030,7 +13050,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libopentelemetry-cpp-1.27.0-hc88f397_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libopentelemetry-cpp-headers-1.27.0-h57928b3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libparquet-24.0.0-h7051d1f_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libparquet-24.0.0-h7051d1f_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/win-64/libpng-1.6.58-h7351971_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libprotobuf-6.33.5-h6cf2d3c_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libraqm-0.10.5-h781ae3c_0.conda
@@ -13061,7 +13081,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/mmh3-5.2.1-py314h13fbf68_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mpc-1.4.0-hc817d3a_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mpfr-4.2.2-h883a981_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.0-py314h909e829_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.1-py314h909e829_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/nlohmann_json-3.12.0-h5112557_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/numba-0.65.1-py314h36f8cf2_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/numcodecs-0.16.5-py314hd8fd7ce_0.conda
@@ -13069,7 +13089,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/numpy-2.4.6-py314h02f10f6_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/onemkl-license-2026.0.0-h57928b3_908.conda
       - conda: https://prefix.dev/conda-forge/win-64/openjpeg-2.5.4-h0e57b4f_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/openjph-0.29.0-hf13a347_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/openjph-0.30.1-hf13a347_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/orc-2.3.0-h8fc0eb6_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/pandas-3.0.3-py314hf700ef7_0.conda
@@ -13099,7 +13119,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/rpds-py-2026.5.1-py314hc980628_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/scikit-image-0.26.0-np2py314he3c5115_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/scikit-learn-1.9.0-np2py314h1b5b07a_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/scipy-1.17.1-py314h221f224_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/scipy-1.18.0-py314h221f224_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/snappy-1.2.2-h7fa0ca8_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/sqlalchemy-2.0.51-py314hc5dbbe4_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/svt-av1-4.0.1-hac47afa_0.conda
@@ -13112,7 +13132,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda
-      - conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.1-py314h5a2d7ad_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.2-py314h5a2d7ad_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libice-1.1.2-h0e40799_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libsm-1.2.6-h0e40799_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libx11-1.8.13-hfa52320_0.conda
@@ -13128,8 +13148,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/zlib-ng-2.3.3-h0261ad2_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - conda_source: dask-core[e7cea6b0] @ .
-      - conda_source: distributed[2f8bebff] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: dask-core[7581a683] @ .
+      - conda_source: distributed[ae0f1589] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
   py314t:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -13140,19 +13160,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.3-hea842a7_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.3-hd2277e8_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.14-h78948cc_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.14.0-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-haa0cbde_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-event-stream-0.7.1-h9cf6be0_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.11.0-h6488f85_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-h3bf836e_5.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.15.2-h0d2f46f_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.5-hb916526_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-haa0cbde_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.16.0-h0d2f46f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.6-hb916526_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.5-haa0cbde_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-haa0cbde_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.40.0-h41299d8_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.747-h6154047_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.40.1-h7a9a9d6_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.747-hf4c7647_7.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-core-cpp-1.16.3-h206d751_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-identity-cpp-1.13.3-h71f81a8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-storage-blobs-cpp-12.18.0-h74b55db_1.conda
@@ -13184,10 +13204,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
       - conda: https://prefix.dev/conda-forge/linux-64/h5py-3.16.0-nompi_py314h1792cf6_102.conda
       - conda: https://prefix.dev/conda-forge/linux-64/harfbuzz-14.2.1-h6083320_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h735b18d_107.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h7d5651c_108.conda
       - conda: https://prefix.dev/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py314h08bb928_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py314h3cef23f_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-hbde042b_1.conda
@@ -13196,11 +13216,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-24.0.0-h157cd41_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-24.0.0-h635bf11_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-24.0.0-h53684a4_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-24.0.0-h635bf11_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-24.0.0-hb4dd7c2_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-24.0.0-hb642ee7_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-24.0.0-h635bf11_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-24.0.0-h53684a4_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-24.0.0-h635bf11_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-24.0.0-hb4dd7c2_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.2-hf998032_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
@@ -13233,8 +13253,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-3.5.0-h8d2ee43_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-3.5.0-hdbdcf42_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-3.6.0-h8d2ee43_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-3.6.0-hdbdcf42_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgrpc-1.78.1-h1d1128b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libhwy-1.4.0-h10be129_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
@@ -13247,7 +13267,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-1.27.0-h9692893_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libparquet-24.0.0-h7376487_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libparquet-24.0.0-h7376487_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-6.33.5-h6eeba95_1.conda
@@ -13272,13 +13292,13 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/lz4-4.4.5-py314hdaf75e5_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/mmh3-5.2.1-py314h3ce7e56_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py314h3ba012d_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py314h3ba012d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/numba-0.65.1-py314hf734fe3_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.6-py314hd4f4903_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.29.0-h8d634f6_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openjph-0.30.1-h8d634f6_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/orc-2.3.0-h21090e2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/pandas-3.0.3-py314hd70f1f7_0.conda
@@ -13300,14 +13320,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.7.4-h92489ea_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/scikit-image-0.26.0-np2py314hf012b0d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/scikit-learn-1.9.0-np2py314h042a7e2_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.17.1-py314h529d2a9_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/scipy-1.18.0-py314h529d2a9_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tornado-6.5.7-py314h56549f7_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.1-py314h56549f7_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-h280c20c_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.2-py314h56549f7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
@@ -13353,8 +13373,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/coverage-7.14.1-pyh7db6752_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/coverage-7.14.3-pyh7db6752_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
@@ -13409,7 +13430,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -13448,28 +13469,28 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/yarl-1.24.2-pyh7db6752_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
-      - conda_source: brotli-python[d832c062] @ continuous_integration/pixi-recipes/brotli
-      - conda_source: dask-core[cfea4cc3] @ .
-      - conda_source: distributed[f47febc1] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: brotli-python[8a448670] @ continuous_integration/pixi-recipes/brotli
+      - conda_source: dask-core[f391cbf4] @ .
+      - conda_source: distributed[45a1d59d] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aom-3.14.1-pl5321h8fffa31_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/at-spi2-atk-2.38.0-h1f2db35_3.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/at-spi2-core-2.40.3-h1f2db35_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/linux-aarch64/atk-1.0-2.38.0-hedc4a1f_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.3-hc916f7b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.3-h5c394e5_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-cal-0.9.14-h343fa25_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-common-0.14.0-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h5b0efec_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-event-stream-0.7.1-h70cbb06_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-http-0.11.0-h9bcd1b7_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-io-0.26.3-hacd6ab7_5.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-mqtt-0.15.2-h3479d1b_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.12.5-hdd40dfe_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h5b0efec_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-mqtt-0.16.0-h3479d1b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.12.6-hdd40dfe_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.5-h5b0efec_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-checksums-0.2.10-h5b0efec_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-crt-cpp-0.40.0-hf7c79f2_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.747-hf48beb8_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-crt-cpp-0.40.1-h0495e26_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.747-h6aa9b71_7.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-core-cpp-1.16.3-h412bcfc_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-identity-cpp-1.13.3-hd0001b6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-storage-blobs-cpp-12.18.0-h2e50874_1.conda
@@ -13501,10 +13522,10 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gts-0.7.6-he293c15_4.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/h5py-3.16.0-nompi_py314h403af85_102.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/harfbuzz-14.2.1-h1134a53_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h02c88d6_107.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h0973965_108.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/hicolor-icon-theme-0.17-h8af1aa0_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py314hc317da5_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py314hb7f4bb1_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/jxrlib-1.1-h31becfc_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/keyutils-1.6.3-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/krb5-1.22.2-h2fb54aa_1.conda
@@ -13513,11 +13534,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libabseil-20260107.1-cxx17_h6983b43_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libaec-1.1.5-hff7e48a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-24.0.0-h5dfeb67_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-24.0.0-hb326ee9_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-compute-24.0.0-hdd99842_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-24.0.0-hb326ee9_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-24.0.0-hf29bd21_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-24.0.0-h6b18018_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-24.0.0-hb326ee9_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-compute-24.0.0-hdd99842_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-24.0.0-hb326ee9_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-24.0.0-hf29bd21_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libavif16-1.4.2-h1641d3b_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlicommon-1.2.0-he30d5cf_1.conda
@@ -13550,8 +13571,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libglx-1.7.0-hd24410f_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libglx-devel-1.7.0-hd24410f_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-3.5.0-h235f271_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-storage-3.5.0-h66d5b86_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-3.6.0-h235f271_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-storage-3.6.0-h66d5b86_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libgrpc-1.78.1-heab1e18_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libhwy-1.4.0-h0626a34_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
@@ -13564,7 +13585,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenblas-0.3.33-pthreads_h9d3fd7e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopentelemetry-cpp-1.27.0-hd82aec3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopentelemetry-cpp-headers-1.27.0-h8af1aa0_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpciaccess-0.19-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libprotobuf-6.33.5-h306233d_1.conda
@@ -13589,13 +13610,13 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/lz4-4.4.5-py314h8e3ad73_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/mmh3-5.2.1-py314h8cb1eed_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py314h1654e16_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.1-py314h1654e16_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/nlohmann_json-3.12.0-h7ac5ae9_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/numba-0.65.1-py314ha8c37cb_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-2.4.6-py314h314fbd6_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/openjph-0.29.0-h55827e0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/openjph-0.30.1-h55827e0_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/orc-2.3.0-hce1ac79_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/pandas-3.0.3-py314hebb84db_0.conda
@@ -13617,14 +13638,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/s2n-1.7.4-h5288e76_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/scikit-image-0.26.0-np2py314h1cd3a63_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/scikit-learn-1.9.0-np2py314h9abcb07_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.17.1-py314h34f1ec5_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.18.0-py314h34f1ec5_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/snappy-1.2.2-he774c54_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/svt-av1-4.0.1-hfae3067_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/tornado-6.5.7-py314hc9ed4f7_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/wayland-1.25.0-h4f8a99f_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.1-py314h2e6e5c7_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.47-h80f16a2_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.2-py314h2e6e5c7_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.48-h80f16a2_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libsm-1.2.6-h0808dbd_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libx11-1.8.13-h63a1b12_0.conda
@@ -13670,8 +13691,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/coverage-7.14.1-pyh7db6752_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/coverage-7.14.3-pyh7db6752_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
@@ -13726,7 +13748,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -13765,9 +13787,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/yarl-1.24.2-pyh7db6752_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
-      - conda_source: brotli-python[dc880c4c] @ continuous_integration/pixi-recipes/brotli
-      - conda_source: dask-core[058df287] @ .
-      - conda_source: distributed[208732bf] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: brotli-python[ad886b61] @ continuous_integration/pixi-recipes/brotli
+      - conda_source: dask-core[f372236f] @ .
+      - conda_source: distributed[298b9d04] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda
@@ -13791,8 +13813,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/coverage-7.14.1-pyh7db6752_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/coverage-7.14.3-pyh7db6752_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
@@ -13847,7 +13870,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -13889,19 +13912,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aom-3.14.1-pl5321h513545f_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/atk-1.0-2.38.0-hd03087b_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.3-hceed5df_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-cal-0.9.14-h81c6212_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-common-0.14.0-h84a0fba_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-compression-0.3.2-h61d3404_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-event-stream-0.7.1-h7e6a3cf_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-http-0.11.0-h0a63974_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_5.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-mqtt-0.15.2-ha70999f_4.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.12.5-h43def2a_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h61d3404_6.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-mqtt-0.16.0-ha70999f_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-checksums-0.2.10-h61d3404_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-crt-cpp-0.40.0-hd6eb0f7_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h55dad5a_6.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-crt-cpp-0.40.1-hb87031f_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h4e95165_7.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-core-cpp-1.16.3-he5ae378_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-identity-cpp-1.13.3-h05177fb_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.18.0-h409340b_1.conda
@@ -13932,21 +13955,21 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/gts-0.7.6-he42f4ea_4.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/h5py-3.16.0-nompi_py314haac4667_102.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/harfbuzz-14.2.1-h3103d1b_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_h9bfbf6c_107.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hb7e0c14_108.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/hicolor-icon-theme-0.17-hce30654_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py314h4197199_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py314h8ee69f8_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/jxrlib-1.1-h93a5062_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/lcms2-2.19.1-hdfa7624_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/lerc-4.1.0-h1eee2c3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libaec-1.1.5-h8664d51_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-24.0.0-hc887bfb_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-24.0.0-ha4f4840_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-compute-24.0.0-h8d10c55_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-24.0.0-ha4f4840_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-24.0.0-h05be00f_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-24.0.0-h6045e8e_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-24.0.0-ha4f4840_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-compute-24.0.0-h8d10c55_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-24.0.0-ha4f4840_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-24.0.0-h05be00f_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libavif16-1.4.2-h1c659b6_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
@@ -13969,8 +13992,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libglib-2.88.1-ha08bb59_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-3.5.0-h688a705_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-storage-3.5.0-ha114238_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-3.6.0-h688a705_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-storage-3.6.0-ha114238_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libhwy-1.4.0-ha332bbd_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
@@ -13984,7 +14007,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h08d5cc3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libparquet-24.0.0-h840b369_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libparquet-24.0.0-h840b369_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libprotobuf-6.33.5-h2d4b707_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libre2-11-2025.11.05-h4c27e2a_1.conda
@@ -14005,13 +14028,13 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/lz4-4.4.5-py314h7990064_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/mmh3-5.2.1-py314h13e809c_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py314h3a9a55a_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py314h3a9a55a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/numba-0.65.1-py314hdd36a67_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.4.6-py314hb25f971_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/openjph-0.29.0-h2a4d681_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/openjph-0.30.1-h2a4d681_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/orc-2.3.0-hd11884d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pandas-3.0.3-py314h3dd0261_0.conda
@@ -14032,12 +14055,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/rpds-py-2026.5.1-py314h4ca4bc6_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/scikit-image-0.26.0-np2py314hbdbd3bc_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/scikit-learn-1.9.0-np2py314h590b7c3_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.17.1-py314h122b93a_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.18.0-py314h122b93a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/svt-av1-4.0.1-h0cb729a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tornado-6.5.7-py314ha0ac461_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.1-py314ha0ac461_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.2-py314ha0ac461_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/xxhash-0.8.3-haa4e116_0.conda
@@ -14046,9 +14069,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - conda_source: brotli-python[ef28090b] @ continuous_integration/pixi-recipes/brotli
-      - conda_source: dask-core[4daf6a12] @ .
-      - conda_source: distributed[a8efca05] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: brotli-python[ccbc29f2] @ continuous_integration/pixi-recipes/brotli
+      - conda_source: dask-core[ac39bd18] @ .
+      - conda_source: distributed[de5a2f6f] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/aiobotocore-3.7.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.2-pyhd8ed1ab_0.conda
@@ -14073,7 +14096,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/coverage-7.14.1-pyh7db6752_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/coverage-7.14.3-pyh7db6752_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.6-py314hd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
@@ -14126,7 +14149,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -14170,19 +14193,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/_libavif_api-1.4.2-h57928b3_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/win-64/aom-3.14.1-pl5321h06fc181_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.3-h75b6777_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.3-h4ad2c79_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-cal-0.9.14-h270aff2_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-common-0.14.0-hfd05255_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-compression-0.3.2-h1f21522_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-event-stream-0.7.1-hfbf5bbe_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-http-0.11.0-h4721ae0_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-io-0.26.3-h1a62f66_5.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-mqtt-0.15.2-h10b66d2_4.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.12.5-h425879c_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.4-h1f21522_6.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-mqtt-0.16.0-h10b66d2_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.12.6-h425879c_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.5-h1f21522_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-checksums-0.2.10-h1f21522_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-crt-cpp-0.40.0-hcaec180_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.747-h5d5b8b4_6.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-crt-cpp-0.40.1-hccacdf3_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.747-h042817b_7.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-core-cpp-1.16.3-h49e36cd_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-identity-cpp-1.13.3-hf9fdf8e_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-storage-blobs-cpp-12.18.0-h4fb3251_1.conda
@@ -14207,20 +14230,20 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/gts-0.7.6-h6b5321d_4.conda
       - conda: https://prefix.dev/conda-forge/win-64/h5py-3.16.0-nompi_py314h1e0f560_102.conda
       - conda: https://prefix.dev/conda-forge/win-64/harfbuzz-14.2.1-h5a1b470_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_h693361b_107.conda
+      - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_ha9ae7cf_108.conda
       - conda: https://prefix.dev/conda-forge/win-64/icu-78.3-h637d24d_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py314h6714266_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py314h18e65a1_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/jxrlib-1.1-hcfcfb64_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/krb5-1.22.2-h719d79b_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/lcms2-2.19.1-hf2c6c5f_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/lerc-4.1.0-hd936e49_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libabseil-20260107.1-cxx17_h0eb2380_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libaec-1.1.5-haf901d7_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-24.0.0-hbef6419_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-24.0.0-h7d8d6a5_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-compute-24.0.0-h081cd8e_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-24.0.0-h7d8d6a5_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-24.0.0-h524e9bd_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-24.0.0-h9dce539_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-24.0.0-h7d8d6a5_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-compute-24.0.0-h081cd8e_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-24.0.0-h7d8d6a5_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-24.0.0-h524e9bd_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/win-64/libavif16-1.4.2-h7e7b026_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libblas-3.11.0-8_h8455456_mkl.conda
       - conda: https://prefix.dev/conda-forge/win-64/libbrotlicommon-1.2.0-hfd05255_1.conda
@@ -14239,8 +14262,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libgd-2.3.3-h4974f7c_12.conda
       - conda: https://prefix.dev/conda-forge/win-64/libglib-2.88.1-h7ce1215_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libgomp-15.2.0-h8ee18e1_19.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-3.5.0-he22669a_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-storage-3.5.0-he04ea4c_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-3.6.0-he22669a_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-storage-3.6.0-he04ea4c_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libgrpc-1.78.1-h9ff2b3e_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://prefix.dev/conda-forge/win-64/libhwy-1.4.0-h172a326_0.conda
@@ -14253,7 +14276,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libopentelemetry-cpp-1.27.0-hc88f397_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libopentelemetry-cpp-headers-1.27.0-h57928b3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libparquet-24.0.0-h7051d1f_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libparquet-24.0.0-h7051d1f_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/win-64/libpng-1.6.58-h7351971_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libprotobuf-6.33.5-h6cf2d3c_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libre2-11-2025.11.05-h04e5de1_1.conda
@@ -14275,13 +14298,13 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/lz4-c-1.10.0-h2466b09_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/mkl-2026.0.0-hac47afa_908.conda
       - conda: https://prefix.dev/conda-forge/win-64/mmh3-5.2.1-py314hd765ef1_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.0-py314h0fe37e9_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.1-py314h0fe37e9_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/nlohmann_json-3.12.0-h5112557_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/numba-0.65.1-py314h01db6d0_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/numpy-2.4.6-py314hffb9209_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/onemkl-license-2026.0.0-h57928b3_908.conda
       - conda: https://prefix.dev/conda-forge/win-64/openjpeg-2.5.4-h0e57b4f_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/openjph-0.29.0-hf13a347_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/openjph-0.30.1-hf13a347_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/orc-2.3.0-h8fc0eb6_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/pandas-3.0.3-py314he4c2ca6_0.conda
@@ -14301,7 +14324,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/rpds-py-2026.5.1-py314h63eb544_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/scikit-image-0.26.0-np2py314h0ae8f6b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/scikit-learn-1.9.0-np2py314hb10d3ac_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/scipy-1.17.1-py314h9c5632b_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/scipy-1.18.0-py314h9c5632b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/snappy-1.2.2-h7fa0ca8_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/svt-av1-4.0.1-hac47afa_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/tbb-2023.0.0-hd3d4ead_2.conda
@@ -14312,7 +14335,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_39.conda
-      - conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.1-py314hac7e1cd_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.2-py314hac7e1cd_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libice-1.1.2-h0e40799_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libsm-1.2.6-h0e40799_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/xorg-libx11-1.8.13-hfa52320_0.conda
@@ -14327,9 +14350,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/zlib-ng-2.3.3-h0261ad2_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - conda_source: brotli-python[40f8be4d] @ continuous_integration/pixi-recipes/brotli
-      - conda_source: dask-core[e7cea6b0] @ .
-      - conda_source: distributed[2f8bebff] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+      - conda_source: brotli-python[cb55e4df] @ continuous_integration/pixi-recipes/brotli
+      - conda_source: dask-core[7581a683] @ .
+      - conda_source: distributed[ae0f1589] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
   spark:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -14337,19 +14360,19 @@ environments:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.3-hea842a7_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.3-hd2277e8_3.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-cal-0.9.14-h78948cc_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-common-0.14.0-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-compression-0.3.2-haa0cbde_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-event-stream-0.7.1-h9cf6be0_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-http-0.11.0-h6488f85_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-c-io-0.26.3-h3bf836e_5.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.15.2-h0d2f46f_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.5-hb916526_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-haa0cbde_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.16.0-h0d2f46f_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.6-hb916526_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.5-haa0cbde_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.2.10-haa0cbde_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.40.0-h41299d8_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.747-h6154047_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.40.1-h7a9a9d6_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.747-hf4c7647_7.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-core-cpp-1.16.3-h206d751_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-identity-cpp-1.13.3-h71f81a8_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/azure-storage-blobs-cpp-12.18.0-h74b55db_1.conda
@@ -14358,7 +14381,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
       - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py312h8a5da7c_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py312h8a5da7c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/fontconfig-2.18.1-h27c8c51_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
       - conda: https://prefix.dev/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
@@ -14372,11 +14395,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
       - conda: https://prefix.dev/conda-forge/linux-64/lerc-4.1.0-hdb68285_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-24.0.0-h157cd41_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-24.0.0-h635bf11_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-24.0.0-h53684a4_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-24.0.0-h635bf11_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-24.0.0-hb4dd7c2_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-24.0.0-hb642ee7_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-24.0.0-h635bf11_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-24.0.0-h53684a4_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-24.0.0-h635bf11_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-24.0.0-hb4dd7c2_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-8_h4a7cf45_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
@@ -14399,8 +14422,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libglib-2.88.1-h0d30a3d_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-3.5.0-h8d2ee43_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-3.5.0-hdbdcf42_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-3.6.0-h8d2ee43_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-3.6.0-hdbdcf42_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libgrpc-1.78.1-h1d1128b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libjpeg-turbo-3.1.4.1-hb03c661_0.conda
@@ -14411,7 +14434,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/libopenblas-0.3.33-pthreads_h94d23a6_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-1.27.0-h9692893_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/libparquet-24.0.0-h7376487_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libparquet-24.0.0-h7376487_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libprotobuf-6.33.5-h6eeba95_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/libre2-11-2025.11.05-h0dc7533_1.conda
@@ -14432,7 +14455,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.6-py312h33ff503_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.5.0-py312h33ff503_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openjdk-21.0.10-ha668962_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/orc-2.3.0-h21090e2_0.conda
@@ -14468,6 +14491,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -14485,7 +14509,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/py4j-0.10.9.9-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyspark-4.1.2-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -14501,23 +14525,23 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda_source: dask-core[cfea4cc3] @ .
+      - conda_source: dask-core[f391cbf4] @ .
       linux-aarch64:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/alsa-lib-1.2.16.1-he30d5cf_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.3-hc916f7b_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.3-h5c394e5_3.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-cal-0.9.14-h343fa25_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-common-0.14.0-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-compression-0.3.2-h5b0efec_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-event-stream-0.7.1-h70cbb06_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-http-0.11.0-h9bcd1b7_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-io-0.26.3-hacd6ab7_5.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-mqtt-0.15.2-h3479d1b_4.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.12.5-hdd40dfe_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h5b0efec_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-mqtt-0.16.0-h3479d1b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.12.6-hdd40dfe_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.5-h5b0efec_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-checksums-0.2.10-h5b0efec_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-crt-cpp-0.40.0-hf7c79f2_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.747-hf48beb8_6.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-crt-cpp-0.40.1-h0495e26_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.747-h6aa9b71_7.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-core-cpp-1.16.3-h412bcfc_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-identity-cpp-1.13.3-hd0001b6_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-storage-blobs-cpp-12.18.0-h2e50874_1.conda
@@ -14526,7 +14550,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_9.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/cairo-1.18.4-h0b6afd8_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.1-py312hd077ced_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.3-py312hd077ced_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/fontconfig-2.18.1-hba86a56_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/gflags-2.2.2-h5ad3122_1005.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/giflib-5.2.2-h31becfc_0.conda
@@ -14540,11 +14564,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.45.1-default_h1979696_102.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/lerc-4.1.0-h52b7260_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libabseil-20260107.1-cxx17_h6983b43_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-24.0.0-h5dfeb67_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-24.0.0-hb326ee9_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-compute-24.0.0-hdd99842_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-24.0.0-hb326ee9_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-24.0.0-hf29bd21_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-24.0.0-h6b18018_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-24.0.0-hb326ee9_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-compute-24.0.0-hdd99842_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-24.0.0-hb326ee9_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-24.0.0-hf29bd21_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libblas-3.11.0-8_haddc8a3_openblas.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlicommon-1.2.0-he30d5cf_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libbrotlidec-1.2.0-he30d5cf_1.conda
@@ -14567,8 +14591,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libglib-2.88.1-h96a7f82_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-3.5.0-h235f271_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-storage-3.5.0-h66d5b86_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-3.6.0-h235f271_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-storage-3.6.0-h66d5b86_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libgrpc-1.78.1-heab1e18_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libiconv-1.18-h90929bb_2.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libjpeg-turbo-3.1.4.1-he30d5cf_0.conda
@@ -14579,7 +14603,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopenblas-0.3.33-pthreads_h9d3fd7e_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopentelemetry-cpp-1.27.0-hd82aec3_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libopentelemetry-cpp-headers-1.27.0-h8af1aa0_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libprotobuf-6.33.5-h306233d_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/libre2-11-2025.11.05-hc5e897d_1.conda
@@ -14600,7 +14624,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-aarch64/lz4-c-1.10.0-h5ad3122_1.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/nlohmann_json-3.12.0-h7ac5ae9_1.conda
-      - conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-2.4.6-py312hce9e0af_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-2.5.0-py312hce9e0af_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openjdk-21.0.10-h488f50d_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
       - conda: https://prefix.dev/conda-forge/linux-aarch64/orc-2.3.0-hce1ac79_0.conda
@@ -14636,6 +14660,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -14653,7 +14678,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/py4j-0.10.9.9-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyspark-4.1.2-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -14669,11 +14694,12 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda_source: dask-core[058df287] @ .
+      - conda_source: dask-core[f372236f] @ .
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/fsspec-2026.6.0-pyhd8ed1ab_0.conda
@@ -14685,7 +14711,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/py4j-0.10.9.9-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyspark-4.1.2-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -14702,19 +14728,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.3-hceed5df_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-cal-0.9.14-h81c6212_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-common-0.14.0-h84a0fba_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-compression-0.3.2-h61d3404_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-event-stream-0.7.1-h7e6a3cf_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-http-0.11.0-h0a63974_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-io-0.26.3-h58c0f83_5.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-mqtt-0.15.2-ha70999f_4.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.12.5-h43def2a_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h61d3404_6.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-mqtt-0.16.0-ha70999f_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/aws-checksums-0.2.10-h61d3404_2.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-crt-cpp-0.40.0-hd6eb0f7_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h55dad5a_6.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-crt-cpp-0.40.1-hb87031f_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h4e95165_7.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-core-cpp-1.16.3-he5ae378_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-identity-cpp-1.13.3-h05177fb_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.18.0-h409340b_1.conda
@@ -14722,17 +14748,17 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/azure-storage-files-datalake-cpp-12.16.0-h16bb3af_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py312h04c11ed_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py312h04c11ed_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/krb5-1.22.2-hfd3d5f3_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-24.0.0-hc887bfb_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-24.0.0-ha4f4840_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-compute-24.0.0-h8d10c55_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-24.0.0-ha4f4840_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-24.0.0-h05be00f_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-24.0.0-h6045e8e_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-24.0.0-ha4f4840_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-compute-24.0.0-h8d10c55_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-24.0.0-ha4f4840_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-24.0.0-h05be00f_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libblas-3.11.0-8_h51639a9_openblas.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlicommon-1.2.0-hc919400_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libbrotlidec-1.2.0-hc919400_1.conda
@@ -14749,8 +14775,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-3.5.0-h688a705_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-storage-3.5.0-ha114238_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-3.6.0-h688a705_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-storage-3.6.0-ha114238_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libgrpc-1.78.1-h3e3f78d_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/liblapack-3.11.0-8_hd9741b5_openblas.conda
@@ -14759,7 +14785,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopenblas-0.3.33-openmp_he657e61_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopentelemetry-cpp-1.27.0-h08d5cc3_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.27.0-hce30654_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/libparquet-24.0.0-h840b369_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libparquet-24.0.0-h840b369_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libprotobuf-6.33.5-h2d4b707_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libre2-11-2025.11.05-h4c27e2a_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
@@ -14773,7 +14799,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_1.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.4.6-py312ha003a3f_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.5.0-py312ha003a3f_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openjdk-21.0.10-h258754b_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/orc-2.3.0-hd11884d_0.conda
@@ -14790,7 +14816,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - conda_source: dask-core[4daf6a12] @ .
+      - conda_source: dask-core[ac39bd18] @ .
       win-64:
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.4.1-pyh6dadd2b_0.conda
@@ -14807,7 +14833,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/py4j-0.10.9.9-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pyspark-4.1.2-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pytest-reportlog-1.0.0-pyhd8ed1ab_0.conda
@@ -14823,19 +14849,19 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.3-h75b6777_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.3-h4ad2c79_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-cal-0.9.14-h270aff2_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-common-0.14.0-hfd05255_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-compression-0.3.2-h1f21522_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-event-stream-0.7.1-hfbf5bbe_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-http-0.11.0-h4721ae0_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-c-io-0.26.3-h1a62f66_5.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-mqtt-0.15.2-h10b66d2_4.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.12.5-h425879c_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.4-h1f21522_6.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-mqtt-0.16.0-h10b66d2_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.12.6-h425879c_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.5-h1f21522_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/aws-checksums-0.2.10-h1f21522_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-crt-cpp-0.40.0-hcaec180_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.747-h5d5b8b4_6.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-crt-cpp-0.40.1-hccacdf3_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.747-h042817b_7.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-core-cpp-1.16.3-h49e36cd_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-identity-cpp-1.13.3-hf9fdf8e_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/azure-storage-blobs-cpp-12.18.0-h4fb3251_1.conda
@@ -14843,14 +14869,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/azure-storage-files-datalake-cpp-12.16.0-heb2e695_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://prefix.dev/conda-forge/win-64/c-ares-1.34.6-hfd05255_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py312h05f76fc_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py312h05f76fc_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/krb5-1.22.2-h719d79b_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libabseil-20260107.1-cxx17_h0eb2380_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-24.0.0-hbef6419_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-24.0.0-h7d8d6a5_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-compute-24.0.0-h081cd8e_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-24.0.0-h7d8d6a5_6_cpu.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-24.0.0-h524e9bd_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-24.0.0-h9dce539_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-24.0.0-h7d8d6a5_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-compute-24.0.0-h081cd8e_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-24.0.0-h7d8d6a5_8_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-24.0.0-h524e9bd_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/win-64/libblas-3.11.0-8_h8455456_mkl.conda
       - conda: https://prefix.dev/conda-forge/win-64/libbrotlicommon-1.2.0-hfd05255_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libbrotlidec-1.2.0-hfd05255_1.conda
@@ -14861,8 +14887,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-3.5.0-he22669a_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-storage-3.5.0-he04ea4c_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-3.6.0-he22669a_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-storage-3.6.0-he04ea4c_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libgrpc-1.78.1-h9ff2b3e_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://prefix.dev/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
@@ -14870,7 +14896,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libopentelemetry-cpp-1.27.0-hc88f397_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libopentelemetry-cpp-headers-1.27.0-h57928b3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libparquet-24.0.0-h7051d1f_6_cpu.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libparquet-24.0.0-h7051d1f_8_cpu.conda
       - conda: https://prefix.dev/conda-forge/win-64/libprotobuf-6.33.5-h6cf2d3c_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libre2-11-2025.11.05-h04e5de1_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.53.2-hf5d6505_0.conda
@@ -14885,7 +14911,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/lz4-c-1.10.0-h2466b09_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/mkl-2026.0.0-hac47afa_908.conda
       - conda: https://prefix.dev/conda-forge/win-64/nlohmann_json-3.12.0-h5112557_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/numpy-2.4.6-py312ha3f287d_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/numpy-2.5.0-py312ha3f287d_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/onemkl-license-2026.0.0-h57928b3_908.conda
       - conda: https://prefix.dev/conda-forge/win-64/openjdk-21.0.10-he453025_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
@@ -14909,7 +14935,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - conda_source: dask-core[e7cea6b0] @ .
+      - conda_source: dask-core[7581a683] @ .
 packages:
 - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -15121,24 +15147,24 @@ packages:
     - aws-c-auth >=0.10.1,<0.10.2.0a0
   size: 134426
   timestamp: 1774274932726
-- conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.3-hea842a7_2.conda
-  sha256: 5b9c20a38fe084b4ffd1f2c64b3797ec6ef9a99e83cc0c1f84e016c9801e3a5c
-  md5: c463d2dbfb12a208c943165d2a568db4
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.10.3-hd2277e8_3.conda
+  sha256: 34238103e9b75a9ed0d8b01132551c2af4f9ae68ee2f81320a685ffb27731f6c
+  md5: 9329dcd00c4d61aa49e516dddd784e91
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - aws-c-io >=0.26.3,<0.26.4.0a0
   - aws-c-cal >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.11.0,<0.11.1.0a0
-  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
   - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
     - aws-c-auth >=0.10.3,<0.10.4.0a0
-  size: 134385
-  timestamp: 1780598328124
+  size: 134649
+  timestamp: 1781802943551
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-auth-0.7.20-h5f1c8d9_0.conda
   sha256: 12f53171a2cb544a83be9866bf41f7a15aa7ff032d9f91ea6fd2ca4c34c84768
   md5: 418775183961dc1ee1c326a473118f98
@@ -15567,22 +15593,6 @@ packages:
     - aws-c-mqtt >=0.11.0,<0.11.1.0a0
   size: 194447
   timestamp: 1731734668760
-- conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.15.2-h0d2f46f_4.conda
-  sha256: c81aa872f74baf6bd2bb82cc87815895b3a654ef7831177a5c3d851ee27c05ea
-  md5: c66a882d62800e451a651b9b002f5066
-  depends:
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - aws-c-http >=0.11.0,<0.11.1.0a0
-  - aws-c-common >=0.14.0,<0.14.1.0a0
-  - aws-c-io >=0.26.3,<0.26.4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  run_exports:
-    weak:
-    - aws-c-mqtt >=0.15.2,<0.15.3.0a0
-  size: 221640
-  timestamp: 1780598982374
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.15.2-he9ea9c5_1.conda
   sha256: 3fc68793c0ca2c36524ae67abac696ce6b066a8be6b2b980cbdc40ae1310041a
   md5: 8e77514673f5773b40ff8953583938b6
@@ -15599,6 +15609,22 @@ packages:
     - aws-c-mqtt >=0.15.2,<0.15.3.0a0
   size: 221711
   timestamp: 1774275485771
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-mqtt-0.16.0-h0d2f46f_0.conda
+  sha256: 2a9ae1da09ae77d0d513ebaaa0e3810f33e4e09b564494c62d50d7d9f217334e
+  md5: 94454ba09f610904865601eae5530600
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-mqtt >=0.16.0,<0.16.1.0a0
+  size: 224231
+  timestamp: 1780681834200
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.11.5-h6d69fc9_5.conda
   sha256: c15869656f5fbebe27cc5aa58b23831f75d85502d324fedd7ee7e552c79b495d
   md5: 4c5c16bf1133dcfe100f33dd4470998e
@@ -15619,26 +15645,26 @@ packages:
     - aws-c-s3 >=0.11.5,<0.11.6.0a0
   size: 151340
   timestamp: 1774282148690
-- conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.5-hb916526_1.conda
-  sha256: 8f193173f1dccb25ff86a95543db27f0c762cccfe93157b02cf20bd5b4c11a92
-  md5: 70bc8e5e8cefd19407423733e7ebf540
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.12.6-hb916526_0.conda
+  sha256: bda2c735382e2232997fb34c5d71d476ab2f4e5ba5bc9e059106f280f2334a88
+  md5: f2b6275244daa12109bcd0a126f1fb85
   depends:
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - aws-checksums >=0.2.10,<0.2.11.0a0
-  - aws-c-cal >=0.9.14,<0.9.15.0a0
-  - openssl >=3.5.6,<4.0a0
-  - aws-c-auth >=0.10.3,<0.10.4.0a0
+  - __glibc >=2.17,<3.0.a0
   - aws-c-common >=0.14.0,<0.14.1.0a0
-  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-checksums >=0.2.10,<0.2.11.0a0
+  - openssl >=3.5.7,<4.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-c-auth >=0.10.3,<0.10.4.0a0
   - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
-    - aws-c-s3 >=0.12.5,<0.12.6.0a0
-  size: 153453
-  timestamp: 1780609553521
+    - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  size: 154088
+  timestamp: 1781252014556
 - conda: https://prefix.dev/conda-forge/linux-64/aws-c-s3-0.5.9-h10bd90f_0.conda
   sha256: f7e0101a3e629e55d2afc6265c25e8f7dc207119eaed860c682afa2cdd083c1f
   md5: 5cd6a7eb8c0e45be0e49a9c6351ff42b
@@ -15719,9 +15745,9 @@ packages:
     - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
   size: 59383
   timestamp: 1764610113765
-- conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.4-haa0cbde_6.conda
-  sha256: 123c4325b16f1f6db95846d51e5e4201399ee29c0325f8b5a8db2e7d732b9151
-  md5: 4b66ac29a7e917a629b790c3d239d110
+- conda: https://prefix.dev/conda-forge/linux-64/aws-c-sdkutils-0.2.5-haa0cbde_0.conda
+  sha256: c351a2bb8734accc6a047b55be15a8ce205725aeeedd2576c320841c3c383731
+  md5: 5088795f3dfcf00a26f03c2a17ae8429
   depends:
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
@@ -15730,9 +15756,9 @@ packages:
   license_family: APACHE
   run_exports:
     weak:
-    - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
-  size: 59085
-  timestamp: 1780568538653
+    - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  size: 65759
+  timestamp: 1781063620400
 - conda: https://prefix.dev/conda-forge/linux-64/aws-checksums-0.1.18-h36a0aea_4.conda
   sha256: 224ead1679870e28005bfa7d27e8dd702f09837005610c6b06c52a95641da30b
   md5: bd99b76853edcc6fae6a901900bba995
@@ -15856,29 +15882,29 @@ packages:
     - aws-crt-cpp >=0.37.4,<0.37.5.0a0
   size: 410120
   timestamp: 1774286908570
-- conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.40.0-h41299d8_1.conda
-  sha256: cc8eade570327e97ea458dd47dad9845fce5be070024a3fdaffe5aa4f68d2126
-  md5: b4fbfcaea33878c12f0e035f5814280b
+- conda: https://prefix.dev/conda-forge/linux-64/aws-crt-cpp-0.40.1-h7a9a9d6_1.conda
+  sha256: 55d39d93aaa69ac47831db4c0661b8112e719d74950fecd4bcbf9181ea6f7d34
+  md5: 976bc22e043e8380f3dd54863b73ecef
   depends:
-  - libstdcxx >=14
   - libgcc >=14
+  - libstdcxx >=14
   - __glibc >=2.17,<3.0.a0
-  - aws-c-io >=0.26.3,<0.26.4.0a0
-  - aws-c-auth >=0.10.3,<0.10.4.0a0
-  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
   - aws-c-event-stream >=0.7.1,<0.7.2.0a0
-  - aws-c-mqtt >=0.15.2,<0.15.3.0a0
-  - aws-c-s3 >=0.12.5,<0.12.6.0a0
-  - aws-c-cal >=0.9.14,<0.9.15.0a0
-  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
   - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-auth >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-mqtt >=0.16.0,<0.16.1.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
-    - aws-crt-cpp >=0.40.0,<0.40.1.0a0
-  size: 415624
-  timestamp: 1780917918279
+    - aws-crt-cpp >=0.40.1,<0.40.2.0a0
+  size: 416196
+  timestamp: 1781814052588
 - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.267-h51dfee4_8.conda
   sha256: 8fb8f648d1ae7d4f2005c130686b569eec998f8fda37d0f24e50fc069428484b
   md5: 188857656abd6d1a4dcc471c619b0de5
@@ -15920,25 +15946,6 @@ packages:
     - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
   size: 2951998
   timestamp: 1732184141000
-- conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.747-h6154047_6.conda
-  sha256: 224c461787555e92a1111b8a5c7f65db0559da631f05b0e29d06e79a267cc130
-  md5: 9096d36ad4522d330bd6a5bdbd458275
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libstdcxx >=14
-  - aws-c-common >=0.14.0,<0.14.1.0a0
-  - aws-crt-cpp >=0.40.0,<0.40.1.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - aws-c-event-stream >=0.7.1,<0.7.2.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  run_exports:
-    weak:
-    - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
-  size: 3624840
-  timestamp: 1781003610286
 - conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.747-hc3785e1_3.conda
   sha256: 62b7e565852fa061a26281b2890e432853fabefa8ea3dc22d00d39295a030805
   md5: cfffedbfd03d5a6bb74157c14b6f0cdf
@@ -15958,6 +15965,25 @@ packages:
     - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
   size: 3624521
   timestamp: 1773666645246
+- conda: https://prefix.dev/conda-forge/linux-64/aws-sdk-cpp-1.11.747-hf4c7647_7.conda
+  sha256: ea7a0f2a1806be8aa9b3e9067d532de8d328fc8b27ecf6b1cb3bda3f74eb70df
+  md5: 6f597863865654f7c0b73dec9e10580d
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - aws-c-event-stream >=0.7.1,<0.7.2.0a0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
+  size: 3624962
+  timestamp: 1781874213173
 - conda: https://prefix.dev/conda-forge/linux-64/azure-core-cpp-1.11.1-h91d86a7_1.conda
   sha256: 810a890bf66d6368637399ef415dcc8152acd28f4b4b61d4048b7be7cba17d4c
   md5: 2dbab1d281b7e1da05eee544cbdc8af6
@@ -17087,9 +17113,9 @@ packages:
   run_exports: {}
   size: 324013
   timestamp: 1769155968691
-- conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py310h3406613_0.conda
-  sha256: 179d5e48b5023d26ff5ebc28be01cf6a234aaf866fd8cd9ce1d527caa3b39b8f
-  md5: 0a83dc99ca644004a0ad7de74ca296e3
+- conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py310h3406613_0.conda
+  sha256: d5ff485f9134e91657bf894fe6535fbdf54e41b11238c6b37701f5a605bfb66a
+  md5: a53275194d9c40d82ac81e89dccae517
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -17097,13 +17123,12 @@ packages:
   - python_abi 3.10.* *_cp310
   - tomli
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 313575
-  timestamp: 1779837983139
-- conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py311h3778330_0.conda
-  sha256: ebefe7c8a41d14e4a50c5b862cf0226b3ac745495415bb6fb0db364b945cfe3a
-  md5: f875c239f662e1b31fbf32282f1da087
+  size: 318490
+  timestamp: 1782178112039
+- conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py311h3778330_0.conda
+  sha256: a143654fedbc23b70b6acc2077e2b6eaf5ff05b9f311084ffe5652d39e9d2020
+  md5: fd575752ccdef69e8381a26d641d04a4
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -17111,13 +17136,12 @@ packages:
   - python_abi 3.11.* *_cp311
   - tomli
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 399156
-  timestamp: 1779838054673
-- conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py312h8a5da7c_0.conda
-  sha256: 80b990c6870c721bcde5e14e71d3560bac3dad93b54d027f723dca2bb7ccda03
-  md5: 6668e2af2de730400bdce9cf2ea132f9
+  size: 405041
+  timestamp: 1782178072991
+- conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py312h8a5da7c_0.conda
+  sha256: 15b33937f062c7c94f5978127fbcae1d3b9c30ff4dff59adab9ab2bd18365024
+  md5: 685d6d2fac5fd5abfc581db3c94652b9
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -17125,13 +17149,12 @@ packages:
   - python_abi 3.12.* *_cp312
   - tomli
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 389696
-  timestamp: 1779838017522
-- conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py313h3dea7bd_0.conda
-  sha256: b4ff99ffe4e60119c2f99fa29234b4267f7e0f43dbf5396dad0f8adaf95284e2
-  md5: 86bbb569988f077e5cb30acac5799599
+  size: 393058
+  timestamp: 1782178186395
+- conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py313h3dea7bd_0.conda
+  sha256: 03524907f2d141ce198ca16f76c105daffa3ff2ad3c710db34fc8d57d2603041
+  md5: ae7823c5693b8d58d5d26f3ecc1be9c0
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -17139,13 +17162,12 @@ packages:
   - python_abi 3.13.* *_cp313
   - tomli
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 396489
-  timestamp: 1779837909103
-- conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.1-py314h67df5f8_0.conda
-  sha256: 4fb298517c0aff45eb449bf4bd484c0f4d0ab36d4e5c1005b7f0312e68330b57
-  md5: 2af0e1fec00680b1b6ef3859585ca8fa
+  size: 401972
+  timestamp: 1782178226325
+- conda: https://prefix.dev/conda-forge/linux-64/coverage-7.14.3-py314h67df5f8_0.conda
+  sha256: 68f6814d548e6b1d8b655371cb34b909f5862d5d80b4b6ccf7231a84ceeb88da
+  md5: e3aecdc8eab8a93c5aad5f113fa91509
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -17153,12 +17175,11 @@ packages:
   - python_abi 3.14.* *_cp314
   - tomli
   license: Apache-2.0
-  license_family: APACHE
   purls:
   - pkg:pypi/coverage?source=hash-mapping
   run_exports: {}
-  size: 413054
-  timestamp: 1779837945378
+  size: 419228
+  timestamp: 1782178151393
 - conda: https://prefix.dev/conda-forge/linux-64/cpp-expected-1.3.1-h171cf75_0.conda
   sha256: 0d9405d9f2de5d4b15d746609d87807aac10e269072d6408b769159762ed113d
   md5: d17488e343e4c5c0bd0db18b3934d517
@@ -18645,17 +18666,17 @@ packages:
     - hdf5 >=1.14.4,<1.14.5.0a0
   size: 3950601
   timestamp: 1733003331788
-- conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h735b18d_107.conda
-  sha256: ff8336394dcfaccf49e56d1dd66091cf767df0d3d33f3fa440c980e0445b34cc
-  md5: b1b444bca8da3ff6cc4afad1fa7f7d61
+- conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_h7d5651c_108.conda
+  sha256: 8225145aababbef3f8900b651cfa4ac9257cd4d522957711f469f6ea5b504761
+  md5: 3c126667b98ad8ccf390a91b9097f574
   depends:
   - __glibc >=2.17,<3.0.a0
   - aws-c-auth >=0.10.3,<0.10.4.0a0
   - aws-c-common >=0.14.0,<0.14.1.0a0
   - aws-c-http >=0.11.0,<0.11.1.0a0
   - aws-c-io >=0.26.3,<0.26.4.0a0
-  - aws-c-s3 >=0.12.5,<0.12.6.0a0
-  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
   - libaec >=1.1.5,<2.0a0
   - libcurl >=8.20.0,<9.0a0
   - libgcc >=14
@@ -18663,14 +18684,14 @@ packages:
   - libgfortran5 >=14.3.0
   - libstdcxx >=14
   - libzlib >=1.3.2,<2.0a0
-  - openssl >=3.5.6,<4.0a0
+  - openssl >=3.5.7,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
   run_exports:
     weak:
     - hdf5 >=2.1.0,<3.0a0
-  size: 4610890
-  timestamp: 1780923415022
+  size: 4377467
+  timestamp: 1781836834023
 - conda: https://prefix.dev/conda-forge/linux-64/hdf5-2.1.0-nompi_hd4fcb43_104.conda
   sha256: c6ff674a4a5a237fcf748fed8f64e79df54b42189986e705f35ba64dc6603235
   md5: 1d92558abd05cea0577f83a5eca38733
@@ -18823,9 +18844,9 @@ packages:
   run_exports: {}
   size: 2063618
   timestamp: 1777731577918
-- conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py312h7a14548_2.conda
-  sha256: c51cb5e6f22847b9c23dabb8f0a9fbc028f8fef23fad50e8830c83e244fe1012
-  md5: 3b7a3c19c273233c00bcd57b4a610736
+- conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py312he3a1cdd_3.conda
+  sha256: ceae6dba80901a17b15af13bebb1cf2de99dc462950f4dc97620a6c293d446c4
+  md5: 0379f12b78a048a2a6d6b3ec35548828
   depends:
   - __glibc >=2.17,<3.0.a0
   - blosc >=1.21.6,<2.0a0
@@ -18856,7 +18877,7 @@ packages:
   - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - openjpeg >=2.5.4,<3.0a0
-  - openjph >=0.29.0,<0.30.0a0
+  - openjph >=0.30.1,<0.31.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - snappy >=1.2.2,<1.3.0a0
@@ -18866,11 +18887,11 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 2318456
-  timestamp: 1781743148101
-- conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py313ha145c31_2.conda
-  sha256: c4fe64632767581f779b9e60c3744a48fa0901171b7039d072d58b3029f1542b
-  md5: fecd334275c919bf9a1c87b838e369e6
+  size: 2314617
+  timestamp: 1782111783641
+- conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py313ha402da8_3.conda
+  sha256: bb5b19bb79e9be63873eaa4aeb3254fbfcbae5b28dad6d9c8db6e2df54146400
+  md5: 195edf9224048bd7fd7d31bf6375234e
   depends:
   - __glibc >=2.17,<3.0.a0
   - blosc >=1.21.6,<2.0a0
@@ -18901,7 +18922,7 @@ packages:
   - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - openjpeg >=2.5.4,<3.0a0
-  - openjph >=0.29.0,<0.30.0a0
+  - openjph >=0.30.1,<0.31.0a0
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - snappy >=1.2.2,<1.3.0a0
@@ -18911,11 +18932,11 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 2324926
-  timestamp: 1781743141900
-- conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py314h08bb928_2.conda
-  sha256: e4191e6c511484ec9db5ecc3b1d9d89e0458491d5af32fed16c3846a8980bb37
-  md5: 2d7f4b4f02c0c6c71d2e6652f05b8489
+  size: 2323524
+  timestamp: 1782111763349
+- conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py314h3cef23f_3.conda
+  sha256: 2eed7843b92ab8dad661359293de3004c029052eacaae51134bd090f6795e870
+  md5: 87f3d241d6def6667452ee675daa66bc
   depends:
   - __glibc >=2.17,<3.0.a0
   - blosc >=1.21.6,<2.0a0
@@ -18946,7 +18967,7 @@ packages:
   - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - openjpeg >=2.5.4,<3.0a0
-  - openjph >=0.29.0,<0.30.0a0
+  - openjph >=0.30.1,<0.31.0a0
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314t
   - snappy >=1.2.2,<1.3.0a0
@@ -18956,11 +18977,11 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 2402110
-  timestamp: 1781743164174
-- conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py314h834e057_2.conda
-  sha256: 2cf9151299554c4b677077e8bd3dbd7d82b644fa38017d2a9bf747a22b2f2ba4
-  md5: 739e400b5579069eb064fac856de1a5e
+  size: 2410280
+  timestamp: 1782111822981
+- conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-2026.6.6-py314h8570d32_3.conda
+  sha256: 68cdae8ca07206ca730b790df7f3bbbd612aa85efc9815eb269805f8b1e6509f
+  md5: d81122df55cf81000814a9980e6b7f30
   depends:
   - __glibc >=2.17,<3.0.a0
   - blosc >=1.21.6,<2.0a0
@@ -18991,7 +19012,7 @@ packages:
   - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - openjpeg >=2.5.4,<3.0a0
-  - openjph >=0.29.0,<0.30.0a0
+  - openjph >=0.30.1,<0.31.0a0
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314
   - snappy >=1.2.2,<1.3.0a0
@@ -19001,8 +19022,8 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 2334852
-  timestamp: 1781743130059
+  size: 2328264
+  timestamp: 1782111764336
 - conda: https://prefix.dev/conda-forge/linux-64/imagecodecs-lite-2019.12.3-py310h261611a_8.conda
   sha256: 726dd56f8725b97181bb46a981b7abddf4ea73b1b7af0aa80fa1eb0056de3cf5
   md5: a774d86477e90322a714a21177ba6322
@@ -19501,13 +19522,13 @@ packages:
     - libarrow >=20.0.0,<20.1.0a0
   size: 9438373
   timestamp: 1774279501142
-- conda: https://prefix.dev/conda-forge/linux-64/libarrow-22.0.0-h157cd41_24_cpu.conda
-  build_number: 24
-  sha256: 1ffa8d1c0c7b66c6c6a2bb5eb542c65619a275d1704f97d90da0d723f4d56adc
-  md5: 759923c9621730a861f399055aa27940
+- conda: https://prefix.dev/conda-forge/linux-64/libarrow-22.0.0-hb646d72_25_cpu.conda
+  build_number: 25
+  sha256: c31b68bb5cbd5377793db17bccad8b4a7d16335392f13ece9611dc5185f3e9be
+  md5: 1f02b09777b4d678d18e4418de65a68f
   depends:
   - __glibc >=2.17,<3.0.a0
-  - aws-crt-cpp >=0.40.0,<0.40.1.0a0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
   - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
   - azure-core-cpp >=1.16.3,<1.16.4.0a0
   - azure-identity-cpp >=1.13.3,<1.13.4.0a0
@@ -19539,15 +19560,15 @@ packages:
   run_exports:
     weak:
     - libarrow >=22.0.0,<22.1.0a0
-  size: 6344854
-  timestamp: 1781581939215
-- conda: https://prefix.dev/conda-forge/linux-64/libarrow-24.0.0-h157cd41_6_cpu.conda
-  build_number: 6
-  sha256: 23d641959ef8eae719ce7e39e0cc28f42eb1691d8f851fb1fe24101117188bf4
-  md5: 18c9acc76e2e7b546831c547f7946959
+  size: 6355970
+  timestamp: 1781908151073
+- conda: https://prefix.dev/conda-forge/linux-64/libarrow-24.0.0-hb642ee7_8_cpu.conda
+  build_number: 8
+  sha256: b30e965aa4b57413da99690e01473dc81a6a24ce1f7548f102350c1d26f4f08a
+  md5: 5e12d802f30c0a1d9c3db30133fe1ec3
   depends:
   - __glibc >=2.17,<3.0.a0
-  - aws-crt-cpp >=0.40.0,<0.40.1.0a0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
   - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
   - azure-core-cpp >=1.16.3,<1.16.4.0a0
   - azure-identity-cpp >=1.13.3,<1.13.4.0a0
@@ -19560,8 +19581,8 @@ packages:
   - libbrotlidec >=1.2.0,<1.3.0a0
   - libbrotlienc >=1.2.0,<1.3.0a0
   - libgcc >=14
-  - libgoogle-cloud >=3.5.0,<3.6.0a0
-  - libgoogle-cloud-storage >=3.5.0,<3.6.0a0
+  - libgoogle-cloud >=3.6.0,<3.7.0a0
+  - libgoogle-cloud-storage >=3.6.0,<3.7.0a0
   - libopentelemetry-cpp >=1.27.0,<1.28.0a0
   - libprotobuf >=6.33.5,<6.33.6.0a0
   - libstdcxx >=14
@@ -19571,16 +19592,15 @@ packages:
   - snappy >=1.2.2,<1.3.0a0
   - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - parquet-cpp <0.0a0
   - apache-arrow-proc =*=cpu
   - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow >=24.0.0,<24.1.0a0
-  size: 6518222
-  timestamp: 1781582236629
+  size: 6522840
+  timestamp: 1782184573454
 - conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-16.0.0-hac33072_1_cpu.conda
   build_number: 1
   sha256: 2d6edbcfbd0d9a96b70fe2898127e7c203e61214f7eb8cb8a5b65258da60d0aa
@@ -19628,14 +19648,14 @@ packages:
     - libarrow-acero >=20.0.0,<20.1.0a0
   size: 669282
   timestamp: 1774279586712
-- conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-22.0.0-h635bf11_24_cpu.conda
-  build_number: 24
-  sha256: 292c1ff4aa5e982ce9b788466368e971ca12bf42088e3007a5950cbaa50ff984
-  md5: 68d127d26783ae0e513f014a89b56a79
+- conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-22.0.0-h635bf11_25_cpu.conda
+  build_number: 25
+  sha256: 8479009c5b69af009cd33664eee16cf7d409f6896bb8f96313f5765068558bed
+  md5: 1e1895e1797c1296a686ebd81106c4ca
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 22.0.0 h157cd41_24_cpu
-  - libarrow-compute 22.0.0 h53684a4_24_cpu
+  - libarrow 22.0.0 hb646d72_25_cpu
+  - libarrow-compute 22.0.0 h53684a4_25_cpu
   - libgcc >=14
   - libstdcxx >=14
   license: Apache-2.0
@@ -19643,32 +19663,31 @@ packages:
   run_exports:
     weak:
     - libarrow-acero >=22.0.0,<22.1.0a0
-  size: 608173
-  timestamp: 1781582237785
-- conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-24.0.0-h635bf11_6_cpu.conda
-  build_number: 6
-  sha256: a5bd032fb163bfa90f93704c422fcc30c774afd3164432e0891607d61a9a7d54
-  md5: 9923cf08ce75f24467841062330fdc5a
+  size: 608320
+  timestamp: 1781908393234
+- conda: https://prefix.dev/conda-forge/linux-64/libarrow-acero-24.0.0-h635bf11_8_cpu.conda
+  build_number: 8
+  sha256: 7d5ff43ac1492f1f7be0b8f497d2ed9782b391a7573aa4f582bf5bb012b33a80
+  md5: 7ee20a0ce202d7f8c1c80aeb15427874
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 24.0.0 h157cd41_6_cpu
-  - libarrow-compute 24.0.0 h53684a4_6_cpu
+  - libarrow 24.0.0 hb642ee7_8_cpu
+  - libarrow-compute 24.0.0 h53684a4_8_cpu
   - libgcc >=14
   - libstdcxx >=14
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow-acero >=24.0.0,<24.1.0a0
-  size: 591012
-  timestamp: 1781582538735
-- conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-22.0.0-h53684a4_24_cpu.conda
-  build_number: 24
-  sha256: e60662a04be08d1749fc61cc8748cd8b1d422ff4d14e9b0c46ac8127796179d1
-  md5: 5dfef4e5292cc1cad0a95136edbee168
+  size: 591077
+  timestamp: 1782184817230
+- conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-22.0.0-h53684a4_25_cpu.conda
+  build_number: 25
+  sha256: e0e0090747626d618047d43ec70fffdea1ab416eba7c511a282a5ec6dac1b7a3
+  md5: 06e3f61a6f5e7fa462225e203a6a8afb
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 22.0.0 h157cd41_24_cpu
+  - libarrow 22.0.0 hb646d72_25_cpu
   - libgcc >=14
   - libre2-11 >=2025.11.5
   - libstdcxx >=14
@@ -19679,27 +19698,26 @@ packages:
   run_exports:
     weak:
     - libarrow-compute >=22.0.0,<22.1.0a0
-  size: 2995512
-  timestamp: 1781582122128
-- conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-24.0.0-h53684a4_6_cpu.conda
-  build_number: 6
-  sha256: 20e0ec5d660a8c18efb826e68c77497750f0486e158f6576db459e6660fd756e
-  md5: a89b6d55d02b00e3b82b5b518046d8c5
+  size: 2995205
+  timestamp: 1781908274735
+- conda: https://prefix.dev/conda-forge/linux-64/libarrow-compute-24.0.0-h53684a4_8_cpu.conda
+  build_number: 8
+  sha256: 0e5a9c2080effae7fd660453eedabedc4945eb9752a81062459f77308e3793a6
+  md5: dd1398cbd330470f75f202ac99225ed8
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 24.0.0 h157cd41_6_cpu
+  - libarrow 24.0.0 hb642ee7_8_cpu
   - libgcc >=14
   - libre2-11 >=2025.11.5
   - libstdcxx >=14
   - libutf8proc >=2.11.3,<2.12.0a0
   - re2
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow-compute >=24.0.0,<24.1.0a0
-  size: 2991572
-  timestamp: 1781582420473
+  size: 2992150
+  timestamp: 1782184697848
 - conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-16.0.0-hac33072_1_cpu.conda
   build_number: 1
   sha256: f59514cce9f771e6b5885bd8dd2210acff469d2d217cb85a7ffb5eae2b71cabe
@@ -19753,44 +19771,43 @@ packages:
     - libarrow-dataset >=20.0.0,<20.1.0a0
   size: 638107
   timestamp: 1774279729327
-- conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-22.0.0-h635bf11_24_cpu.conda
-  build_number: 24
-  sha256: 7b3e309b4c2e25d5af6d72fab6d9db59e6b028c9c5b2f3ef941e75d6f8ccc876
-  md5: 7f60dfc2332a143c5f951371666c3afd
+- conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-22.0.0-h635bf11_25_cpu.conda
+  build_number: 25
+  sha256: 246bcfe53e87cc2ed9b9fda1054da2b30b146dbc3afabddaa4edd05e8a60ae33
+  md5: 14b56c588de43ea7550b344bdcd6468b
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 22.0.0 h157cd41_24_cpu
-  - libarrow-acero 22.0.0 h635bf11_24_cpu
-  - libarrow-compute 22.0.0 h53684a4_24_cpu
+  - libarrow 22.0.0 hb646d72_25_cpu
+  - libarrow-acero 22.0.0 h635bf11_25_cpu
+  - libarrow-compute 22.0.0 h53684a4_25_cpu
   - libgcc >=14
-  - libparquet 22.0.0 h7376487_24_cpu
+  - libparquet 22.0.0 h7376487_25_cpu
   - libstdcxx >=14
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
     - libarrow-dataset >=22.0.0,<22.1.0a0
-  size: 606677
-  timestamp: 1781582317246
-- conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-24.0.0-h635bf11_6_cpu.conda
-  build_number: 6
-  sha256: 6f7210f38be2320765cc2b70f9a4bedadd605db3395e737624c196ac745ec056
-  md5: d9d1ca90b1fd6edabfe0267b83c272c3
+  size: 606362
+  timestamp: 1781908472086
+- conda: https://prefix.dev/conda-forge/linux-64/libarrow-dataset-24.0.0-h635bf11_8_cpu.conda
+  build_number: 8
+  sha256: 32fc98ff80fd72b4dd8d8b0a2f49c5e1d778f26e29d91314fa5af3f687e63e4c
+  md5: 7b0fe5832f7f4f9bbccfbe599482e5aa
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 24.0.0 h157cd41_6_cpu
-  - libarrow-acero 24.0.0 h635bf11_6_cpu
-  - libarrow-compute 24.0.0 h53684a4_6_cpu
+  - libarrow 24.0.0 hb642ee7_8_cpu
+  - libarrow-acero 24.0.0 h635bf11_8_cpu
+  - libarrow-compute 24.0.0 h53684a4_8_cpu
   - libgcc >=14
-  - libparquet 24.0.0 h7376487_6_cpu
+  - libparquet 24.0.0 h7376487_8_cpu
   - libstdcxx >=14
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow-dataset >=24.0.0,<24.1.0a0
-  size: 590554
-  timestamp: 1781582620048
+  size: 590422
+  timestamp: 1782184900125
 - conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-16.0.0-h7e0c224_1_cpu.conda
   build_number: 1
   sha256: 672d4eb00060e9cdd06360ed9145e69d185cfbf60c70eb10a6375f5f62f27a90
@@ -19853,17 +19870,17 @@ packages:
     - libarrow-substrait >=20.0.0,<20.1.0a0
   size: 529670
   timestamp: 1774279833247
-- conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-22.0.0-hb4dd7c2_24_cpu.conda
-  build_number: 24
-  sha256: 44404e7ecc8d50df3b2f7bd5dc29207f0ec3b0db565643ed6965442bfb95fe23
-  md5: 4dfdf6dc4474087ef4e9c0599e158e12
+- conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-22.0.0-hb4dd7c2_25_cpu.conda
+  build_number: 25
+  sha256: eb02a18d365bdb7244bc7f91ba247bf2891507198d7667e7cc65277d1bbd4200
+  md5: 9973fb7f60ffa7a2db125383c490ed4a
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
   - libabseil >=20260107.1,<20260108.0a0
-  - libarrow 22.0.0 h157cd41_24_cpu
-  - libarrow-acero 22.0.0 h635bf11_24_cpu
-  - libarrow-dataset 22.0.0 h635bf11_24_cpu
+  - libarrow 22.0.0 hb646d72_25_cpu
+  - libarrow-acero 22.0.0 h635bf11_25_cpu
+  - libarrow-dataset 22.0.0 h635bf11_25_cpu
   - libgcc >=14
   - libprotobuf >=6.33.5,<6.33.6.0a0
   - libstdcxx >=14
@@ -19872,29 +19889,28 @@ packages:
   run_exports:
     weak:
     - libarrow-substrait >=22.0.0,<22.1.0a0
-  size: 512066
-  timestamp: 1781582343938
-- conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-24.0.0-hb4dd7c2_6_cpu.conda
-  build_number: 6
-  sha256: 2d05d0c291ac6dde6f03c1948aecbaafcbec2d2673635da766e48442a970afd7
-  md5: 9e8d802e4ab7c5ce0f407ef51f348bc2
+  size: 513958
+  timestamp: 1781908500461
+- conda: https://prefix.dev/conda-forge/linux-64/libarrow-substrait-24.0.0-hb4dd7c2_8_cpu.conda
+  build_number: 8
+  sha256: cc0e3f6ef64d2bc60eefd84e06e122de600249433f6a50f4f092bca31f8dcdc5
+  md5: f03a27d9512c5754cc1d189b9ca78204
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
   - libabseil >=20260107.1,<20260108.0a0
-  - libarrow 24.0.0 h157cd41_6_cpu
-  - libarrow-acero 24.0.0 h635bf11_6_cpu
-  - libarrow-dataset 24.0.0 h635bf11_6_cpu
+  - libarrow 24.0.0 hb642ee7_8_cpu
+  - libarrow-acero 24.0.0 h635bf11_8_cpu
+  - libarrow-dataset 24.0.0 h635bf11_8_cpu
   - libgcc >=14
   - libprotobuf >=6.33.5,<6.33.6.0a0
   - libstdcxx >=14
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow-substrait >=24.0.0,<24.1.0a0
-  size: 501127
-  timestamp: 1781582647223
+  size: 500657
+  timestamp: 1782184927343
 - conda: https://prefix.dev/conda-forge/linux-64/libavif16-1.4.2-hf998032_1.conda
   sha256: b831161d7c86f7dfeb58d7189176c3314d7c2ccb38b4e1c8b376557ae4238f0b
   md5: 57845550bac29aeb754615c41b518f74
@@ -20695,6 +20711,29 @@ packages:
     - libgoogle-cloud >=3.5.0,<3.6.0a0
   size: 2647694
   timestamp: 1780029060448
+- conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-3.6.0-h8d2ee43_0.conda
+  sha256: eb6fe89a6e2ffa6b485c437022e15d2173c2da3ada86690cf250bcfe6f6382d5
+  md5: 50a88a9c7d89d854336c633966b67e56
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libgcc >=14
+  - libgrpc >=1.78.1,<1.79.0a0
+  - libopentelemetry-cpp >=1.27.0,<1.28.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libstdcxx >=14
+  - openssl >=3.5.7,<4.0a0
+  constrains:
+  - libgoogle-cloud 3.6.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - libgoogle-cloud >=3.6.0,<3.7.0a0
+  size: 2680630
+  timestamp: 1781922536584
 - conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-2.23.0-hc7a4891_1.conda
   sha256: b85ce8b78e9262670a145a1639e253708e2a9eb9100d60ccec16f8e41d87a4bb
   md5: ee99fb9107ffb579b58ee92a5fb14b06
@@ -20774,6 +20813,26 @@ packages:
     - libgoogle-cloud-storage >=3.5.0,<3.6.0a0
   size: 779116
   timestamp: 1780029183339
+- conda: https://prefix.dev/conda-forge/linux-64/libgoogle-cloud-storage-3.6.0-hdbdcf42_0.conda
+  sha256: 2d94ab8302408d34894024a80604e85936bb208a487841a222cafdb15c143f23
+  md5: a5001567e3c2758834d63129ecb89bb1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgcc >=14
+  - libgoogle-cloud 3.6.0 h8d2ee43_0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - libgoogle-cloud-storage >=3.6.0,<3.7.0a0
+  size: 785866
+  timestamp: 1781922659639
 - conda: https://prefix.dev/conda-forge/linux-64/libgrpc-1.62.2-h15f2491_0.conda
   sha256: 28241ed89335871db33cb6010e9ccb2d9e9b6bb444ddf6884f02f0857363c06a
   md5: 8dabe607748cb3d7002ad73cd06f1325
@@ -21396,13 +21455,13 @@ packages:
     - libparquet >=20.0.0,<20.1.0a0
   size: 1266871
   timestamp: 1774279693519
-- conda: https://prefix.dev/conda-forge/linux-64/libparquet-22.0.0-h7376487_24_cpu.conda
-  build_number: 24
-  sha256: c26df59b4b422ca52c7eefa09832a5f7857aede537713bef91abbf1b96e56f2d
-  md5: 8d38d220f7e19b753acc32f8fe51882a
+- conda: https://prefix.dev/conda-forge/linux-64/libparquet-22.0.0-h7376487_25_cpu.conda
+  build_number: 25
+  sha256: eb8ba4a8ce160e59e657eaa7a5bd1ff6f5f575416ba55fac5b17c74aa9a9284e
+  md5: 968b70c25ba7eec6b0ca9b7e0e9e8884
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 22.0.0 h157cd41_24_cpu
+  - libarrow 22.0.0 hb646d72_25_cpu
   - libgcc >=14
   - libstdcxx >=14
   - libthrift >=0.22.0,<0.22.1.0a0
@@ -21412,26 +21471,25 @@ packages:
   run_exports:
     weak:
     - libparquet >=22.0.0,<22.1.0a0
-  size: 1371961
-  timestamp: 1781582210139
-- conda: https://prefix.dev/conda-forge/linux-64/libparquet-24.0.0-h7376487_6_cpu.conda
-  build_number: 6
-  sha256: cdffce037f31009379ed0d00d99205b16367ddfa6d00fe50ff76acce1062d999
-  md5: 53070bfc11eeaa2267d6bc79b9d66e0f
+  size: 1374879
+  timestamp: 1781908363765
+- conda: https://prefix.dev/conda-forge/linux-64/libparquet-24.0.0-h7376487_8_cpu.conda
+  build_number: 8
+  sha256: 9d466a57037ee713cf954c04a5c8756f0042c54d0d698f3f918f2df8bd77b5b1
+  md5: 2b1feb7e1c3900157172fac5a69b6252
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 24.0.0 h157cd41_6_cpu
+  - libarrow 24.0.0 hb642ee7_8_cpu
   - libgcc >=14
   - libstdcxx >=14
   - libthrift >=0.22.0,<0.22.1.0a0
   - openssl >=3.5.7,<4.0a0
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libparquet >=24.0.0,<24.1.0a0
-  size: 1427184
-  timestamp: 1781582510406
+  size: 1426831
+  timestamp: 1782184788047
 - conda: https://prefix.dev/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda
   sha256: f41721636a7c2e51bc2c642e1127955ab9c81145470714fdaac44d4d09e4af41
   md5: 33082e13b4769b48cfeb648e15bfe3fc
@@ -22741,17 +22799,17 @@ packages:
     - mbedtls >=3.6.3.1,<3.7.0a0
   size: 950599
   timestamp: 1747803179261
-- conda: https://prefix.dev/conda-forge/linux-64/menuinst-2.5.0-py314hdafbbf9_0.conda
-  sha256: a17173c4716f5217fd0064d97fda8b195e2a3e348eacae56ec32661e6ef9a5e0
-  md5: 1ad046ceb7f6ad323b8a962cabbb53ac
+- conda: https://prefix.dev/conda-forge/linux-64/menuinst-2.5.0-py314h9e666f3_1.conda
+  sha256: 3a57010accdc25f84a21c19df21f34be22c723ace420fa8579031e879d565b66
+  md5: 02b60032eba5a756c4b7db24b3e1b5c2
   depends:
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
+  - python
   - tomli-w
+  - python_abi 3.14.* *_cp314
   license: BSD-3-Clause AND MIT
   run_exports: {}
-  size: 195700
-  timestamp: 1780906855538
+  size: 206728
+  timestamp: 1782062685981
 - conda: https://prefix.dev/conda-forge/linux-64/mmh3-3.0.0-py310hd8f1fbe_3.tar.bz2
   sha256: e2708419745fc374170f124fd298eab93a97755a3c8b5f372ce644a0710abf4c
   md5: 8b677e7e3f2c9cb90778b2f2bd19b5fa
@@ -22892,9 +22950,9 @@ packages:
     - mpg123 >=1.32.9,<1.33.0a0
   size: 491140
   timestamp: 1730581373280
-- conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py310h03d9f68_0.conda
-  sha256: e5c22509aaf0e493ffecca114ec6df42fe5c23f8ac6a87c59d428c3cdd09767f
-  md5: 9d5b16741347a9d8001bf8ae67f2c7d9
+- conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py310h03d9f68_0.conda
+  sha256: 8ab82fda622ac03b0eeea4a44ea7f68b893c7ef702236c488fbf9fadb47ca671
+  md5: d9517a2dc02ef5fa8068148afbb96823
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -22904,11 +22962,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 94567
-  timestamp: 1781786082096
-- conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py311hdf67eae_0.conda
-  sha256: 86bc5946308c7ef1b8dab5b6cf8fc4fbd3482b166abc4037c70754234f57ee72
-  md5: f801b293c221d5d56c7e6afe0871465e
+  size: 95066
+  timestamp: 1782070374404
+- conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py311hdf67eae_0.conda
+  sha256: 14cd416f5db9837557806e6fb25f1a0a100c1b906cd02bdfaeda3e0a65ce1ae9
+  md5: edbfdea2063003c565d19b7f3743811e
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -22918,11 +22976,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 101643
-  timestamp: 1781786075710
-- conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py312hd9148b4_0.conda
-  sha256: 7c42cee4b781482b6f783c53c28a8c12f36d189a5b717427792d55fea7fdcbd9
-  md5: a60f60d91804bed51104c4faa580265f
+  size: 101921
+  timestamp: 1782070376756
+- conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py312hd9148b4_0.conda
+  sha256: cb47e612ae50b589d6370eaacad826864894434515ac441898c790f635ba2c40
+  md5: 7d3516af126c9f5330f31622350a443e
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -22932,11 +22990,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 101833
-  timestamp: 1781786075150
-- conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py313h7037e92_0.conda
-  sha256: f8a3312b3ef1ea9caad0437dbf1f0e7472b2911bdf9f5251202db488440451df
-  md5: 88de11aefd2a95aa83581d71efbe3a69
+  size: 102104
+  timestamp: 1782070372383
+- conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py313h7037e92_0.conda
+  sha256: 87a569daa29cb526cff5e9e5cca3fc92c479a92f13c0bac6a4ad6b38ef068f5b
+  md5: 4f7f0bbf165e65d6f620251860c098c2
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -22946,11 +23004,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 102245
-  timestamp: 1781786078701
-- conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py314h3ba012d_0.conda
-  sha256: ae2261e37c17e3125d8c21ce4204ff2a1e9f1587d8a730ba77d5a11c38504b24
-  md5: 116e78ef33657dde2b38619ec63a0f54
+  size: 102737
+  timestamp: 1782070377224
+- conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py314h3ba012d_0.conda
+  sha256: b4c3079832fa703d4d188ce19bff09b55ce89cd81ae8c3cc7fe140033ff11a20
+  md5: b214388d2f3e8349cff9d03f9d9d9de7
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -22960,11 +23018,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 101786
-  timestamp: 1781786081245
-- conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.0-py314h9891dd4_0.conda
-  sha256: 9d712735adfc1f73ceee231b8c6ea47ecbf2e63a93d816891cca9ef19caa8b8a
-  md5: cb1c896c307a55e1c3adc06ad8f616d7
+  size: 102824
+  timestamp: 1782070380299
+- conda: https://prefix.dev/conda-forge/linux-64/msgpack-python-1.2.1-py314h9891dd4_0.conda
+  sha256: bbbb210e90dbd8c9ddba24730aca81aefe23f5ecaf79a81b6740e0dbd25f7b21
+  md5: 9b67bf9c63607097b6e010a7b555a388
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -22976,8 +23034,8 @@ packages:
   purls:
   - pkg:pypi/msgpack?source=compressed-mapping
   run_exports: {}
-  size: 103160
-  timestamp: 1781786083396
+  size: 103513
+  timestamp: 1782070374726
 - conda: https://prefix.dev/conda-forge/linux-64/multidict-6.7.1-py310h3406613_0.conda
   sha256: 7566d0cd317ffb09374d0fdcfd921c8fe14702d551d159173b582c996b123fca
   md5: 60069e0f230489d6f7119009696321c7
@@ -23575,27 +23633,6 @@ packages:
     - numpy >=1.21,<3
   size: 8490501
   timestamp: 1747545073507
-- conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.6-py312h33ff503_0.conda
-  sha256: dfcbeadb3e7ad0da7a55a0525884ca34c19584154e13cc4159396b305d1bd445
-  md5: 6e31d55ee1110fda83b4f4045f4d73ff
-  depends:
-  - python
-  - libstdcxx >=14
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - liblapack >=3.9.0,<4.0a0
-  - libblas >=3.9.0,<4.0a0
-  - python_abi 3.12.* *_cp312
-  - libcblas >=3.9.0,<4.0a0
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - numpy >=1.23,<3
-  size: 8759520
-  timestamp: 1779169200325
 - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.6-py313hf6604e3_0.conda
   sha256: 3740c9bc562db9c6f252f8697c5c7948bb48784346856f6d6308aba72ea4f00b
   md5: a5fdb80595ec7912e6b1634b2abd4b50
@@ -23659,6 +23696,27 @@ packages:
     - numpy >=1.23,<3
   size: 8978806
   timestamp: 1779169197952
+- conda: https://prefix.dev/conda-forge/linux-64/numpy-2.5.0-py312h33ff503_0.conda
+  sha256: c8d5f70715fc6cd3dcd16fdd11b51879ed4484963f066b33fbaf20c4ffb153af
+  md5: 24f70d3db040fc69ee72cc38e55bc8e3
+  depends:
+  - python
+  - libgcc >=14
+  - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - libblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - numpy >=1.25,<3
+  size: 8911732
+  timestamp: 1782112536981
 - conda: https://prefix.dev/conda-forge/linux-64/openjdk-21.0.10-ha668962_0.conda
   sha256: 87126a0022812fb81df02f6807a6c844bf43bffbf51a1320fbc41647cae0fcb2
   md5: b70f3ae987f9f167f06941a8699794a3
@@ -23727,9 +23785,9 @@ packages:
     - openjph >=0.27.4,<0.28.0a0
   size: 283312
   timestamp: 1780596792557
-- conda: https://prefix.dev/conda-forge/linux-64/openjph-0.29.0-h8d634f6_0.conda
-  sha256: baa037746498eb420a434ee92caa767fd39de9435713a25a64ba2b6558020a4e
-  md5: b27832bf274bd4a399d899341826f682
+- conda: https://prefix.dev/conda-forge/linux-64/openjph-0.30.1-h8d634f6_0.conda
+  sha256: e405a62cc16604c4274d1d64387fa62ba5466cc65fa087ae45451d0150f4b698
+  md5: 6143d4af035262f7e1b954e1cba9156d
   depends:
   - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
@@ -23739,9 +23797,9 @@ packages:
   license_family: BSD
   run_exports:
     weak:
-    - openjph >=0.29.0,<0.30.0a0
-  size: 291200
-  timestamp: 1781694306500
+    - openjph >=0.30.1,<0.31.0a0
+  size: 294315
+  timestamp: 1782091151122
 - conda: https://prefix.dev/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
   sha256: cb0b07db15e303e6f0a19646807715d28f1264c6350309a559702f4f34f37892
   md5: 2e5bf4f1da39c0b32778561c3c4e5878
@@ -24660,24 +24718,23 @@ packages:
   run_exports: {}
   size: 12191860
   timestamp: 1781020717312
-- conda: https://prefix.dev/conda-forge/linux-64/py-rattler-build-0.66.1-py310hb823017_0.conda
+- conda: https://prefix.dev/conda-forge/linux-64/py-rattler-build-0.67.0-py310hb823017_0.conda
   noarch: python
-  sha256: 1fe25aa2c4ae8551695673858792439131b3ad729f8719866cce9568ec147637
-  md5: 3c3b0ce183e9358d8391ab550265c9b9
+  sha256: 1f5061df8a7bc853ed7ead84063e75adc2211351ee9ad48983c38076207493e3
+  md5: 35644029c341cbf5d2bf7bf0875c77e2
   depends:
   - python
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - openssl >=3.5.7,<4.0a0
   - _python_abi3_support 1.*
   - cpython >=3.10
-  - openssl >=3.5.7,<4.0a0
   constrains:
   - __glibc >=2.17
   license: BSD-3-Clause
-  license_family: BSD
   run_exports: {}
-  size: 18395250
-  timestamp: 1781383670788
+  size: 17841804
+  timestamp: 1782144026397
 - conda: https://prefix.dev/conda-forge/linux-64/pyarrow-16.0.0-py310h17c5347_0.conda
   sha256: e8a1da80701136b2ba4476488809bda923a5e20849a13219f82de3cc8ae0e979
   md5: 1adbbc9ae829cabb6eaa2444739cc450
@@ -26137,9 +26194,9 @@ packages:
     - qt6-main >=6.9.2,<6.10.0a0
   size: 52405921
   timestamp: 1758011263853
-- conda: https://prefix.dev/conda-forge/linux-64/rattler-build-0.66.2-ha759004_0.conda
-  sha256: c7903ea7d05b309b323f28069ecb8ed7b886b67985f2d98f1be18a0a3ddd850e
-  md5: 77510aed95136891fca09a11c60f0eb7
+- conda: https://prefix.dev/conda-forge/linux-64/rattler-build-0.67.0-ha759004_0.conda
+  sha256: bc0a551dc160ab19b8e45b289896e8330cd5a2e63cd3dfee066f5f16fbd9437f
+  md5: 44b2514c25c7b81116b367db90128a38
   depends:
   - patchelf
   - libgcc >=14
@@ -26149,10 +26206,9 @@ packages:
   constrains:
   - __glibc >=2.17
   license: BSD-3-Clause
-  license_family: BSD
   run_exports: {}
-  size: 19236101
-  timestamp: 1781721847573
+  size: 19415053
+  timestamp: 1782150852619
 - conda: https://prefix.dev/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
   sha256: cf550bbc8e5ebedb6dba9ccaead3e07bd1cb86b183644a4c853e06e4b3ad5ac7
   md5: d83958768626b3c8471ce032e28afcd3
@@ -26926,9 +26982,9 @@ packages:
   run_exports: {}
   size: 17303931
   timestamp: 1779874783665
-- conda: https://prefix.dev/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_1.conda
-  sha256: d5ac05ad45c0d48731eb189c2cbb2bb99f0e3cb7e1acaad373cb2f1f2597fc75
-  md5: 15995ecb2ef890778ba9a3750190f09d
+- conda: https://prefix.dev/conda-forge/linux-64/scipy-1.18.0-py312h54fa4ab_0.conda
+  sha256: c304dfb0bbf0d824d3706623f6437237d7bfc83941bb7b18f80e05abb10ec79e
+  md5: f8d242c552b0f7f682451ce95879af5e
   depends:
   - __glibc >=2.17,<3.0.a0
   - libblas >=3.9.0,<4.0a0
@@ -26940,17 +26996,17 @@ packages:
   - libstdcxx >=14
   - numpy <2.7
   - numpy >=1.23,<3
-  - numpy >=1.25.2
+  - numpy >=2.0.0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 16828243
-  timestamp: 1779874781187
-- conda: https://prefix.dev/conda-forge/linux-64/scipy-1.17.1-py313h4b8bb8b_1.conda
-  sha256: 2ecb1a3d6aacd20e279a72196954bc8de2e83302823f9dd9f8b9b3310d1bf515
-  md5: 4b098461b0b5edff1a9359c25e675cfd
+  size: 17104066
+  timestamp: 1781912972195
+- conda: https://prefix.dev/conda-forge/linux-64/scipy-1.18.0-py313h4b8bb8b_0.conda
+  sha256: 3ffdca726208a7394b2aa9989e5b1718e28a6285329bbc10bea4e92066e14f49
+  md5: a32f88181ff9a3451c71be1f17a7c799
   depends:
   - __glibc >=2.17,<3.0.a0
   - libblas >=3.9.0,<4.0a0
@@ -26962,17 +27018,17 @@ packages:
   - libstdcxx >=14
   - numpy <2.7
   - numpy >=1.23,<3
-  - numpy >=1.25.2
+  - numpy >=2.0.0
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 17184702
-  timestamp: 1779874789436
-- conda: https://prefix.dev/conda-forge/linux-64/scipy-1.17.1-py314h529d2a9_1.conda
-  sha256: 43d0840cf682eebf5677988e2f46e8cf30f46883e97d2aa093f3b6ba05b02e0e
-  md5: 8d0a7b118f2ef5249e94a87d5aef7809
+  size: 17171066
+  timestamp: 1781912954186
+- conda: https://prefix.dev/conda-forge/linux-64/scipy-1.18.0-py314h529d2a9_0.conda
+  sha256: d24b778c9b714882451092ac941616b8da2ee168ae1c863135470181a2e15bb2
+  md5: 99bee56848517debb3c46eecc889ff00
   depends:
   - __glibc >=2.17,<3.0.a0
   - libblas >=3.9.0,<4.0a0
@@ -26984,17 +27040,17 @@ packages:
   - libstdcxx >=14
   - numpy <2.7
   - numpy >=1.23,<3
-  - numpy >=1.25.2
+  - numpy >=2.0.0
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314t
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 16932606
-  timestamp: 1779874762918
-- conda: https://prefix.dev/conda-forge/linux-64/scipy-1.17.1-py314hf07bd8e_1.conda
-  sha256: 505e3466e97c16d125a9adb61a80bdfc2fefe62bc9f0bfe798eda88706e4b0ed
-  md5: 718437171257e579e7d1f3b51c62536f
+  size: 17493248
+  timestamp: 1781912966973
+- conda: https://prefix.dev/conda-forge/linux-64/scipy-1.18.0-py314hf07bd8e_0.conda
+  sha256: 85503102237f8515ab92319fc14609e894ac9e95e3a1398b0c49db1f9ee50877
+  md5: 62c390c1f8f51240f1ebc7ba782669ad
   depends:
   - __glibc >=2.17,<3.0.a0
   - libblas >=3.9.0,<4.0a0
@@ -27006,14 +27062,14 @@ packages:
   - libstdcxx >=14
   - numpy <2.7
   - numpy >=1.23,<3
-  - numpy >=1.25.2
+  - numpy >=2.0.0
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 16995364
-  timestamp: 1779874760991
+  size: 17260022
+  timestamp: 1781912924009
 - conda: https://prefix.dev/conda-forge/linux-64/secretstorage-3.5.0-py314hdafbbf9_0.conda
   sha256: 1493aadd9fcb4894b879ea0e0e0eed4cb60a60a26bb95b821dcb6ea5def47d06
   md5: 2d7b5ae8ad713d8a7097a75a248f8ba3
@@ -27299,12 +27355,12 @@ packages:
     - tiledb >=2.26.2,<2.27.0a0
   size: 4358157
   timestamp: 1732207838896
-- conda: https://prefix.dev/conda-forge/linux-64/tiledb-2.30.1-h83b82d1_12.conda
-  sha256: 6a5f17ff96c3a8f67f69af4af1f6f1e188483e075eeddc58ebdb671550ca85f4
-  md5: 0f9fd7b9bcee06024774c40a61f506fd
+- conda: https://prefix.dev/conda-forge/linux-64/tiledb-2.30.1-h1c34289_13.conda
+  sha256: 352fe89ae1c29c10470d5da6cb0e3733b7a750b3932d5637efdf19544954d14a
+  md5: 1308e63e77f6b37c742707e9b466811c
   depends:
   - __glibc >=2.17,<3.0.a0
-  - aws-crt-cpp >=0.40.0,<0.40.1.0a0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
   - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
   - azure-core-cpp >=1.16.3,<1.16.4.0a0
   - azure-identity-cpp >=1.13.3,<1.13.4.0a0
@@ -27312,7 +27368,7 @@ packages:
   - azure-storage-common-cpp >=12.14.0,<12.14.1.0a0
   - azure-storage-files-datalake-cpp >=12.16.0,<12.16.1.0a0
   - bzip2 >=1.0.8,<2.0a0
-  - c-blosc2 >=3.1.3,<3.2.0a0
+  - c-blosc2 >=3.1.4,<3.2.0a0
   - capnproto >=1.4.0,<1.4.1.0a0
   - fmt >=12.1.0,<12.2.0a0
   - libabseil * cxx17*
@@ -27333,8 +27389,8 @@ packages:
   run_exports:
     weak:
     - tiledb >=2.30.1,<2.31.0a0
-  size: 4424615
-  timestamp: 1781620046596
+  size: 4427832
+  timestamp: 1781892025937
 - conda: https://prefix.dev/conda-forge/linux-64/tiledb-2.30.1-hd503402_6.conda
   sha256: b944523f99c1989b8b03c628ac8caabc93c1e4588c724e8e34bfccd876561a21
   md5: ee39c08516125cbe8ee41ef76f17f178
@@ -27606,19 +27662,19 @@ packages:
   run_exports: {}
   size: 409562
   timestamp: 1770909102180
-- conda: https://prefix.dev/conda-forge/linux-64/uv-0.11.22-h26efc2c_0.conda
-  sha256: 219429d3cc0aeb4ee746c84192a7e336e9b1c7187d081981ed3893a62d078998
-  md5: 853d95620154f47148ed41a2bf732019
+- conda: https://prefix.dev/conda-forge/linux-64/uv-0.11.23-h26efc2c_0.conda
+  sha256: 4c6138933f61eae6416fdf49b63e03a309bd20c262f9809907802991f3ff2d08
+  md5: e5049fe0ce7b185cf27e7268f7a24818
   depends:
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
+  - __glibc >=2.17,<3.0.a0
   constrains:
   - __glibc >=2.17
   license: Apache-2.0 OR MIT
   run_exports: {}
-  size: 19843702
-  timestamp: 1781836456795
+  size: 19833024
+  timestamp: 1781912273818
 - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
   sha256: ea374d57a8fcda281a0a89af0ee49a2c2e99cc4ac97cf2e2db7064e74e764bdb
   md5: 996583ea9c796e5b915f7d7580b51ea6
@@ -27635,86 +27691,80 @@ packages:
     - wayland >=1.25.0,<2.0a0
   size: 334139
   timestamp: 1773959575393
-- conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.1-py310h7c4b9e2_0.conda
-  sha256: 50f580af14d83030eceb4a5d439b9c33b05946692693df2fdcdb9bb9fda9ee90
-  md5: 551230d62e51575f9c2b2c387dfc8f1d
+- conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.2-py310h7c4b9e2_0.conda
+  sha256: ba0ae448c1f531fb6f6dfeec0ec06c751b3ea21802168673c0cd02c5b6fd9aab
+  md5: 5eae4e242426bdd5da1daf6c6776eef4
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 101965
-  timestamp: 1779477455278
-- conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.1-py311h49ec1c0_0.conda
-  sha256: 4461bb07b3aed91fcfb437891a53a0fa0c2591910bc5da85abce481694effced
-  md5: e6cc7808fc5ac070f75c682ca9d00cb5
+  size: 102790
+  timestamp: 1782133644964
+- conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.2-py311h49ec1c0_0.conda
+  sha256: 12dbcbf5416c05f2fae8e13839a6c811342249dfb736c91b8ebcad5370ec03c8
+  md5: ebf29957ecd2619000dd136b80bf5933
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 117311
-  timestamp: 1779477448367
-- conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.1-py312h4c3975b_0.conda
-  sha256: 3d36b297c5f0c1ab0e598760f0033377334a3bfb5c12f4129c2abcb884e2d632
-  md5: a4d41bb00f252b99b4b903b3a8fa3ecc
+  size: 118090
+  timestamp: 1782133648480
+- conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.2-py312h4c3975b_0.conda
+  sha256: 64ae5393d36cc553bcf05d3afbb42aef28b3d1fa986ed5c9358cd32d785940b7
+  md5: 8555a1457e54a2b96093140db1b4b28b
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 114800
-  timestamp: 1779477451511
-- conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.1-py313h07c4f96_0.conda
-  sha256: 852d62cce1d7d6ad60fbfbc4ae40981eebbde5f8b68695157d1c96c3ed8f59c3
-  md5: 5ba52a9fe1509b87de4d18f26d2fe619
+  size: 115842
+  timestamp: 1782133640094
+- conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.2-py313h07c4f96_0.conda
+  sha256: 234b4888d4303c29f839408345f52194078716a369680920af09f6a8fef803a9
+  md5: d6f92eb04d026a9e5b9c5d52c8cd65d6
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 116363
-  timestamp: 1779477447903
-- conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.1-py314h56549f7_0.conda
-  sha256: 92525af64889f75f37327da613aef92fec74a898a308af4636381d97a6793231
-  md5: adc17901a324c5f154648dc70c2998fb
+  size: 117401
+  timestamp: 1782133645625
+- conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.2-py314h56549f7_0.conda
+  sha256: 8de6f7674f4f6567a6e4b6db7cb7b64db25025a020dd697d7c42a10c078ad59d
+  md5: 552c81f84844981fd59d6846526e4acc
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314t
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 119953
-  timestamp: 1779477449220
-- conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.1-py314h5bd0f2a_0.conda
-  sha256: bc53c274d2f7ddbd0ce9212eb72a99d17abe42069e1c78139c5581011ea85bd6
-  md5: 7e4cdd7cc4909e0c9e0a75b3d74e1cad
+  size: 120655
+  timestamp: 1782133649617
+- conda: https://prefix.dev/conda-forge/linux-64/wrapt-2.2.2-py314h5bd0f2a_0.conda
+  sha256: f2789ff73f60f3b740629146a64f778bbf40e26900978cb632180878a496423c
+  md5: e1e275654a6c998b7357606f5da46af7
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314
   license: BSD-2-Clause
-  license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=hash-mapping
+  - pkg:pypi/wrapt?source=compressed-mapping
   run_exports: {}
-  size: 117023
-  timestamp: 1779477450167
+  size: 118096
+  timestamp: 1782133651496
 - conda: https://prefix.dev/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
   sha256: ad8cab7e07e2af268449c2ce855cbb51f43f4664936eff679b1f3862e6e4b01d
   md5: fdc27cb255a7a2cc73b7919a968b48f0
@@ -27799,9 +27849,9 @@ packages:
     - xcb-util-wm >=0.4.2,<0.5.0a0
   size: 51689
   timestamp: 1718844051451
-- conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.47-h280c20c_1.conda
-  sha256: 2bd7452f68c39bfff954385b062aca9389262369e318739af270d23af47580a5
-  md5: bb1e548a92b0efa12c3e2385ae2d4529
+- conda: https://prefix.dev/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
+  sha256: 3b04afd5d1a65d2d27ac2d49a63b01ab8bcd875776779ec63e337370ed38afdc
+  md5: b233b41be0bf210989d57160ed39b394
   depends:
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
@@ -27809,8 +27859,8 @@ packages:
   license: MIT
   license_family: MIT
   run_exports: {}
-  size: 440702
-  timestamp: 1781482698093
+  size: 441670
+  timestamp: 1782027360439
 - conda: https://prefix.dev/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
   sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
   md5: fb901ff28063514abb6046c9ec2c4a45
@@ -28575,23 +28625,23 @@ packages:
     - aws-c-auth >=0.10.1,<0.10.2.0a0
   size: 142765
   timestamp: 1774274954323
-- conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.3-hc916f7b_2.conda
-  sha256: 44cfea10ca5747b8083ebdfedb737999d85577877e02852e2f02179bf8acbdbb
-  md5: 4f5400f2a13f64eccd154d34b4524c74
+- conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.10.3-h5c394e5_3.conda
+  sha256: 08b1667546b6cadc722a5690632430eb793e0e92895115e6b55a83ef2e6a098e
+  md5: ba4cb3df9e4a6013be09a6884070a69f
   depends:
   - libgcc >=14
+  - aws-c-io >=0.26.3,<0.26.4.0a0
   - aws-c-http >=0.11.0,<0.11.1.0a0
-  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
   - aws-c-cal >=0.9.14,<0.9.15.0a0
   - aws-c-common >=0.14.0,<0.14.1.0a0
-  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
     - aws-c-auth >=0.10.3,<0.10.4.0a0
-  size: 142795
-  timestamp: 1780598344064
+  size: 144116
+  timestamp: 1781802957479
 - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-auth-0.7.20-haea164f_0.conda
   sha256: 3e12105706271384634776a5ebf364f400b887600ab950ad79c2ea892f6e011a
   md5: d86c0927fc214cc75f852df9d199629c
@@ -29000,21 +29050,6 @@ packages:
     - aws-c-mqtt >=0.11.0,<0.11.1.0a0
   size: 169040
   timestamp: 1731734203264
-- conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-mqtt-0.15.2-h3479d1b_4.conda
-  sha256: 81c4e397f9a3ca1bab43e269f98dccd3773421b357227fa9a5a86721feb6eb63
-  md5: b3486fb9e4b45313f884921b55099dee
-  depends:
-  - libgcc >=14
-  - aws-c-common >=0.14.0,<0.14.1.0a0
-  - aws-c-http >=0.11.0,<0.11.1.0a0
-  - aws-c-io >=0.26.3,<0.26.4.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  run_exports:
-    weak:
-    - aws-c-mqtt >=0.15.2,<0.15.3.0a0
-  size: 196655
-  timestamp: 1780598992490
 - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-mqtt-0.15.2-hdc5d86d_1.conda
   sha256: 640941aae63031de6e5d118a32741ba3ef3d892d077052d92e4c5fdaec55fbf0
   md5: a407faf5b7e0c97acfb83ff7032806ac
@@ -29030,6 +29065,21 @@ packages:
     - aws-c-mqtt >=0.15.2,<0.15.3.0a0
   size: 196681
   timestamp: 1774275512330
+- conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-mqtt-0.16.0-h3479d1b_0.conda
+  sha256: 5dfb678f299f258dd54ba39bbb0b43b31f7393c999a386a328edf794e652a1ed
+  md5: 5d6c352a3ddf21cb58e2afbecd0dfdfc
+  depends:
+  - libgcc >=14
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-mqtt >=0.16.0,<0.16.1.0a0
+  size: 198686
+  timestamp: 1780681843392
 - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.11.5-h1747a43_5.conda
   sha256: 231feeb591c2e77459c60f69288aaed9114d323141ff7a09fb4ad70d6c06c9df
   md5: 3dec5bb65af0e9164fe1d1f7247e386d
@@ -29049,25 +29099,25 @@ packages:
     - aws-c-s3 >=0.11.5,<0.11.6.0a0
   size: 156882
   timestamp: 1774282164494
-- conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.12.5-hdd40dfe_1.conda
-  sha256: 90a12ca54c43aa7c93ece43cc180d3d436925803758c8880367b8a223cd10e1f
-  md5: 42ec3ff3dbdc216da4ec9fbacedfd4a3
+- conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.12.6-hdd40dfe_0.conda
+  sha256: 9a62d67348d140c5b626f72f1d5f5192e6ea0cbdf047e7ebd9f46f33f63e268a
+  md5: 88df147dd58567e2a18eabd84d37f79f
   depends:
   - libgcc >=14
-  - aws-c-http >=0.11.0,<0.11.1.0a0
   - aws-c-io >=0.26.3,<0.26.4.0a0
-  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
   - aws-c-auth >=0.10.3,<0.10.4.0a0
-  - openssl >=3.5.6,<4.0a0
   - aws-checksums >=0.2.10,<0.2.11.0a0
   - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - openssl >=3.5.7,<4.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
-    - aws-c-s3 >=0.12.5,<0.12.6.0a0
-  size: 158789
-  timestamp: 1780609566744
+    - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  size: 160942
+  timestamp: 1781252023638
 - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-s3-0.5.9-h39e75e1_0.conda
   sha256: e074103668e3d0f1b0ab3dcd908ef76d1230412f63a97b8cf52bd00af0b70a69
   md5: c526363ca483694258fead4c0eeee077
@@ -29132,19 +29182,6 @@ packages:
     - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
   size: 58256
   timestamp: 1731687032896
-- conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h5b0efec_6.conda
-  sha256: dae89e319d2e2fe072f514d17a7634365f0fb054782ae2d319185be0a3c9c6cf
-  md5: 2bb1961f16ea54ebff23f314650d1076
-  depends:
-  - libgcc >=14
-  - aws-c-common >=0.14.0,<0.14.1.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  run_exports:
-    weak:
-    - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
-  size: 62698
-  timestamp: 1780568551197
 - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.4-h6f28e42_4.conda
   sha256: 33c5279607c4b47cdd6e7217d70410ced7b67aa430aa98f77a55c068600dff09
   md5: 92b452c0a36ed41ae93db16662f7ee8b
@@ -29158,6 +29195,19 @@ packages:
     - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
   size: 62893
   timestamp: 1764755676453
+- conda: https://prefix.dev/conda-forge/linux-aarch64/aws-c-sdkutils-0.2.5-h5b0efec_0.conda
+  sha256: 2cdcddc176ad9a255e4f38c20eb72ee45bad879ac43f080c1ccb2f6ff06fd950
+  md5: 63d2469f561dbd794d4e73de32f16fb5
+  depends:
+  - libgcc >=14
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  size: 69143
+  timestamp: 1781063636600
 - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-checksums-0.1.18-h7972eaf_4.conda
   sha256: 8d0f27cde33d1f86fba4aa438eb9fa32fe350a60ddda222b5581f6f35acc5676
   md5: 5c4cd53b40f29218bfbc4d1519bb29c3
@@ -29276,28 +29326,28 @@ packages:
     - aws-crt-cpp >=0.37.4,<0.37.5.0a0
   size: 326733
   timestamp: 1774286925145
-- conda: https://prefix.dev/conda-forge/linux-aarch64/aws-crt-cpp-0.40.0-hf7c79f2_1.conda
-  sha256: c423bfc3ad1364aa47a76dbfb1b3dc536c39cad396ca5ad96f04e5464d1c8662
-  md5: e59a55e39458bc4aef8dd77d96e5d00a
+- conda: https://prefix.dev/conda-forge/linux-aarch64/aws-crt-cpp-0.40.1-h0495e26_1.conda
+  sha256: 351724940bb515c3cffb497920d077a040b40b634b1fe1b365d3d6444070813f
+  md5: ac8f3c5a8e8e549e6ce9f599fb540324
   depends:
   - libgcc >=14
   - libstdcxx >=14
-  - aws-c-s3 >=0.12.5,<0.12.6.0a0
-  - aws-c-event-stream >=0.7.1,<0.7.2.0a0
-  - aws-c-auth >=0.10.3,<0.10.4.0a0
-  - aws-c-io >=0.26.3,<0.26.4.0a0
-  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
-  - aws-c-http >=0.11.0,<0.11.1.0a0
   - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  - aws-c-auth >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.7.1,<0.7.2.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-mqtt >=0.16.0,<0.16.1.0a0
   - aws-c-common >=0.14.0,<0.14.1.0a0
-  - aws-c-mqtt >=0.15.2,<0.15.3.0a0
+  - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
-    - aws-crt-cpp >=0.40.0,<0.40.1.0a0
-  size: 333272
-  timestamp: 1780917925832
+    - aws-crt-cpp >=0.40.1,<0.40.2.0a0
+  size: 333626
+  timestamp: 1781814070857
 - conda: https://prefix.dev/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.267-he30cb05_8.conda
   sha256: cf73364b4f5c4c5aa762a12d2abfaaa1ef5fcce960bdadd2093d16d0c18acc70
   md5: 61e5f105b7beb1d05f971e6800b18a35
@@ -29356,24 +29406,24 @@ packages:
     - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
   size: 3437133
   timestamp: 1773666674653
-- conda: https://prefix.dev/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.747-hf48beb8_6.conda
-  sha256: 2b9096ac4f1bccda9ee62e1a8a0f4ae0ace939e2d8daa0f6460ae8e62afd0808
-  md5: 16ebf12b5c9e8325f4f44b88ef40680e
+- conda: https://prefix.dev/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.747-h6aa9b71_7.conda
+  sha256: 5aea253048953b5c735d9271110d8630207b9da121574f21c4c5151086c08872
+  md5: c365d649c7ed12d2877e7160b14bb2e0
   depends:
-  - libgcc >=14
   - libstdcxx >=14
+  - libgcc >=14
   - libcurl >=8.20.0,<9.0a0
-  - aws-crt-cpp >=0.40.0,<0.40.1.0a0
-  - aws-c-common >=0.14.0,<0.14.1.0a0
   - libzlib >=1.3.2,<2.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
   - aws-c-event-stream >=0.7.1,<0.7.2.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
     - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
-  size: 3436548
-  timestamp: 1781003629432
+  size: 3466524
+  timestamp: 1781874228607
 - conda: https://prefix.dev/conda-forge/linux-aarch64/azure-core-cpp-1.14.0-h1887c18_0.conda
   sha256: 8967b3ccee4d74e61f6ec82dd8efb9deb854ee7ba012dfe767b7a92e0ac77724
   md5: e0c3a906a41be769f0ae20ca3e31cfc0
@@ -30401,71 +30451,66 @@ packages:
   run_exports: {}
   size: 342661
   timestamp: 1769155977005
-- conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.1-py310h3b5aacf_0.conda
-  sha256: 22c7b636896031b18fd2a93031abc604c7c1ff942ea971a67fd36a83101cc267
-  md5: ecfa495576f762628d97a14cd45b909b
+- conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.3-py310h3b5aacf_0.conda
+  sha256: 507d37215c5c5e190d4ffd72d5967ed23931806530a2088b1808a613ec7cfb43
+  md5: 00f4b3f6c00d70e259cad81bef33f551
   depends:
   - libgcc >=14
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   - tomli
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 314197
-  timestamp: 1779838926829
-- conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.1-py311h2dad8b0_0.conda
-  sha256: cdbd5a66b2bbeb0a40986bbd33f568432b37ea0f9b363105ae4eca87b854377d
-  md5: 0958d51cf101263aa4de328bdf80a0d5
+  size: 319673
+  timestamp: 1782179255177
+- conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.3-py311h2dad8b0_0.conda
+  sha256: 581083d7aa981bb9dda687f3802739d1fc7fd79c59a530cf7302868ab3b2cf03
+  md5: 51e2f3d343acc48f9c527b64d21ccb8e
   depends:
   - libgcc >=14
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - tomli
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 400494
-  timestamp: 1779839067781
-- conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.1-py312hd077ced_0.conda
-  sha256: 9079de8b96c433468f33eb2eb89539e785a564f122ce62a4f1d716f0295edf1c
-  md5: 803aee59c5fc81cefd35d10dcfca9dc0
+  size: 405416
+  timestamp: 1782179182913
+- conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.3-py312hd077ced_0.conda
+  sha256: f34502e517964cae1f275f0916e008e683e779c469167361bfe37e1318d95bc8
+  md5: 8c6e320e532c4117e6b12bb11b55559a
   depends:
   - libgcc >=14
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - tomli
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 390698
-  timestamp: 1779839029690
-- conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.1-py313hfa222a2_0.conda
-  sha256: 30fead8dae0ba63b807a3a9a0898c0b6c4214d8468f39014472a80935595544f
-  md5: f4ba18e3a01bac74f37d0c47be7abc82
+  size: 395819
+  timestamp: 1782179124827
+- conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.3-py313hfa222a2_0.conda
+  sha256: 79e7278d3c061ba2eba4f762701bd18a4d1dda67813c3db75d25a424de9ff3a1
+  md5: b43fe48b77cd6040b05851a0a4e16094
   depends:
   - libgcc >=14
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - tomli
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 397781
-  timestamp: 1779839037021
-- conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.1-py314hb76de3f_0.conda
-  sha256: ad97d0c3c1f4ed5d4f8311ce21ed0884bb4428361c5282a725be643c341efcf3
-  md5: 8ea7448165e3f1b7a39864ceaec9dee3
+  size: 401758
+  timestamp: 1782179261956
+- conda: https://prefix.dev/conda-forge/linux-aarch64/coverage-7.14.3-py314hb76de3f_0.conda
+  sha256: 45a28da74fefd3a20010f7bf4dd453dd9ab2001f3f9677d944515a19b56836d1
+  md5: a65f6993498c70892f008a3233d4cfab
   depends:
   - libgcc >=14
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314
   - tomli
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 415533
-  timestamp: 1779839078882
+  size: 419692
+  timestamp: 1782179237581
 - conda: https://prefix.dev/conda-forge/linux-aarch64/cpp-expected-1.3.1-hdc560ac_0.conda
   sha256: 4edebca2a9dadd8afabb3948a007edae2072e4869d8959b3e51aebc2367e1df4
   md5: 13f0be21fdd39114c28501ac21f0dd00
@@ -31723,16 +31768,16 @@ packages:
     - hdf5 >=1.14.4,<1.14.5.0a0
   size: 4034228
   timestamp: 1733010297124
-- conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h02c88d6_107.conda
-  sha256: a8c8ea1f842583d1779b0b4d5c62709c5c2c75a55b266664ce2dbd8f486ba07f
-  md5: cc9b223819793da2ef247666102d44ac
+- conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h0973965_108.conda
+  sha256: 24899626cc632fd98e6ce1e00257f8f500ca60d18fc2a142da760a26b9c11eef
+  md5: fda606c9f7d6418d748f1776b5d9d88a
   depends:
   - aws-c-auth >=0.10.3,<0.10.4.0a0
   - aws-c-common >=0.14.0,<0.14.1.0a0
   - aws-c-http >=0.11.0,<0.11.1.0a0
   - aws-c-io >=0.26.3,<0.26.4.0a0
-  - aws-c-s3 >=0.12.5,<0.12.6.0a0
-  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
   - libaec >=1.1.5,<2.0a0
   - libcurl >=8.20.0,<9.0a0
   - libgcc >=14
@@ -31740,14 +31785,14 @@ packages:
   - libgfortran5 >=14.3.0
   - libstdcxx >=14
   - libzlib >=1.3.2,<2.0a0
-  - openssl >=3.5.6,<4.0a0
+  - openssl >=3.5.7,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
   run_exports:
     weak:
     - hdf5 >=2.1.0,<3.0a0
-  size: 4545958
-  timestamp: 1780925393775
+  size: 4191043
+  timestamp: 1781838634022
 - conda: https://prefix.dev/conda-forge/linux-aarch64/hdf5-2.1.0-nompi_h81b49a2_104.conda
   sha256: 1a0198c569b90bf1a1f644efe70569d0fa4db2fe06df43da80a87db067050bac
   md5: 6663434543b4834fda59f5d0eaac7a3e
@@ -31896,9 +31941,9 @@ packages:
   run_exports: {}
   size: 1967673
   timestamp: 1777731629958
-- conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py312h33d290e_2.conda
-  sha256: 2a341321706050f10ac01cef20b7c955368dc0482bc48078db387d88eb39d3eb
-  md5: fe294e7bafa879ef90c0f8d5e77094ad
+- conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py312ha5741de_3.conda
+  sha256: 72e9074622dc385b76fe6b3a591edacf2826e4c7714f5abdd8b0026bffff97e8
+  md5: 94563f5485cf4427b2e4aad53e535c26
   depends:
   - blosc >=1.21.6,<2.0a0
   - brunsli >=0.1,<1.0a0
@@ -31928,7 +31973,7 @@ packages:
   - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - openjpeg >=2.5.4,<3.0a0
-  - openjph >=0.29.0,<0.30.0a0
+  - openjph >=0.30.1,<0.31.0a0
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
@@ -31939,11 +31984,11 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 2193779
-  timestamp: 1781743224625
-- conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py313h6e237fd_2.conda
-  sha256: b6892255d96fdd9c5f0ed2d4e1501b9f234475254fa5dc28d296e365586f1fad
-  md5: d71d414579357883020db0bc33cd3590
+  size: 2194350
+  timestamp: 1782111840779
+- conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py313h7daf9ad_3.conda
+  sha256: 336bde1208b48185a2abf81d57b1623df78c05e3d958f83a0c1740fd5ac20586
+  md5: 5142aff653e61fae6b030df3931e3dbb
   depends:
   - blosc >=1.21.6,<2.0a0
   - brunsli >=0.1,<1.0a0
@@ -31973,7 +32018,7 @@ packages:
   - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - openjpeg >=2.5.4,<3.0a0
-  - openjph >=0.29.0,<0.30.0a0
+  - openjph >=0.30.1,<0.31.0a0
   - python >=3.13,<3.14.0a0
   - python >=3.13,<3.14.0a0 *_cp313
   - python_abi 3.13.* *_cp313
@@ -31984,11 +32029,11 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 2190503
-  timestamp: 1781743218997
-- conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py314h790143f_2.conda
-  sha256: ba1d77e5b1ca8c84b7d6d1ed36f93a058bb3f5dcce87a56c5488861700bf4333
-  md5: 59c6d0b89d7ebb1ffc313d9895210d46
+  size: 2197843
+  timestamp: 1782111823450
+- conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py314h9dc542c_3.conda
+  sha256: 7a125792358ce34d53bc0502c2f2e778718c91325353597014793a1f4eed07d9
+  md5: cde20d208991be57bfb8118a4364130d
   depends:
   - blosc >=1.21.6,<2.0a0
   - brunsli >=0.1,<1.0a0
@@ -32018,7 +32063,7 @@ packages:
   - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - openjpeg >=2.5.4,<3.0a0
-  - openjph >=0.29.0,<0.30.0a0
+  - openjph >=0.30.1,<0.31.0a0
   - python >=3.14,<3.15.0a0
   - python >=3.14,<3.15.0a0 *_cp314
   - python_abi 3.14.* *_cp314
@@ -32029,11 +32074,11 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 2208405
-  timestamp: 1781743202909
-- conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py314hc317da5_2.conda
-  sha256: 312cf7759f82119a3836f1e57ba341f4a54b95b564543a510323ff02d94b10a6
-  md5: f8ed7d8b0701b4a584b703e46f29bd1c
+  size: 2212232
+  timestamp: 1782111864371
+- conda: https://prefix.dev/conda-forge/linux-aarch64/imagecodecs-2026.6.6-py314hb7f4bb1_3.conda
+  sha256: 445e6cf43a04543697e928213f1c3dfe2c7ef377e5c8ffac61911f0c52faf51c
+  md5: 879c2558063de94ce5a02e3f0b232d15
   depends:
   - blosc >=1.21.6,<2.0a0
   - brunsli >=0.1,<1.0a0
@@ -32063,7 +32108,7 @@ packages:
   - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - openjpeg >=2.5.4,<3.0a0
-  - openjph >=0.29.0,<0.30.0a0
+  - openjph >=0.30.1,<0.31.0a0
   - python >=3.14,<3.15.0a0
   - python >=3.14,<3.15.0a0 *_cp314t
   - python_abi 3.14.* *_cp314t
@@ -32074,8 +32119,8 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 2506609
-  timestamp: 1781743264957
+  size: 2504462
+  timestamp: 1782111912836
 - conda: https://prefix.dev/conda-forge/linux-aarch64/jxrlib-1.1-h31becfc_3.conda
   sha256: 157e151068d44042c56d6dd6f634d0b2c1fe084114ae56125299f518dd8b1500
   md5: 720f7b9ccdf426ac73dafcf92f7d7bf4
@@ -32509,12 +32554,12 @@ packages:
     - libarrow >=20.0.0,<20.1.0a0
   size: 8642764
   timestamp: 1774278157246
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-22.0.0-h5dfeb67_24_cpu.conda
-  build_number: 24
-  sha256: b5df4faed96965547c751cde55b32584eb117354606ba4886a3d285e8d202ac2
-  md5: 69d28099a725b643a7f7845efc6317bf
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-22.0.0-h2ee4372_25_cpu.conda
+  build_number: 25
+  sha256: c86c0e19a485bd83dc2cd218cf79210488f824dfe277b71f48e3f4253e0f4e1a
+  md5: 9a0f82a8a53e179f4b7b4d11fe9efb3d
   depends:
-  - aws-crt-cpp >=0.40.0,<0.40.1.0a0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
   - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
   - azure-core-cpp >=1.16.3,<1.16.4.0a0
   - azure-identity-cpp >=1.13.3,<1.13.4.0a0
@@ -32538,22 +32583,22 @@ packages:
   - snappy >=1.2.2,<1.3.0a0
   - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - arrow-cpp <0.0a0
-  - parquet-cpp <0.0a0
   - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
     - libarrow >=22.0.0,<22.1.0a0
-  size: 5999189
-  timestamp: 1781580605278
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-24.0.0-h5dfeb67_6_cpu.conda
-  build_number: 6
-  sha256: 4498e111c6d3e30ea1fb29c7a652561bd59770450ee0fc13b143114c22aefe39
-  md5: f7c93e106b6fe80ed11627370c5ee357
+  size: 6005097
+  timestamp: 1781906625337
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-24.0.0-h6b18018_8_cpu.conda
+  build_number: 8
+  sha256: 8a6fea627585a2bcadc402766e3489d9b89e92edd11895b4ee68383972e3ad88
+  md5: 13856187ddb7d2130613ad1cb55c90c6
   depends:
-  - aws-crt-cpp >=0.40.0,<0.40.1.0a0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
   - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
   - azure-core-cpp >=1.16.3,<1.16.4.0a0
   - azure-identity-cpp >=1.13.3,<1.13.4.0a0
@@ -32566,8 +32611,8 @@ packages:
   - libbrotlidec >=1.2.0,<1.3.0a0
   - libbrotlienc >=1.2.0,<1.3.0a0
   - libgcc >=14
-  - libgoogle-cloud >=3.5.0,<3.6.0a0
-  - libgoogle-cloud-storage >=3.5.0,<3.6.0a0
+  - libgoogle-cloud >=3.6.0,<3.7.0a0
+  - libgoogle-cloud-storage >=3.6.0,<3.7.0a0
   - libopentelemetry-cpp >=1.27.0,<1.28.0a0
   - libprotobuf >=6.33.5,<6.33.6.0a0
   - libstdcxx >=14
@@ -32581,12 +32626,11 @@ packages:
   - arrow-cpp <0.0a0
   - parquet-cpp <0.0a0
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow >=24.0.0,<24.1.0a0
-  size: 6048394
-  timestamp: 1781580503812
+  size: 6062071
+  timestamp: 1782182891373
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-16.0.0-h5ad3122_1_cpu.conda
   build_number: 1
   sha256: ce185433c5272d85dcdc2c44d1fa886a6a06b35a1cb48660166cd868a13d78a5
@@ -32632,13 +32676,13 @@ packages:
     - libarrow-acero >=20.0.0,<20.1.0a0
   size: 634854
   timestamp: 1774278210695
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-22.0.0-hb326ee9_24_cpu.conda
-  build_number: 24
-  sha256: d82fc8225f2d5c55c840dd2b69ae9ee861b5ba09aa16bad3d4cb4ff31dc08691
-  md5: a965b65a6a610b85e808f0c1436112ca
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-22.0.0-hb326ee9_25_cpu.conda
+  build_number: 25
+  sha256: 8de24a6aa5a0798df67b0c2bb88f4c7f7ad9b9b97034180f8e7ac334fbca6596
+  md5: 09edd7ba48cd5b68e26762cf34be36dd
   depends:
-  - libarrow 22.0.0 h5dfeb67_24_cpu
-  - libarrow-compute 22.0.0 hdd99842_24_cpu
+  - libarrow 22.0.0 h2ee4372_25_cpu
+  - libarrow-compute 22.0.0 hdd99842_25_cpu
   - libgcc >=14
   - libstdcxx >=14
   license: Apache-2.0
@@ -32646,30 +32690,29 @@ packages:
   run_exports:
     weak:
     - libarrow-acero >=22.0.0,<22.1.0a0
-  size: 568496
-  timestamp: 1781580834483
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-24.0.0-hb326ee9_6_cpu.conda
-  build_number: 6
-  sha256: 3a245eb92e458e6a5f462c680b50f72fa9adf37963f2ef9e40814e1698a0e346
-  md5: 3dad350a6195bd0c666f7969ebb7dc92
+  size: 568777
+  timestamp: 1781906917005
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-acero-24.0.0-hb326ee9_8_cpu.conda
+  build_number: 8
+  sha256: 216ad57405811183a08a1cbc2580489b6bdbc1f9843f0e10b3dea2414db1db6d
+  md5: 1f5e41fcbdde6a7dffdfe27cd8149ddb
   depends:
-  - libarrow 24.0.0 h5dfeb67_6_cpu
-  - libarrow-compute 24.0.0 hdd99842_6_cpu
+  - libarrow 24.0.0 h6b18018_8_cpu
+  - libarrow-compute 24.0.0 hdd99842_8_cpu
   - libgcc >=14
   - libstdcxx >=14
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow-acero >=24.0.0,<24.1.0a0
-  size: 549199
-  timestamp: 1781580613314
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-compute-22.0.0-hdd99842_24_cpu.conda
-  build_number: 24
-  sha256: 3235b545d6c2d6653000877aecff3d5762317b72ee53e41b0662c60d93651aeb
-  md5: c53dcc56c4a7fd331cef3d2d6d6a2574
+  size: 548464
+  timestamp: 1782183001281
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-compute-22.0.0-hdd99842_25_cpu.conda
+  build_number: 25
+  sha256: e302d6f3bf52edd856059f9c70294f77959f4d209af41caf43130902e5d8c8d8
+  md5: 2fa0bbbb68c78fd073aba9bc210a3a4c
   depends:
-  - libarrow 22.0.0 h5dfeb67_24_cpu
+  - libarrow 22.0.0 h2ee4372_25_cpu
   - libgcc >=14
   - libre2-11 >=2025.11.5
   - libstdcxx >=14
@@ -32680,26 +32723,25 @@ packages:
   run_exports:
     weak:
     - libarrow-compute >=22.0.0,<22.1.0a0
-  size: 2616936
-  timestamp: 1781580763888
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-compute-24.0.0-hdd99842_6_cpu.conda
-  build_number: 6
-  sha256: bba8761f8c65e83f1aeeb8537fe322bafc230329df212c02e998b8d397d97506
-  md5: 0b1bdfb9f5e10f8075483b471b9578b6
+  size: 2613317
+  timestamp: 1781906846147
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-compute-24.0.0-hdd99842_8_cpu.conda
+  build_number: 8
+  sha256: fe0d33f1f07c1ee1b1e76a731a74a9ee913050f34fc96f0f8fefd246d4020429
+  md5: 699188173bb12fb5599ae38313af5468
   depends:
-  - libarrow 24.0.0 h5dfeb67_6_cpu
+  - libarrow 24.0.0 h6b18018_8_cpu
   - libgcc >=14
   - libre2-11 >=2025.11.5
   - libstdcxx >=14
   - libutf8proc >=2.11.3,<2.12.0a0
   - re2
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow-compute >=24.0.0,<24.1.0a0
-  size: 2556406
-  timestamp: 1781580541912
+  size: 2556153
+  timestamp: 1782182929223
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-16.0.0-h5ad3122_1_cpu.conda
   build_number: 1
   sha256: 79dff6cdcaff6121f611621b57473cf9828533f3349c6380c3f1da13e32c76ed
@@ -32751,42 +32793,41 @@ packages:
     - libarrow-dataset >=20.0.0,<20.1.0a0
   size: 619395
   timestamp: 1774278300604
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-22.0.0-hb326ee9_24_cpu.conda
-  build_number: 24
-  sha256: d9b8b1172534b4b9f8e9f2146e5adb5d9cb86dd78c1b8895464b48bb9b5cdf36
-  md5: 636225b035f6886748721e5ebe870792
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-22.0.0-hb326ee9_25_cpu.conda
+  build_number: 25
+  sha256: 2e920bb0b563c7b3701ceada52a1af86f5c74bed941d776e1308052389295b49
+  md5: 70bcbfc0620eeb8033c2c19ba13ebad9
   depends:
-  - libarrow 22.0.0 h5dfeb67_24_cpu
-  - libarrow-acero 22.0.0 hb326ee9_24_cpu
-  - libarrow-compute 22.0.0 hdd99842_24_cpu
+  - libarrow 22.0.0 h2ee4372_25_cpu
+  - libarrow-acero 22.0.0 hb326ee9_25_cpu
+  - libarrow-compute 22.0.0 hdd99842_25_cpu
   - libgcc >=14
-  - libparquet 22.0.0 h87079af_24_cpu
+  - libparquet 22.0.0 h87079af_25_cpu
   - libstdcxx >=14
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
     - libarrow-dataset >=22.0.0,<22.1.0a0
-  size: 572687
-  timestamp: 1781580879360
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-24.0.0-hb326ee9_6_cpu.conda
-  build_number: 6
-  sha256: f66e29461184d5ae1aa591ccf8614ecc8225ec68ae7626ec104b434d47e8488a
-  md5: bf390eb311b8e85f3511995ba99786c8
+  size: 572046
+  timestamp: 1781906959884
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-dataset-24.0.0-hb326ee9_8_cpu.conda
+  build_number: 8
+  sha256: 81d72fdde6433980c0a376eae28d66feefd5e7bf7712fab0175f381ec4662191
+  md5: 8a23f3cc4dda06300b9c52d6e4b34e19
   depends:
-  - libarrow 24.0.0 h5dfeb67_6_cpu
-  - libarrow-acero 24.0.0 hb326ee9_6_cpu
-  - libarrow-compute 24.0.0 hdd99842_6_cpu
+  - libarrow 24.0.0 h6b18018_8_cpu
+  - libarrow-acero 24.0.0 hb326ee9_8_cpu
+  - libarrow-compute 24.0.0 hdd99842_8_cpu
   - libgcc >=14
-  - libparquet 24.0.0 h87079af_6_cpu
+  - libparquet 24.0.0 h87079af_8_cpu
   - libstdcxx >=14
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow-dataset >=24.0.0,<24.1.0a0
-  size: 553142
-  timestamp: 1781580659233
+  size: 553180
+  timestamp: 1782183047481
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-16.0.0-h08b7278_1_cpu.conda
   build_number: 1
   sha256: 2dd8a514e73beb76bcdd391fffda6af6d2bd62a2bf8c77356fd9bc5938fcd1bf
@@ -32847,16 +32888,16 @@ packages:
     - libarrow-substrait >=20.0.0,<20.1.0a0
   size: 542622
   timestamp: 1774278366437
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-22.0.0-hf29bd21_24_cpu.conda
-  build_number: 24
-  sha256: 89f838fedf38e3ac4bacc478579aa75a90a7aed7ad7f62060c38b54689d9131a
-  md5: ad9dcb7e714c7ef1be07dab3ed79703f
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-22.0.0-hf29bd21_25_cpu.conda
+  build_number: 25
+  sha256: fc81ad3f98cb183e5c4a5e8a0e62db2ac03540dcc944159425153f6662f5fa4f
+  md5: 7c6f12398aa3f2ec554e2a4d4443058e
   depends:
   - libabseil * cxx17*
   - libabseil >=20260107.1,<20260108.0a0
-  - libarrow 22.0.0 h5dfeb67_24_cpu
-  - libarrow-acero 22.0.0 hb326ee9_24_cpu
-  - libarrow-dataset 22.0.0 hb326ee9_24_cpu
+  - libarrow 22.0.0 h2ee4372_25_cpu
+  - libarrow-acero 22.0.0 hb326ee9_25_cpu
+  - libarrow-dataset 22.0.0 hb326ee9_25_cpu
   - libgcc >=14
   - libprotobuf >=6.33.5,<6.33.6.0a0
   - libstdcxx >=14
@@ -32865,28 +32906,27 @@ packages:
   run_exports:
     weak:
     - libarrow-substrait >=22.0.0,<22.1.0a0
-  size: 487108
-  timestamp: 1781580896893
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-24.0.0-hf29bd21_6_cpu.conda
-  build_number: 6
-  sha256: e28cc00a79604a997bb7d60e186176ffbaef1eacaca00b5f25ae79b565d9decd
-  md5: 4223347252de13eca46a6168639bf58b
+  size: 487491
+  timestamp: 1781906979503
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libarrow-substrait-24.0.0-hf29bd21_8_cpu.conda
+  build_number: 8
+  sha256: 750a2806d7ad4f34319d6394cdb7c9d97f6552245e2651408cb562f0c801c2c0
+  md5: 9a2b1e9df4ef51de33bc44e2c859e276
   depends:
   - libabseil * cxx17*
   - libabseil >=20260107.1,<20260108.0a0
-  - libarrow 24.0.0 h5dfeb67_6_cpu
-  - libarrow-acero 24.0.0 hb326ee9_6_cpu
-  - libarrow-dataset 24.0.0 hb326ee9_6_cpu
+  - libarrow 24.0.0 h6b18018_8_cpu
+  - libarrow-acero 24.0.0 hb326ee9_8_cpu
+  - libarrow-dataset 24.0.0 hb326ee9_8_cpu
   - libgcc >=14
   - libprotobuf >=6.33.5,<6.33.6.0a0
   - libstdcxx >=14
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow-substrait >=24.0.0,<24.1.0a0
-  size: 466560
-  timestamp: 1781580677208
+  size: 466352
+  timestamp: 1782183065824
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libavif16-1.4.2-h1641d3b_1.conda
   sha256: ff9934da0e52979c9e98fc310c8c2e4a1f9d3bd9dacc54509b6b711e1eeb242e
   md5: 7099e12b95f08ff5792a636da5354b37
@@ -33545,6 +33585,28 @@ packages:
     - libgoogle-cloud >=3.5.0,<3.6.0a0
   size: 2632025
   timestamp: 1780029431255
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-3.6.0-h235f271_0.conda
+  sha256: 0b1164de0dc18cc98ea612b666fa58478118da26912f9b06603b85eb842866e0
+  md5: 9adff49a478b99b18feede12337727d6
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libgcc >=14
+  - libgrpc >=1.78.1,<1.79.0a0
+  - libopentelemetry-cpp >=1.27.0,<1.28.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libstdcxx >=14
+  - openssl >=3.5.7,<4.0a0
+  constrains:
+  - libgoogle-cloud 3.6.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - libgoogle-cloud >=3.6.0,<3.7.0a0
+  size: 2640742
+  timestamp: 1781921353383
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-storage-2.23.0-hdb39181_1.conda
   sha256: 977dc600e6958b3c88a278567f279c46eb596cbaac284705bdeec8d7f7e24c39
   md5: 0cdda7751432e9ec4255e19becdac10d
@@ -33621,6 +33683,25 @@ packages:
     - libgoogle-cloud-storage >=3.5.0,<3.6.0a0
   size: 729099
   timestamp: 1780029550339
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libgoogle-cloud-storage-3.6.0-h66d5b86_0.conda
+  sha256: 0d700ed356bbcc0d9424d201472ec298f6304edb9ebe9e3d43ea4a645fda36df
+  md5: c261fe0b89a4cae0639cddda0753653a
+  depends:
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgcc >=14
+  - libgoogle-cloud 3.6.0 h235f271_0
+  - libstdcxx >=14
+  - libzlib >=1.3.2,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - libgoogle-cloud-storage >=3.6.0,<3.7.0a0
+  size: 736958
+  timestamp: 1781921457398
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libgrpc-1.62.2-h98a9317_0.conda
   sha256: ae5fe7ba0c5c599f0e20fa08be436518b7ef25ab6f705e8c7fcf0d0f34525f72
   md5: 2a669953ec0f08c2cc56bb43fed78de8
@@ -34123,12 +34204,12 @@ packages:
     - libparquet >=20.0.0,<20.1.0a0
   size: 1194505
   timestamp: 1774278279006
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-22.0.0-h87079af_24_cpu.conda
-  build_number: 24
-  sha256: 1406d6f7ef99f673c145689e0b8d2e82d6b631f15cd48ee8a59120d20d4cc498
-  md5: 556e3ccf969c990e88e4974373c0b8a3
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-22.0.0-h87079af_25_cpu.conda
+  build_number: 25
+  sha256: a7394a97ebefb4e580dc7c2f18abd000a660326fb48d6a87d611b05383b26f94
+  md5: 89abdca61c81df6650f90f30016d28a2
   depends:
-  - libarrow 22.0.0 h5dfeb67_24_cpu
+  - libarrow 22.0.0 h2ee4372_25_cpu
   - libgcc >=14
   - libstdcxx >=14
   - libthrift >=0.22.0,<0.22.1.0a0
@@ -34138,25 +34219,24 @@ packages:
   run_exports:
     weak:
     - libparquet >=22.0.0,<22.1.0a0
-  size: 1274520
-  timestamp: 1781580818713
-- conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_6_cpu.conda
-  build_number: 6
-  sha256: df3efc6edc974e970097491d099ceb4a0ad41e3d15916e2e41bf327739a183bc
-  md5: da14563c4dd0cd4567cb2db50aaad5a3
+  size: 1274479
+  timestamp: 1781906899317
+- conda: https://prefix.dev/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_8_cpu.conda
+  build_number: 8
+  sha256: 44aa54e302a9561cb53dc8258829f75d4d0268336e41bd28fa9b7e5ba72e1e3b
+  md5: 5bb07bf5e606e697edd7e5e394a759f3
   depends:
-  - libarrow 24.0.0 h5dfeb67_6_cpu
+  - libarrow 24.0.0 h6b18018_8_cpu
   - libgcc >=14
   - libstdcxx >=14
   - libthrift >=0.22.0,<0.22.1.0a0
   - openssl >=3.5.7,<4.0a0
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libparquet >=24.0.0,<24.1.0a0
-  size: 1304474
-  timestamp: 1781580597501
+  size: 1305802
+  timestamp: 1782182985292
 - conda: https://prefix.dev/conda-forge/linux-aarch64/libpciaccess-0.19-he30d5cf_0.conda
   sha256: 5d26d751b7cc4b66e28ed1ae75900956600aaa5c5d874d5a8cf106d3aff834d3
   md5: 462239e256bc180c9c45dd049ba797ee
@@ -35285,18 +35365,17 @@ packages:
     - mbedtls >=3.6.3.1,<3.7.0a0
   size: 943604
   timestamp: 1747806377302
-- conda: https://prefix.dev/conda-forge/linux-aarch64/menuinst-2.5.0-py314h28a4750_0.conda
-  sha256: 1eb9a222f8a5d23d8534917caa76910ad9b33c8c65018c883a835cd3feae12f3
-  md5: 92560f3b28e1b1742f85e7f454180386
+- conda: https://prefix.dev/conda-forge/linux-aarch64/menuinst-2.5.0-py314h064b4d9_1.conda
+  sha256: 350759b81d1f77b4358cbb23eada7a37806ac029c11be678bf3a34749746731b
+  md5: b88e84d3b3a2554bb5245a7e41ff434c
   depends:
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
+  - python
   - tomli-w
+  - python_abi 3.14.* *_cp314
   license: BSD-3-Clause AND MIT
   run_exports: {}
-  size: 196286
-  timestamp: 1780906917179
+  size: 206996
+  timestamp: 1782062693447
 - conda: https://prefix.dev/conda-forge/linux-aarch64/mmh3-5.2.1-py310h57cea71_0.conda
   sha256: 32df6e3916167535a8b92fce03dafad6c874067c2e80a6ae75ead230225ea256
   md5: d414532361e01a62683ecf75677fad5b
@@ -35408,9 +35487,9 @@ packages:
     - mpfr >=4.2.2,<5.0a0
   size: 1933306
   timestamp: 1773413839223
-- conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py310h0992a49_0.conda
-  sha256: 175ba94012d86f457162f15cc2ac6f380a4e77779bae35f6a56532d5917937e9
-  md5: fc606c6a35766f4f30b258ca2bd7889e
+- conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.1-py310h0992a49_0.conda
+  sha256: 2f8a7d023463f80ad593215d48e83936f728ca3f92703b1b9c5f8ed5d7ce7ea6
+  md5: da46a433a60c148cccb67d6cef757e5f
   depends:
   - libgcc >=14
   - libstdcxx >=14
@@ -35420,11 +35499,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 94095
-  timestamp: 1781786146486
-- conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py311hfca10b7_0.conda
-  sha256: 43083c27dceb10546f7db55f44982730fad59a4668b1f3adb55c56803fcdb9ae
-  md5: fbb74be2237430e4c5daa262ab9decaa
+  size: 93717
+  timestamp: 1782070437828
+- conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.1-py311hfca10b7_0.conda
+  sha256: 68e208357617ab01b4e611ae5fe2d416a7d65e2f023f9b51fce7d734bf8c311b
+  md5: c6fb2f9d03b06a5b05b2f4c4d385f93e
   depends:
   - libgcc >=14
   - libstdcxx >=14
@@ -35434,11 +35513,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 100804
-  timestamp: 1781786135730
-- conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py312h4f740d2_0.conda
-  sha256: 2e53c5aa8f19b89c6636245879b132dec61693f5f8208f64315dd883cf0ff345
-  md5: a4d97be25901daf65c851fe05c71c6ae
+  size: 100258
+  timestamp: 1782070428159
+- conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.1-py312h4f740d2_0.conda
+  sha256: 969c34271f6c487ce9347cee49ce15cedd656c2cd56c0c923be951d82c608903
+  md5: c0be51d841515f51257182c1dd6370af
   depends:
   - libgcc >=14
   - libstdcxx >=14
@@ -35448,11 +35527,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 98569
-  timestamp: 1781786128392
-- conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py313he6111f0_0.conda
-  sha256: 67afb6637b786c3c262d40996d6da74f439e2197e9af886e00126582a17d7272
-  md5: 57975870b543fc2b08392d4efba246a3
+  size: 98998
+  timestamp: 1782070558357
+- conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.1-py313he6111f0_0.conda
+  sha256: 7d976f5702ad078abfd6d2f3e266a64f2736f7906f55676fa97a25ce2911a2f3
+  md5: 6c8e30755c2e19db1628581d5587a0a8
   depends:
   - libgcc >=14
   - libstdcxx >=14
@@ -35462,11 +35541,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 99319
-  timestamp: 1781786131060
-- conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py314h1654e16_0.conda
-  sha256: 4d3df60e18937eca128baf0718c96b455ab2cfe338b3a6bf98ba6ba150111ce8
-  md5: 8fd71df362b1576fa424ed4545480ef4
+  size: 100100
+  timestamp: 1782070400774
+- conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.1-py314h1654e16_0.conda
+  sha256: 269e1421c60bb0ffdbbf92633c4553363e8be515cdb46cc3e965392fc1b01ad7
+  md5: 01dffd385ee1120c5b337086168b42b8
   depends:
   - libgcc >=14
   - libstdcxx >=14
@@ -35476,11 +35555,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 103147
-  timestamp: 1781786146648
-- conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.0-py314hd7d8586_0.conda
-  sha256: 37a1be685f2d42f2c4948ccccb1602128ff32ffeb70b32bd05ae16e3c98292da
-  md5: 25f86c29ca9de90e3e217ccd448f3f86
+  size: 103401
+  timestamp: 1782070422623
+- conda: https://prefix.dev/conda-forge/linux-aarch64/msgpack-python-1.2.1-py314hd7d8586_0.conda
+  sha256: 036285b9167b186aa8833d3207ef7fef0e66bafdcea344d70bc79b372336c98f
+  md5: 522861c3cf643b3d49b73ea80bd085c4
   depends:
   - libgcc >=14
   - libstdcxx >=14
@@ -35490,8 +35569,8 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 100240
-  timestamp: 1781786121982
+  size: 100611
+  timestamp: 1782070426564
 - conda: https://prefix.dev/conda-forge/linux-aarch64/multidict-6.7.1-py310h2d8da20_0.conda
   sha256: 56d7e436569e1f9839b13f56c8cca86b2250f6de55974c053ed0032c7bb60fa9
   md5: ac6a85104ecc7d26ffc1680648803b2c
@@ -35967,26 +36046,6 @@ packages:
     - numpy >=1.21,<3
   size: 7070289
   timestamp: 1747545069701
-- conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-2.4.6-py312hce9e0af_0.conda
-  sha256: 4facc6fe76540d7e6e77b802602f7b1b3aa574a5fa6f406e0d21960858f1f539
-  md5: 84ad95777b2f6bc736a6e08e5f02c04e
-  depends:
-  - python
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.12.* *_cp312
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - numpy >=1.23,<3
-  size: 7839794
-  timestamp: 1779169203525
 - conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-2.4.6-py313h839dfd1_0.conda
   sha256: 8ad211ea2021ee1fe9b16ba5883a10a5f2c5d297344a7d924d8e5ec1c576e8e1
   md5: 60c33b31cc1b7c6e5d7b0940849e7f22
@@ -36047,6 +36106,26 @@ packages:
     - numpy >=1.23,<3
   size: 8002900
   timestamp: 1779169206742
+- conda: https://prefix.dev/conda-forge/linux-aarch64/numpy-2.5.0-py312hce9e0af_0.conda
+  sha256: e8861d71fbab336eb8e51d11e67bd0b6bb2960ae9868e35728002be541aae425
+  md5: 3999a1bf4bbe125744ade3be75392321
+  depends:
+  - python
+  - libstdcxx >=14
+  - libgcc >=14
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - numpy >=1.25,<3
+  size: 7995988
+  timestamp: 1782112547039
 - conda: https://prefix.dev/conda-forge/linux-aarch64/openjdk-21.0.10-h488f50d_0.conda
   sha256: 7e124f56dd7ea1bec019ad3a990f61a67704588f95b3c177ff7c482d61f93d4c
   md5: 4583a5e8959f654c9b9d1174078ca246
@@ -36112,9 +36191,9 @@ packages:
     - openjph >=0.27.4,<0.28.0a0
   size: 231064
   timestamp: 1780596799608
-- conda: https://prefix.dev/conda-forge/linux-aarch64/openjph-0.29.0-h55827e0_0.conda
-  sha256: b2198f7c42529857af611eef2f9fa29c2f6c27a251c7bd7653ac2741d910dd03
-  md5: 9188c79c723e03e0145a1cc28c15fb95
+- conda: https://prefix.dev/conda-forge/linux-aarch64/openjph-0.30.1-h55827e0_0.conda
+  sha256: 12f6ac15e3bd4de872a28f096817c6c66bd9a058e7d684ee1e57aff118004d42
+  md5: 6d8f94ef9f90c0b202d31043a9aab1a8
   depends:
   - libstdcxx >=14
   - libgcc >=14
@@ -36123,9 +36202,9 @@ packages:
   license_family: BSD
   run_exports:
     weak:
-    - openjph >=0.29.0,<0.30.0a0
-  size: 235606
-  timestamp: 1781694304142
+    - openjph >=0.30.1,<0.31.0a0
+  size: 238874
+  timestamp: 1782091147195
 - conda: https://prefix.dev/conda-forge/linux-aarch64/openldap-2.6.10-h30c48ee_0.conda
   sha256: 13c7ba058b6e151468111235218158083b9e867738e66a5afb96096c5c123348
   md5: 48f31a61be512ec1929f4b4a9cedf4bd
@@ -36961,10 +37040,10 @@ packages:
   run_exports: {}
   size: 11908262
   timestamp: 1781020732931
-- conda: https://prefix.dev/conda-forge/linux-aarch64/py-rattler-build-0.66.1-py310h160093b_0.conda
+- conda: https://prefix.dev/conda-forge/linux-aarch64/py-rattler-build-0.67.0-py310h160093b_0.conda
   noarch: python
-  sha256: 5771b0a2fc889a946699a0ccbf15693abb48d8df76403f902a3df0f45ebc6fa8
-  md5: 082f170dde834bfec2d1d35c3bab4e45
+  sha256: 383060e3f7efcb3c473e7b647b579a7c3474ef8902bd1fd83333ff49db8a2c40
+  md5: 8a76c5e55b193a9fc67e119495761991
   depends:
   - python
   - libgcc >=14
@@ -36974,10 +37053,9 @@ packages:
   constrains:
   - __glibc >=2.17
   license: BSD-3-Clause
-  license_family: BSD
   run_exports: {}
-  size: 17792750
-  timestamp: 1781383673568
+  size: 17000964
+  timestamp: 1782144026990
 - conda: https://prefix.dev/conda-forge/linux-aarch64/pyarrow-16.0.0-py310h70ff3ff_0.conda
   sha256: e6b73e3cdc40acdf3fd71ec934d024b929e3a26cc8896d16b391d24507af0a49
   md5: a2af4d2f06edce06e62ebaecdfa82f70
@@ -38235,9 +38313,9 @@ packages:
     - qt6-main >=6.9.2,<6.10.0a0
   size: 54448718
   timestamp: 1758012048836
-- conda: https://prefix.dev/conda-forge/linux-aarch64/rattler-build-0.66.2-h1d7f6d8_0.conda
-  sha256: fcfcb7c8c15ed4c76fee6593da372b5550147fa41f209cd8c3d65d5eb1d6cfff
-  md5: 72ffc57ae0eb80bac066afb215a473e0
+- conda: https://prefix.dev/conda-forge/linux-aarch64/rattler-build-0.67.0-h1d7f6d8_0.conda
+  sha256: 47050f8918be509dd44f191368cfebdaec92b66c65a73245d75b150dfcf0810a
+  md5: d3cef40eb6714caa4688143870aa13c4
   depends:
   - patchelf
   - libstdcxx >=14
@@ -38246,10 +38324,9 @@ packages:
   constrains:
   - __glibc >=2.17
   license: BSD-3-Clause
-  license_family: BSD
   run_exports: {}
-  size: 18576328
-  timestamp: 1781721862240
+  size: 18697949
+  timestamp: 1782150880080
 - conda: https://prefix.dev/conda-forge/linux-aarch64/rav1e-0.8.1-h9d4cc37_0.conda
   sha256: b54b0e66d264ce5904862012f08eda155ecfc6520f66a321f9363682fef94c59
   md5: a3c060f1a410865150bb1d59cddf6d7c
@@ -38938,9 +39015,9 @@ packages:
   run_exports: {}
   size: 16831564
   timestamp: 1779874514705
-- conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.17.1-py312ha7f05e0_1.conda
-  sha256: faad223a5a3318687308cd1ae235ad5aee4de2d090cbc2280b3281e506279249
-  md5: 60bbefd5c712570fec2b52275f641192
+- conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.18.0-py312ha7f05e0_0.conda
+  sha256: 79343875bcc5cce28a54001844b221395b883a3d28fd8d9125dd38a4afab825b
+  md5: c957cde07f79a2cf5c7e9cdab39fa90b
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
@@ -38951,17 +39028,17 @@ packages:
   - libstdcxx >=14
   - numpy <2.7
   - numpy >=1.23,<3
-  - numpy >=1.25.2
+  - numpy >=2.0.0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 16878451
-  timestamp: 1779874509446
-- conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.17.1-py313h6b7a087_1.conda
-  sha256: 5a4f5bd13677a9f4c5733a385d811e918acd832ba0a8871d4281e2cb7a22ed11
-  md5: 1420dedc221a2e63a93f13da3b873241
+  size: 17170333
+  timestamp: 1781912658149
+- conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.18.0-py313h6b7a087_0.conda
+  sha256: cbd8a6654b1d751692a840ab0c47d7e26c2d693f61c7ad20f45efe788d986367
+  md5: a8c520f9306c885edada86bccf712b70
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
@@ -38972,17 +39049,17 @@ packages:
   - libstdcxx >=14
   - numpy <2.7
   - numpy >=1.23,<3
-  - numpy >=1.25.2
+  - numpy >=2.0.0
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 16780720
-  timestamp: 1779874513404
-- conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.17.1-py314h052a9b3_1.conda
-  sha256: bdf16e3e4b78286fd401f6fb0b6825ffcddc1c090e110ec97d5f6ff221523303
-  md5: d697e42de4a29b91e1e80bf0923d46ce
+  size: 17157159
+  timestamp: 1781912672622
+- conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.18.0-py314h052a9b3_0.conda
+  sha256: 401d63fc4d1b1d942b9cae09abac6cf2c65a121f2adc6d50096b5576e263af0c
+  md5: 3aad2b7b36cdd59c7ac05d4da908401f
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
@@ -38993,17 +39070,17 @@ packages:
   - libstdcxx >=14
   - numpy <2.7
   - numpy >=1.23,<3
-  - numpy >=1.25.2
+  - numpy >=2.0.0
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 17072101
-  timestamp: 1779874523382
-- conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.17.1-py314h34f1ec5_1.conda
-  sha256: 3454033be1eebc49e0c1c8f515eb8187ffeccdf287eb2e37b8c43b9202271cad
-  md5: a095fb0c14f275ae30894548fd8414d0
+  size: 17107935
+  timestamp: 1781912692906
+- conda: https://prefix.dev/conda-forge/linux-aarch64/scipy-1.18.0-py314h34f1ec5_0.conda
+  sha256: 8361b3555d8ad4f80d4ec5dba855e9810d2083fd8b61edabcc440b45dd59b7fd
+  md5: e8cceaf40b6ed06f8c9cf85c2af534e9
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
@@ -39014,14 +39091,14 @@ packages:
   - libstdcxx >=14
   - numpy <2.7
   - numpy >=1.23,<3
-  - numpy >=1.25.2
+  - numpy >=2.0.0
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314t
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 16964762
-  timestamp: 1779874543021
+  size: 17251547
+  timestamp: 1781912674234
 - conda: https://prefix.dev/conda-forge/linux-aarch64/secretstorage-3.5.0-py314ha42fa4b_0.conda
   sha256: da425d987a22959e824b531c9594ff20294de9195d0e1f19257dc0ab458b38bd
   md5: 6c909bd001b375ece69317bbd630f1fd
@@ -39207,11 +39284,11 @@ packages:
     - tiledb >=2.26.2,<2.27.0a0
   size: 4186259
   timestamp: 1732208474954
-- conda: https://prefix.dev/conda-forge/linux-aarch64/tiledb-2.30.1-ha20e67a_12.conda
-  sha256: a5085308120a6b4a75cc51085de7863f5b4b98698b47c13a900a9c5b767abef8
-  md5: 29c5907c64675aed639938243ba5e830
+- conda: https://prefix.dev/conda-forge/linux-aarch64/tiledb-2.30.1-h4e56350_13.conda
+  sha256: 05e443abcfac8d233c5ca8eb9a230a453f5bc47117a21194819b61c21a701bfb
+  md5: c25a72e29b96a281472973ecbf8cd92d
   depends:
-  - aws-crt-cpp >=0.40.0,<0.40.1.0a0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
   - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
   - azure-core-cpp >=1.16.3,<1.16.4.0a0
   - azure-identity-cpp >=1.13.3,<1.13.4.0a0
@@ -39219,7 +39296,7 @@ packages:
   - azure-storage-common-cpp >=12.14.0,<12.14.1.0a0
   - azure-storage-files-datalake-cpp >=12.16.0,<12.16.1.0a0
   - bzip2 >=1.0.8,<2.0a0
-  - c-blosc2 >=3.1.3,<3.2.0a0
+  - c-blosc2 >=3.1.4,<3.2.0a0
   - capnproto >=1.4.0,<1.4.1.0a0
   - fmt >=12.1.0,<12.2.0a0
   - libabseil * cxx17*
@@ -39240,8 +39317,8 @@ packages:
   run_exports:
     weak:
     - tiledb >=2.30.1,<2.31.0a0
-  size: 4175238
-  timestamp: 1781620075210
+  size: 4178147
+  timestamp: 1781892211177
 - conda: https://prefix.dev/conda-forge/linux-aarch64/tiledb-2.30.1-hea54fe8_6.conda
   sha256: feeed06a64a79d0ab97111c324c7aecd883ee0acfbd59c8ac4a63c67a2f2af67
   md5: 6a4d506575a80366dc725c4f295878f0
@@ -39486,9 +39563,9 @@ packages:
   run_exports: {}
   size: 410032
   timestamp: 1770909146009
-- conda: https://prefix.dev/conda-forge/linux-aarch64/uv-0.11.22-haa595b2_0.conda
-  sha256: 40233ca16f23b6003be9b8b1c2184ee21bd0dd806f7a1428cbf2964a644028e6
-  md5: e259e64c71415c61fd1d093f80147e53
+- conda: https://prefix.dev/conda-forge/linux-aarch64/uv-0.11.23-haa595b2_0.conda
+  sha256: 4d959bbe55abe9182f22abc889d62239f2ed73ceb7094cb36b5aa87a083668f5
+  md5: f771344eac8726e05a743869584d4b80
   depends:
   - libstdcxx >=14
   - libgcc >=14
@@ -39496,8 +39573,8 @@ packages:
   - __glibc >=2.17
   license: Apache-2.0 OR MIT
   run_exports: {}
-  size: 19081723
-  timestamp: 1781836302730
+  size: 19082779
+  timestamp: 1781912273909
 - conda: https://prefix.dev/conda-forge/linux-aarch64/wayland-1.25.0-h4f8a99f_0.conda
   sha256: 3cc479df517b0ce110835a1256f91ca568581cb6dfe1c53a0786f0a226039a45
   md5: 0a7a9548726f98d5869fd4c43e110f0f
@@ -39513,45 +39590,6 @@ packages:
     - wayland >=1.25.0,<2.0a0
   size: 335260
   timestamp: 1773959583826
-- conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.1-py310h5b55623_0.conda
-  sha256: 0841c62e642ca56945034ef27a19c65913faf161d1c4b79432b5c5d4e7a5f38c
-  md5: 22d80e0560ec555f15828eaf99e2bf57
-  depends:
-  - libgcc >=14
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  license: BSD-2-Clause
-  license_family: BSD
-  run_exports: {}
-  size: 102187
-  timestamp: 1779477504335
-- conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.1-py311h19352d5_0.conda
-  sha256: 93a5035c103f405fa17285e25b79c541c93b14017acc7fa4a2e56a494293c661
-  md5: dcb296a6672ff11d3efee3f00038c255
-  depends:
-  - libgcc >=14
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  license: BSD-2-Clause
-  license_family: BSD
-  run_exports: {}
-  size: 118292
-  timestamp: 1779477500493
-- conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.1-py312hcd1a082_0.conda
-  sha256: 4a2a23309047c6a45131d106316c19bfb4e50ec36e8453c5f674b154197de9b5
-  md5: e43ff6a1d7def0b1bb077a02f610cc04
-  depends:
-  - libgcc >=14
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: BSD-2-Clause
-  license_family: BSD
-  run_exports: {}
-  size: 115121
-  timestamp: 1779477494775
 - conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.1-py313h6194ac5_0.conda
   sha256: 276b0be16df2347a2eb6d66b11a4b89b22d8a3c825a7a06a51a92cc1eef5a145
   md5: e0a136f4200f48f1ea73e4b0c89359e3
@@ -39565,32 +39603,66 @@ packages:
   run_exports: {}
   size: 116483
   timestamp: 1779477492175
-- conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.1-py314h2e6e5c7_0.conda
-  sha256: 60e5b5dedc792e77349cb47b2aedbe2fdbd6427f1d65201de6a8cd81965a9ac0
-  md5: 44b5c872bb509bec93daaed877030d96
+- conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.2-py310h5b55623_0.conda
+  sha256: a30b48d672afa1eccd7ff17b0baff2b972b81b79780d5a82fb76571ce4d82319
+  md5: 6127cede591c74620b222baadeef5d39
+  depends:
+  - libgcc >=14
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  license: BSD-2-Clause
+  run_exports: {}
+  size: 103352
+  timestamp: 1782133698409
+- conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.2-py311h19352d5_0.conda
+  sha256: f67e6986fc702afd0e78a5077f1de45e1923aa77ded504a402a46a39e2cdd2ad
+  md5: 23816ab8eab41d7785230adce6311e3c
+  depends:
+  - libgcc >=14
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  run_exports: {}
+  size: 118699
+  timestamp: 1782133710798
+- conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.2-py312hcd1a082_0.conda
+  sha256: 920a81cd9444293a78fe6e9479bacf8fbf672fc6f5268c7237ba4335376f275e
+  md5: e2b2d650e49db3cafe5d9e7da964e167
+  depends:
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-2-Clause
+  run_exports: {}
+  size: 115536
+  timestamp: 1782133697736
+- conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.2-py314h2e6e5c7_0.conda
+  sha256: 15a08bfdfcb399c6cec5a51c87552582b3b0ff01343676c1851cb3bac47db787
+  md5: 01cd6d32ba19c4ebd8563ac3fc4ce6f0
   depends:
   - libgcc >=14
   - python >=3.14,<3.15.0a0
   - python >=3.14,<3.15.0a0 *_cp314t
   - python_abi 3.14.* *_cp314t
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 121085
-  timestamp: 1779477504477
-- conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.1-py314h51f160d_0.conda
-  sha256: 4658b698192ac881d088a112ec46ad6ff5dfedd1e523e1964a55b93a90c6f9b8
-  md5: 1d5825e4dc347eb29a89e440b8a2f7ca
+  size: 121010
+  timestamp: 1782133717847
+- conda: https://prefix.dev/conda-forge/linux-aarch64/wrapt-2.2.2-py314h51f160d_0.conda
+  sha256: 9b17ad8c0b74930af2285636857456882ea2fc912163d0465dc3b0f76b477feb
+  md5: bf43644f5d4f777755c046de12e50baa
   depends:
   - libgcc >=14
   - python >=3.14,<3.15.0a0
   - python >=3.14,<3.15.0a0 *_cp314
   - python_abi 3.14.* *_cp314
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 117890
-  timestamp: 1779477497705
+  size: 118650
+  timestamp: 1782133688881
 - conda: https://prefix.dev/conda-forge/linux-aarch64/xcb-util-0.4.1-hca56bd8_2.conda
   sha256: d874906e236a5edc9309d479599bf2de4d8adca0f23c355b76759d5fb3c4bef8
   md5: 159ffec8f7fab775669a538f0b29373a
@@ -39673,17 +39745,17 @@ packages:
     - xcb-util-wm >=0.4.2,<0.5.0a0
   size: 50772
   timestamp: 1718845072660
-- conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.47-h80f16a2_1.conda
-  sha256: 70070c1bd0c8f6af2640fa6302c06c29ad5740c80e290a6b287c8a6498290207
-  md5: 81ae02fc22dcd8d56dc197851c95e2f8
+- conda: https://prefix.dev/conda-forge/linux-aarch64/xkeyboard-config-2.48-h80f16a2_0.conda
+  sha256: 96078068df25ddccc60958be740e6fa99efb1e0fa2dae2f84e775201bf84d70c
+  md5: 3dbc6d9e1f8a8768e7ef9f57585a43ca
   depends:
   - libgcc >=14
   - xorg-libx11 >=1.8.13,<2.0a0
   license: MIT
   license_family: MIT
   run_exports: {}
-  size: 441739
-  timestamp: 1781482715632
+  size: 442725
+  timestamp: 1782027381059
 - conda: https://prefix.dev/conda-forge/linux-aarch64/xorg-libice-1.1.2-h86ecc28_0.conda
   sha256: a2ba1864403c7eb4194dacbfe2777acf3d596feae43aada8d1b478617ce45031
   md5: c8d8ec3e00cd0fd8a231789b91a7c5b7
@@ -40675,16 +40747,16 @@ packages:
   run_exports: {}
   size: 4526315
   timestamp: 1781002115296
-- conda: https://prefix.dev/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
-  sha256: ea5f4c876eff2ed469551b57f1cc889a3c01128bf3e2e10b1fea11c3ef39eac2
-  md5: c7eb87af73750d6fd97eff8bbee8cb9c
+- conda: https://prefix.dev/conda-forge/noarch/boltons-26.0.0-pyhd8ed1ab_0.conda
+  sha256: d3c8be0524a5223bfed89c4a5be90598bfca28e0c702014f7799b978027eb5e1
+  md5: 06c2cbdcfd20af2f72a95e09f8747c52
   depends:
-  - python >=3.9
+  - python >=3.10
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 302296
-  timestamp: 1749686302834
+  size: 307488
+  timestamp: 1781879511321
 - conda: https://prefix.dev/conda-forge/noarch/boto3-1.43.0-pyhd8ed1ab_0.conda
   sha256: 17f739967f206da6a23ab73f740f17e83f5125fea6c212d5542b23a606efd0ba
   md5: c0587e9421bbe4660b9483a101895ef7
@@ -40929,6 +41001,8 @@ packages:
   - python >=3.9
   license: BSD-3-Clause
   license_family: BSD
+  purls:
+  - pkg:pypi/colorama?source=hash-mapping
   run_exports: {}
   size: 27011
   timestamp: 1733218222191
@@ -41153,19 +41227,18 @@ packages:
   run_exports: {}
   size: 22216
   timestamp: 1778152874928
-- conda: https://prefix.dev/conda-forge/noarch/coverage-7.14.1-pyh7db6752_0.conda
-  sha256: cab663d2ccdc1a795fb04d2a550168f22211ee6544d9eb581862ed97fa606c0f
-  md5: f740a050738d48172b3f4c878ae16ba2
+- conda: https://prefix.dev/conda-forge/noarch/coverage-7.14.3-pyh7db6752_0.conda
+  sha256: 89476d961b6a1a07fb1c75049c67c28e83b80e017666ab283ffab9c41d440838
+  md5: ad9f1683d1c5df55b3febffc03074018
   depends:
   - python >=3.10
   - tomli
   track_features:
   - coverage_no_compile
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 167594
-  timestamp: 1779837904259
+  size: 171647
+  timestamp: 1782178072825
 - conda: https://prefix.dev/conda-forge/noarch/cpython-3.10.20-py310hd8ed1ab_1.conda
   noarch: generic
   sha256: 705917252b4cdfca93d8df09d40dc9b08074ecbd23b0ca23eb74bca8d1629599
@@ -43317,9 +43390,9 @@ packages:
   run_exports: {}
   size: 346511
   timestamp: 1778103405862
-- conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.1-pyhcf101f3_0.conda
-  sha256: a4ad48b01e5e2640561011d8d48ac038fec66670f24e22c370097747bd9200d2
-  md5: 3b05fc4bb3e31efd3498136b3221c18f
+- conda: https://prefix.dev/conda-forge/noarch/pydantic-settings-2.14.2-pyhcf101f3_0.conda
+  sha256: de1eb2cdb22a678387ec7757f10b7815c4c2a4d62f23b2a70fe4beff7e8a1fd4
+  md5: a1c5305893d9956abd2079d377c5113f
   depends:
   - typing-inspection >=0.4.0
   - python >=3.10
@@ -43329,8 +43402,8 @@ packages:
   license: MIT
   license_family: MIT
   run_exports: {}
-  size: 52280
-  timestamp: 1778254612174
+  size: 52920
+  timestamp: 1781884990751
 - conda: https://prefix.dev/conda-forge/noarch/pydot-4.0.1-pyhcf101f3_2.conda
   sha256: af7213a8ca077895e7e10c8f33d5de3436b8a26828422e8a113cc59c9277a3e2
   md5: 15f6d0866b0997c5302fc230a566bc72
@@ -43461,10 +43534,11 @@ packages:
   run_exports: {}
   size: 294852
   timestamp: 1762354779909
-- conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.0-pyhc364b38_1.conda
-  sha256: 2acb99bdf01f8b6c9d5758850df35bf272844c6d4fbc4f6f3865d7a0c172c62e
-  md5: 244fd1dfaeef8291dfafdef694abc133
+- conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
+  sha256: 430051d80765207a7d782b2b188230ba1489d35c6e75fd9903f76cb9fda4af16
+  md5: 64c98a12c4e23eb238bf66bbecafdf3c
   depends:
+  - colorama
   - pygments >=2.7.2
   - python >=3.10
   - iniconfig >=1.0.1
@@ -43480,8 +43554,8 @@ packages:
   purls:
   - pkg:pypi/pytest?source=compressed-mapping
   run_exports: {}
-  size: 306619
-  timestamp: 1781699581695
+  size: 306724
+  timestamp: 1782127176429
 - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
   sha256: 44e42919397bd00bfaa47358a6ca93d4c21493a8c18600176212ec21a8d25ca5
   md5: 67d1790eefa81ed305b89d8e314c7923
@@ -44652,19 +44726,19 @@ packages:
   run_exports: {}
   size: 103560
   timestamp: 1778188657149
-- conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
-  sha256: 8dbe1085b6dbc0beaaa45514a983bc91c2c306079a257c936566b727f5e82fb8
-  md5: d3874a78e238013db5106c8e31f1ae58
+- conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-2.1.0-pyhd8ed1ab_0.conda
+  sha256: ff6c66d598e6f155a0b2b4e0f973f2a6af96a785073b323ee4fed157b1d4b1eb
+  md5: fd6b105efdadb43ec24e5fc5c0dc1d8f
   depends:
   - packaging >=20
+  - pytest
   - python >=3.10
   - tomli >=1
   - typing_extensions
   license: MIT
-  license_family: MIT
   run_exports: {}
-  size: 63943
-  timestamp: 1776865877973
+  size: 79857
+  timestamp: 1782207616320
 - conda: https://prefix.dev/conda-forge/noarch/virtualenv-21.5.1-pyhcf101f3_0.conda
   sha256: 0a7b0a2ada7ad719f9d4f8874eb10911e1fcfdecefc86456105eb806ebd60ac4
   md5: e449fb99b714be1e13fa5564dacd1af5
@@ -45128,23 +45202,23 @@ packages:
     - aws-c-auth >=0.10.1,<0.10.2.0a0
   size: 116820
   timestamp: 1774275057443
-- conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.3-hceed5df_2.conda
-  sha256: b4689664156e8067ba1aa97125f2a309a96b2bc0d1c608f4a88f30ea1f4c9aba
-  md5: e7501df14d3145fc86943ebfeb76a402
+- conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.10.3-hc11c9a1_3.conda
+  sha256: 623c4f69ce1e2eac92c209ef0e16e5f9ab8832232a749e3a272e11f1f46191c6
+  md5: 1fc365a60432d78b729d1468fce1b6c9
   depends:
   - __osx >=11.0
-  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
   - aws-c-http >=0.11.0,<0.11.1.0a0
   - aws-c-common >=0.14.0,<0.14.1.0a0
-  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
   - aws-c-cal >=0.9.14,<0.9.15.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
     - aws-c-auth >=0.10.3,<0.10.4.0a0
-  size: 116718
-  timestamp: 1780598398659
+  size: 116705
+  timestamp: 1781803055465
 - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-auth-0.7.20-h5cf208e_0.conda
   sha256: ca095f3d6678d3073b912722a53ac4489f2e78e79e7075731464b7be4210d458
   md5: 8b6134a6e4ab346a4f7c3aaeb90073c8
@@ -45561,21 +45635,21 @@ packages:
     - aws-c-mqtt >=0.15.2,<0.15.3.0a0
   size: 156423
   timestamp: 1774275623505
-- conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-mqtt-0.15.2-ha70999f_4.conda
-  sha256: ab15db26173d775b92503808bd4c29bfca484d5feb6b639793f8adba3004c56e
-  md5: 24f47ec268da87f530058df459de3dad
+- conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-mqtt-0.16.0-ha70999f_0.conda
+  sha256: 311a2051eb2e48664229a9b10886013c4c059aef602b70909ac1bc8d2000fc6d
+  md5: 23ef6506ce17c3ed79db869898f99598
   depends:
   - __osx >=11.0
-  - aws-c-io >=0.26.3,<0.26.4.0a0
   - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
   - aws-c-http >=0.11.0,<0.11.1.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
-    - aws-c-mqtt >=0.15.2,<0.15.3.0a0
-  size: 156284
-  timestamp: 1780599082085
+    - aws-c-mqtt >=0.16.0,<0.16.1.0a0
+  size: 158010
+  timestamp: 1780681916713
 - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.11.5-ha5d16b2_5.conda
   sha256: bd8f4ffb8346dd02bda2bc1ae9993ebdb131298b1308cb9e6b1e771b530d9dd5
   md5: f33735fd60f9c4a21c51a0283eb8afc1
@@ -45594,24 +45668,24 @@ packages:
     - aws-c-s3 >=0.11.5,<0.11.6.0a0
   size: 129783
   timestamp: 1774282252139
-- conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.12.5-h43def2a_1.conda
-  sha256: 0a99b506bbe21f00f21047db50b2eea2ff8a0b1146ff0fba7d04b39a568453f4
-  md5: 7dc63973f9fe772985b8c2f8ba5958ce
+- conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.12.6-h43def2a_0.conda
+  sha256: 258678f29912d503e4301814f411b29bb2324f6a0131a06a385f2280b4916eeb
+  md5: 912c61c44a2782693d63af2272551455
   depends:
   - __osx >=11.0
   - aws-c-common >=0.14.0,<0.14.1.0a0
-  - aws-checksums >=0.2.10,<0.2.11.0a0
-  - aws-c-io >=0.26.3,<0.26.4.0a0
-  - aws-c-auth >=0.10.3,<0.10.4.0a0
   - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-checksums >=0.2.10,<0.2.11.0a0
+  - aws-c-auth >=0.10.3,<0.10.4.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
   - aws-c-http >=0.11.0,<0.11.1.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
-    - aws-c-s3 >=0.12.5,<0.12.6.0a0
-  size: 132141
-  timestamp: 1780609600116
+    - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  size: 132571
+  timestamp: 1781253082057
 - conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-s3-0.5.9-he1e208d_0.conda
   sha256: c5f113e37c670982abc0a6e1b000186e4c94a6838d2a283dce6726ca92a882d0
   md5: 64f5167f45ce390443e4e80ff37671c6
@@ -45687,9 +45761,9 @@ packages:
     - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
   size: 53430
   timestamp: 1764755714246
-- conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.4-h61d3404_6.conda
-  sha256: ef53cd1e30bc8c865c44df6f097f36361945665157e63957d68fe90aa7e4d66c
-  md5: 127bce41f9e6cc3bdb9e6daed95896d9
+- conda: https://prefix.dev/conda-forge/osx-arm64/aws-c-sdkutils-0.2.5-h61d3404_0.conda
+  sha256: f47cd32244c77d12bfbf9ae1eecf6672d776f9df8f5357c365fd8254e3d2acb9
+  md5: 4a91f77674daaa9e0a6bbcf9a45d23fd
   depends:
   - __osx >=11.0
   - aws-c-common >=0.14.0,<0.14.1.0a0
@@ -45697,9 +45771,9 @@ packages:
   license_family: APACHE
   run_exports:
     weak:
-    - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
-  size: 53659
-  timestamp: 1780568618924
+    - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  size: 58773
+  timestamp: 1781798801665
 - conda: https://prefix.dev/conda-forge/osx-arm64/aws-checksums-0.1.18-h35c0bb2_4.conda
   sha256: 3b7320a5b17d3d7dcf816e60f19122635219c4e1be4dd53cf9ae454b9ed2422d
   md5: f0177671ec47f34998666eeb7cd227f9
@@ -45818,28 +45892,28 @@ packages:
     - aws-crt-cpp >=0.37.4,<0.37.5.0a0
   size: 269460
   timestamp: 1774286981607
-- conda: https://prefix.dev/conda-forge/osx-arm64/aws-crt-cpp-0.40.0-hd6eb0f7_1.conda
-  sha256: 258cea4855f3d289dce09ab197bf2abfb5e983fefce371e4d100ec1a8d015277
-  md5: 522e7961ac3402ab3814d9759f7c54de
+- conda: https://prefix.dev/conda-forge/osx-arm64/aws-crt-cpp-0.40.1-hb87031f_1.conda
+  sha256: 6d2b0bf67403c53f6954b7602e529cac91b1d156b22f71db5d97bf9ebc269790
+  md5: 602dd44df5dd28061de3ee798e991b42
   depends:
-  - __osx >=11.0
   - libcxx >=19
-  - aws-c-event-stream >=0.7.1,<0.7.2.0a0
-  - aws-c-auth >=0.10.3,<0.10.4.0a0
-  - aws-c-cal >=0.9.14,<0.9.15.0a0
-  - aws-c-s3 >=0.12.5,<0.12.6.0a0
-  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
-  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - __osx >=11.0
+  - aws-c-s3 >=0.12.6,<0.12.7.0a0
   - aws-c-http >=0.11.0,<0.11.1.0a0
-  - aws-c-mqtt >=0.15.2,<0.15.3.0a0
+  - aws-c-mqtt >=0.16.0,<0.16.1.0a0
+  - aws-c-auth >=0.10.3,<0.10.4.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-event-stream >=0.7.1,<0.7.2.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
   - aws-c-common >=0.14.0,<0.14.1.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
-    - aws-crt-cpp >=0.40.0,<0.40.1.0a0
-  size: 275283
-  timestamp: 1780917960902
+    - aws-crt-cpp >=0.40.1,<0.40.2.0a0
+  size: 275202
+  timestamp: 1781814158495
 - conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.267-h108e708_8.conda
   sha256: 7e7c6d017b86287e4d645209a094860559188e59aba1cbe31965348aeb5be921
   md5: bd77e7719bc124f92dab0f8c6c682215
@@ -45880,24 +45954,24 @@ packages:
     - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
   size: 2737395
   timestamp: 1732184718613
-- conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h55dad5a_6.conda
-  sha256: 9fa8fcc0da0b26269e488f8db252d416062671b55fbb57bc81c049343567ac37
-  md5: 391aa9618724ce3a08901de5ae43c447
+- conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-h4e95165_7.conda
+  sha256: 48a47f63331523fdf56502ae2c820c56b9d83b576c71c980372825d179b5db65
+  md5: 28a22c86c0819985c291dbde9dbe548a
   depends:
   - libcxx >=19
   - __osx >=11.0
-  - libcurl >=8.20.0,<9.0a0
-  - aws-c-event-stream >=0.7.1,<0.7.2.0a0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
   - aws-c-common >=0.14.0,<0.14.1.0a0
   - libzlib >=1.3.2,<2.0a0
-  - aws-crt-cpp >=0.40.0,<0.40.1.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - aws-c-event-stream >=0.7.1,<0.7.2.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
     - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
-  size: 3261009
-  timestamp: 1781003677069
+  size: 3261003
+  timestamp: 1781874466880
 - conda: https://prefix.dev/conda-forge/osx-arm64/aws-sdk-cpp-1.11.747-had22720_3.conda
   sha256: b5ce4fafe17ab58980f944b9a45504ce45dda0423064591d51240eb8308589af
   md5: 157ae2a6008d62f61107f5b78dce06d2
@@ -47029,9 +47103,9 @@ packages:
   run_exports: {}
   size: 290405
   timestamp: 1769156069514
-- conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py310hb46c203_0.conda
-  sha256: 4d23bba633067b9eb5a6c3b27a536292c50afe96028520c50699fa247b0af3bd
-  md5: f4c432059a9776f1de567c8a726c8bae
+- conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py310hb46c203_0.conda
+  sha256: 84955228de7326b188fcfb0a9465c0af10b2da304cbe6c233c2a032b475537c8
+  md5: 7ea8141e34515df14cee891b551d799a
   depends:
   - __osx >=11.0
   - python >=3.10,<3.11.0a0
@@ -47039,13 +47113,12 @@ packages:
   - python_abi 3.10.* *_cp310
   - tomli
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 313126
-  timestamp: 1779838381806
-- conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py311hc290fe0_0.conda
-  sha256: d9475f473084602003da38e373604b48b674b5fbd5939eb6f26b757cbda89f28
-  md5: 2e3107762a2b8bb31093fe14bab1fe17
+  size: 317808
+  timestamp: 1782178475278
+- conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py311hc290fe0_0.conda
+  sha256: 27306b6a944eae0565fb7d4483b7de287f739b1e8f11363e4b259b4b54b02d32
+  md5: 3d7e96733f48d9623ab9cef29c45e7c0
   depends:
   - __osx >=11.0
   - python >=3.11,<3.12.0a0
@@ -47053,13 +47126,12 @@ packages:
   - python_abi 3.11.* *_cp311
   - tomli
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 397978
-  timestamp: 1779838426505
-- conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py312h04c11ed_0.conda
-  sha256: 62f7590a0e6456ff8f534c3f6213e4ec50443d3409fa3babfa30a38822a2b0fa
-  md5: 86b295185747ca5b09e95d7d33280382
+  size: 403734
+  timestamp: 1782178661341
+- conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py312h04c11ed_0.conda
+  sha256: c2d645a0f6628f67e022ef01056a2d2edeec87349d8f660b12e9de32a22d813d
+  md5: 87f48959c9e5ac6816f1a9d6291a15dd
   depends:
   - __osx >=11.0
   - python >=3.12,<3.13.0a0
@@ -47067,13 +47139,12 @@ packages:
   - python_abi 3.12.* *_cp312
   - tomli
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 388500
-  timestamp: 1779838256904
-- conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py313h65a2061_0.conda
-  sha256: 46d98e0d517ecf6bff6160b2200a27f88da681786d4eb223cd5949d73a0b7610
-  md5: e3f15d7b559de10dd9f60bd345efcdaa
+  size: 393891
+  timestamp: 1782178650048
+- conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py313h65a2061_0.conda
+  sha256: d2730d071b5c0f1a000b04f513b6d2d949684a500d569ce9bf7ed5ffab5596e0
+  md5: b087cd0441275628d2f3d59744f86316
   depends:
   - __osx >=11.0
   - python >=3.13,<3.14.0a0
@@ -47081,13 +47152,12 @@ packages:
   - python_abi 3.13.* *_cp313
   - tomli
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 396380
-  timestamp: 1779838267496
-- conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.1-py314h6e9b3f0_0.conda
-  sha256: b2c5285cf2610bf98d0df3c1474beb2e706d2d75b2ae4b1cd7f7f22ef6932c3a
-  md5: 75074919bec101f674e64b0c00a8aa7c
+  size: 401430
+  timestamp: 1782178606926
+- conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.14.3-py314h6e9b3f0_0.conda
+  sha256: 8de3938e100bbbd775d3b0c6d121c29e7aa2cd0024a9b5ee8023706c0b8f28e6
+  md5: cb60422148fa8d70cbb6fc290e79e21c
   depends:
   - __osx >=11.0
   - python >=3.14,<3.15.0a0
@@ -47095,12 +47165,11 @@ packages:
   - python_abi 3.14.* *_cp314
   - tomli
   license: Apache-2.0
-  license_family: APACHE
   purls:
   - pkg:pypi/coverage?source=hash-mapping
   run_exports: {}
-  size: 412237
-  timestamp: 1779838737834
+  size: 417888
+  timestamp: 1782178502982
 - conda: https://prefix.dev/conda-forge/osx-arm64/cpp-expected-1.3.1-h4f10f1e_0.conda
   sha256: a7380056125a29ddc4c4efc4e39670bc8002609c70f143d92df801b42e0b486f
   md5: 5cb4f9b93055faf7b6ae76da6123f927
@@ -48338,31 +48407,31 @@ packages:
     - hdf5 >=1.14.4,<1.14.5.0a0
   size: 3485821
   timestamp: 1733002735281
-- conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_h9bfbf6c_107.conda
-  sha256: 67e9ef0dfd22a37ff51d0b19aa35e9f7da21739a624976bcac1f72ab1698e8f8
-  md5: fb804a23360d2b40c4f9d15a8bf0b869
+- conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hb7e0c14_108.conda
+  sha256: 8f37c0185801b81a50e4e1430501ddd1c9bfe5e6a5e4ea3c61464e0f1d9199aa
+  md5: 5cc8ba7775f6694349b7a71837bbad90
   depends:
   - __osx >=11.0
   - aws-c-auth >=0.10.3,<0.10.4.0a0
   - aws-c-common >=0.14.0,<0.14.1.0a0
   - aws-c-http >=0.11.0,<0.11.1.0a0
   - aws-c-io >=0.26.3,<0.26.4.0a0
-  - aws-c-s3 >=0.12.5,<0.12.6.0a0
-  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
   - libaec >=1.1.5,<2.0a0
   - libcurl >=8.20.0,<9.0a0
   - libcxx >=19
   - libgfortran
   - libgfortran5 >=14.3.0
   - libzlib >=1.3.2,<2.0a0
-  - openssl >=3.5.6,<4.0a0
+  - openssl >=3.5.7,<4.0a0
   license: BSD-3-Clause
   license_family: BSD
   run_exports:
     weak:
     - hdf5 >=2.1.0,<3.0a0
-  size: 3562608
-  timestamp: 1780924273738
+  size: 3342788
+  timestamp: 1781837329072
 - conda: https://prefix.dev/conda-forge/osx-arm64/hdf5-2.1.0-nompi_hc95e3eb_104.conda
   sha256: 5b96accf983be97718fbfaddd6706591d7ef6511b4ccdac8a09f6b9899d1b284
   md5: e5390fd4a3b964a3ed619480df918294
@@ -48510,9 +48579,9 @@ packages:
   run_exports: {}
   size: 1611550
   timestamp: 1777732192000
-- conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py312h029426b_2.conda
-  sha256: f891774644434cf77770377fa29caef67665cef4c785f0c3234ef6ebd5368858
-  md5: 20a43ca26de75a45b5bd77b34f489a57
+- conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py312he3e6aaf_3.conda
+  sha256: d6ee21a0292866327fc6e1e6967b416c32b659c7851c8f42f3f91875cd8ec5fa
+  md5: bb41da32a0f551079e09d05c418af1f0
   depends:
   - __osx >=11.0
   - blosc >=1.21.6,<2.0a0
@@ -48542,7 +48611,7 @@ packages:
   - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - openjpeg >=2.5.4,<3.0a0
-  - openjph >=0.29.0,<0.30.0a0
+  - openjph >=0.30.1,<0.31.0a0
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
@@ -48553,11 +48622,11 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 1846103
-  timestamp: 1781743981168
-- conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py313he947694_2.conda
-  sha256: c1b76c1f02943a212ad5006f5896a88567920589c94c8b44a7312688b1a102d8
-  md5: 5f372a3bee1fe2210d7715208890aa49
+  size: 1848265
+  timestamp: 1782112248954
+- conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py313h9d12897_3.conda
+  sha256: 3f31cceb7d0991244107d9fe633e22d4faa79fd1a9cab65d954fa6e60a7387d3
+  md5: 74c22fef6564ec7f252cfce6888504c0
   depends:
   - __osx >=11.0
   - blosc >=1.21.6,<2.0a0
@@ -48587,7 +48656,7 @@ packages:
   - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - openjpeg >=2.5.4,<3.0a0
-  - openjph >=0.29.0,<0.30.0a0
+  - openjph >=0.30.1,<0.31.0a0
   - python >=3.13,<3.14.0a0
   - python >=3.13,<3.14.0a0 *_cp313
   - python_abi 3.13.* *_cp313
@@ -48598,11 +48667,11 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 1854731
-  timestamp: 1781743705215
-- conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py314h4197199_2.conda
-  sha256: 63e4dc8679bf9b65e574e9393ba01ef0c3aaddc3877ebdde50b37cc261b2f515
-  md5: c212c0df7ad51a961099e5d4ca2fe0ae
+  size: 1855640
+  timestamp: 1782112862862
+- conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py314h8ee69f8_3.conda
+  sha256: f9da83a9b74f59307a0b41a3762d7c261c1a2ccc6a0195ef7294df7c371f27a5
+  md5: dcc3e3438ce509887751be06b34b022b
   depends:
   - __osx >=11.0
   - blosc >=1.21.6,<2.0a0
@@ -48632,7 +48701,7 @@ packages:
   - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - openjpeg >=2.5.4,<3.0a0
-  - openjph >=0.29.0,<0.30.0a0
+  - openjph >=0.30.1,<0.31.0a0
   - python >=3.14,<3.15.0a0
   - python >=3.14,<3.15.0a0 *_cp314t
   - python_abi 3.14.* *_cp314t
@@ -48643,11 +48712,11 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 2222030
-  timestamp: 1781743762359
-- conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py314hcca8607_2.conda
-  sha256: 29ba2ed085ea98e02cfb649ed16f19cbb7dd2c466f14e5bb33d8776d781ca43c
-  md5: 9bfd012b011c34ee57d2e6a590205d54
+  size: 2213244
+  timestamp: 1782112311323
+- conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-2026.6.6-py314hdaaf36e_3.conda
+  sha256: d62fceb2bba579bfd370faec00e6112fdf954f29e5966ba639f3b33674ed9aa1
+  md5: b2b14052518f13241615be89a2d8500c
   depends:
   - __osx >=11.0
   - blosc >=1.21.6,<2.0a0
@@ -48677,7 +48746,7 @@ packages:
   - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - openjpeg >=2.5.4,<3.0a0
-  - openjph >=0.29.0,<0.30.0a0
+  - openjph >=0.30.1,<0.31.0a0
   - python >=3.14,<3.15.0a0
   - python >=3.14,<3.15.0a0 *_cp314
   - python_abi 3.14.* *_cp314
@@ -48688,8 +48757,8 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 1874467
-  timestamp: 1781743975811
+  size: 1868589
+  timestamp: 1782112374975
 - conda: https://prefix.dev/conda-forge/osx-arm64/imagecodecs-lite-2019.12.3-py310hb3e58dc_8.conda
   sha256: 63af9b09bab7b3494907570819a950e9f51f3a313a29c03b72096d790090436d
   md5: 306a5b0a0ff19eecb03ec242d9a10945
@@ -49155,13 +49224,13 @@ packages:
     - libarrow >=20.0.0,<20.1.0a0
   size: 5649699
   timestamp: 1774279750659
-- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-22.0.0-h8abb18b_24_cpu.conda
-  build_number: 24
-  sha256: 1caf0a8524ad07abc87aa3bfff222a0b573b2e766be2e30ab73992d823e0ad25
-  md5: fd71c40f6e77601e2cac029fdc307fc0
+- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-22.0.0-h2f99e73_25_cpu.conda
+  build_number: 25
+  sha256: 87f69fa1fa0224d326057445159f551ddb63640226550a92d9a5ed67eb32287e
+  md5: c9bdab712fecf010b4466a356ed7531d
   depends:
   - __osx >=11.0
-  - aws-crt-cpp >=0.40.0,<0.40.1.0a0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
   - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
   - azure-core-cpp >=1.16.3,<1.16.4.0a0
   - azure-identity-cpp >=1.13.3,<1.13.4.0a0
@@ -49192,15 +49261,15 @@ packages:
   run_exports:
     weak:
     - libarrow >=22.0.0,<22.1.0a0
-  size: 4144120
-  timestamp: 1781581886996
-- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-24.0.0-hc887bfb_6_cpu.conda
-  build_number: 6
-  sha256: 28202e5f479c1115b53a1693f8ab4ca7a22ab54d1ec75e396dbf12f75a870a5f
-  md5: 735cf8d8223865d02ef727ddfdc83e19
+  size: 4148421
+  timestamp: 1781922232710
+- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-24.0.0-h6045e8e_8_cpu.conda
+  build_number: 8
+  sha256: 3fb75f077b1b1a2fc577e96c7c7bbb149c38819c3807795d4919fdfbf4d35f9e
+  md5: f4c6a48b3bf53c59a0f3ee5f5b492c62
   depends:
   - __osx >=11.0
-  - aws-crt-cpp >=0.40.0,<0.40.1.0a0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
   - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
   - azure-core-cpp >=1.16.3,<1.16.4.0a0
   - azure-identity-cpp >=1.13.3,<1.13.4.0a0
@@ -49213,8 +49282,8 @@ packages:
   - libbrotlidec >=1.2.0,<1.3.0a0
   - libbrotlienc >=1.2.0,<1.3.0a0
   - libcxx >=21
-  - libgoogle-cloud >=3.5.0,<3.6.0a0
-  - libgoogle-cloud-storage >=3.5.0,<3.6.0a0
+  - libgoogle-cloud >=3.6.0,<3.7.0a0
+  - libgoogle-cloud-storage >=3.6.0,<3.7.0a0
   - libopentelemetry-cpp >=1.27.0,<1.28.0a0
   - libprotobuf >=6.33.5,<6.33.6.0a0
   - libzlib >=1.3.2,<2.0a0
@@ -49223,16 +49292,15 @@ packages:
   - snappy >=1.2.2,<1.3.0a0
   - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - parquet-cpp <0.0a0
   - apache-arrow-proc =*=cpu
   - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow >=24.0.0,<24.1.0a0
-  size: 4262638
-  timestamp: 1781582643878
+  size: 4262820
+  timestamp: 1782184446658
 - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-16.0.0-h00cdb27_1_cpu.conda
   build_number: 1
   sha256: 39c64ca3481019b18c63dc273ae177ac5dab3fdb150780a9e89eb3476232106c
@@ -49282,16 +49350,16 @@ packages:
     - libarrow-acero >=20.0.0,<20.1.0a0
   size: 511880
   timestamp: 1774279965265
-- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-22.0.0-he2f0307_24_cpu.conda
-  build_number: 24
-  sha256: 799570d4d40f67a07d0959c2d823bc888f5b72d8dd0fcc21e11584cb4c7f2ba0
-  md5: e8f8c05fbf4c52081b6e533f587c58bf
+- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-22.0.0-he2f0307_25_cpu.conda
+  build_number: 25
+  sha256: 78477285ae54fff309e8d19e973ad06bc6f99416d126b7777c17c2690116870f
+  md5: c5a1ecf57aa964b17e04f90227d0495a
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
   - libabseil >=20260107.1,<20260108.0a0
-  - libarrow 22.0.0 h8abb18b_24_cpu
-  - libarrow-compute 22.0.0 h92c7015_24_cpu
+  - libarrow 22.0.0 h2f99e73_25_cpu
+  - libarrow-compute 22.0.0 h92c7015_25_cpu
   - libcxx >=19
   - libopentelemetry-cpp >=1.27.0,<1.28.0a0
   - libprotobuf >=6.33.5,<6.33.6.0a0
@@ -49300,37 +49368,36 @@ packages:
   run_exports:
     weak:
     - libarrow-acero >=22.0.0,<22.1.0a0
-  size: 544435
-  timestamp: 1781582358924
-- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-24.0.0-ha4f4840_6_cpu.conda
-  build_number: 6
-  sha256: 0582f506857aca16c124d5eec8b44f5ba30d2ce165050980994d5fb206313c9c
-  md5: fe31fe1831bb6eb976028980a1c6fe3f
+  size: 544119
+  timestamp: 1781922692969
+- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-acero-24.0.0-ha4f4840_8_cpu.conda
+  build_number: 8
+  sha256: 46c20e39c6104cba3c74c781671933ccdebb958131003ff61d50a552e0b8f8e6
+  md5: 39a30fa1ac563d314ea65741e6761739
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
   - libabseil >=20260107.1,<20260108.0a0
-  - libarrow 24.0.0 hc887bfb_6_cpu
-  - libarrow-compute 24.0.0 h8d10c55_6_cpu
+  - libarrow 24.0.0 h6045e8e_8_cpu
+  - libarrow-compute 24.0.0 h8d10c55_8_cpu
   - libcxx >=21
   - libopentelemetry-cpp >=1.27.0,<1.28.0a0
   - libprotobuf >=6.33.5,<6.33.6.0a0
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow-acero >=24.0.0,<24.1.0a0
-  size: 520500
-  timestamp: 1781583155520
-- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-compute-22.0.0-h92c7015_24_cpu.conda
-  build_number: 24
-  sha256: 7ac74a0d4121681a6491d77cf7d3d77a9335fedf0ab0bf858ded47337d26a4ca
-  md5: 0ddbc3afc6a77a9718d19b5d9a18be3f
+  size: 519849
+  timestamp: 1782184880774
+- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-compute-22.0.0-h92c7015_25_cpu.conda
+  build_number: 25
+  sha256: 00cd5e11524281b5f6b0c447113e32d88dc4bbff4b7f87564970391d451687e7
+  md5: 3b1a2b9f4448c728a36a57517faed1f1
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
   - libabseil >=20260107.1,<20260108.0a0
-  - libarrow 22.0.0 h8abb18b_24_cpu
+  - libarrow 22.0.0 h2f99e73_25_cpu
   - libcxx >=19
   - libopentelemetry-cpp >=1.27.0,<1.28.0a0
   - libprotobuf >=6.33.5,<6.33.6.0a0
@@ -49342,17 +49409,17 @@ packages:
   run_exports:
     weak:
     - libarrow-compute >=22.0.0,<22.1.0a0
-  size: 2179929
-  timestamp: 1781582036775
-- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-compute-24.0.0-h8d10c55_6_cpu.conda
-  build_number: 6
-  sha256: 10cab01cff6a88b76b46ed7b0fc9f1c5a26512193f283da15b51ede85238c389
-  md5: 92d632e95839989a2a20b2aafd90e46c
+  size: 2179028
+  timestamp: 1781922374512
+- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-compute-24.0.0-h8d10c55_8_cpu.conda
+  build_number: 8
+  sha256: 9f73c59cfbe680f0328098f20e4116df36b45484a204743813ebec03e8a70a2a
+  md5: 8d9f3dc3909108ddf4bc5411623b2ccc
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
   - libabseil >=20260107.1,<20260108.0a0
-  - libarrow 24.0.0 hc887bfb_6_cpu
+  - libarrow 24.0.0 h6045e8e_8_cpu
   - libcxx >=21
   - libopentelemetry-cpp >=1.27.0,<1.28.0a0
   - libprotobuf >=6.33.5,<6.33.6.0a0
@@ -49360,12 +49427,11 @@ packages:
   - libutf8proc >=2.11.3,<2.12.0a0
   - re2
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow-compute >=24.0.0,<24.1.0a0
-  size: 2240814
-  timestamp: 1781582819765
+  size: 2243840
+  timestamp: 1782184563897
 - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-16.0.0-h00cdb27_1_cpu.conda
   build_number: 1
   sha256: 215d5a7baa684e4bf9268272f6b19544edfcb102bb66bd5f7b87edb4fb7accc0
@@ -49421,50 +49487,49 @@ packages:
     - libarrow-dataset >=20.0.0,<20.1.0a0
   size: 513371
   timestamp: 1774280294550
-- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-22.0.0-he2f0307_24_cpu.conda
-  build_number: 24
-  sha256: 0e40a27803f5fb6548e7b3160728f38e361b026562db93e3467d47438a42ca30
-  md5: 172acd4a73a7712f496f49adf7f98661
+- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-22.0.0-he2f0307_25_cpu.conda
+  build_number: 25
+  sha256: 8f756d31630174e759114d848d3c0553d0d156995a1dbbbc9c4cddcc4a22166b
+  md5: 5c734d9771a6bc2ae4892f3cc7932e22
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
   - libabseil >=20260107.1,<20260108.0a0
-  - libarrow 22.0.0 h8abb18b_24_cpu
-  - libarrow-acero 22.0.0 he2f0307_24_cpu
-  - libarrow-compute 22.0.0 h92c7015_24_cpu
+  - libarrow 22.0.0 h2f99e73_25_cpu
+  - libarrow-acero 22.0.0 he2f0307_25_cpu
+  - libarrow-compute 22.0.0 h92c7015_25_cpu
   - libcxx >=19
   - libopentelemetry-cpp >=1.27.0,<1.28.0a0
-  - libparquet 22.0.0 h4b95741_24_cpu
+  - libparquet 22.0.0 h4b95741_25_cpu
   - libprotobuf >=6.33.5,<6.33.6.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
     - libarrow-dataset >=22.0.0,<22.1.0a0
-  size: 542302
-  timestamp: 1781582550154
-- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-24.0.0-ha4f4840_6_cpu.conda
-  build_number: 6
-  sha256: 8a49aff633e60bf6fe9c09ac4ad85dba16c068881cf12fd464def44972fdc897
-  md5: 466ffa087ca276917a3f177d6e64b05f
+  size: 542368
+  timestamp: 1781922971157
+- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-dataset-24.0.0-ha4f4840_8_cpu.conda
+  build_number: 8
+  sha256: d1db32a0d814236188945bee083e49d578dc0b35715367c5823b7125d7aeee25
+  md5: f22bc2e04525bee90f5e89c2661f796f
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
   - libabseil >=20260107.1,<20260108.0a0
-  - libarrow 24.0.0 hc887bfb_6_cpu
-  - libarrow-acero 24.0.0 ha4f4840_6_cpu
-  - libarrow-compute 24.0.0 h8d10c55_6_cpu
+  - libarrow 24.0.0 h6045e8e_8_cpu
+  - libarrow-acero 24.0.0 ha4f4840_8_cpu
+  - libarrow-compute 24.0.0 h8d10c55_8_cpu
   - libcxx >=21
   - libopentelemetry-cpp >=1.27.0,<1.28.0a0
-  - libparquet 24.0.0 h840b369_6_cpu
+  - libparquet 24.0.0 h840b369_8_cpu
   - libprotobuf >=6.33.5,<6.33.6.0a0
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow-dataset >=24.0.0,<24.1.0a0
-  size: 518706
-  timestamp: 1781583361967
+  size: 518870
+  timestamp: 1782185056190
 - conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-16.0.0-hc68f6b8_1_cpu.conda
   build_number: 1
   sha256: 3129f4d25c58a9f566e29f6a0cfaa37e5409a6d7fef5124ebfc3fc818a583e01
@@ -49525,17 +49590,17 @@ packages:
     - libarrow-substrait >=20.0.0,<20.1.0a0
   size: 449428
   timestamp: 1774280565431
-- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-22.0.0-h8746646_24_cpu.conda
-  build_number: 24
-  sha256: 956af40e58d6a00df9b2b8d582f653852cfebce9cf7217d7b2b99b2f267687a8
-  md5: abc7b411f53f4111487f71d2ca49db0a
+- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-22.0.0-h8746646_25_cpu.conda
+  build_number: 25
+  sha256: c4d0bc56193c7da64c8d72c7a7db259e46ba3684ca69c7fc59776e9d086677be
+  md5: 6861ffbc92c7669abb92a41a671a946e
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
   - libabseil >=20260107.1,<20260108.0a0
-  - libarrow 22.0.0 h8abb18b_24_cpu
-  - libarrow-acero 22.0.0 he2f0307_24_cpu
-  - libarrow-dataset 22.0.0 he2f0307_24_cpu
+  - libarrow 22.0.0 h2f99e73_25_cpu
+  - libarrow-acero 22.0.0 he2f0307_25_cpu
+  - libarrow-dataset 22.0.0 he2f0307_25_cpu
   - libcxx >=19
   - libprotobuf >=6.33.5,<6.33.6.0a0
   license: Apache-2.0
@@ -49543,28 +49608,27 @@ packages:
   run_exports:
     weak:
     - libarrow-substrait >=22.0.0,<22.1.0a0
-  size: 481598
-  timestamp: 1781582607884
-- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-24.0.0-h05be00f_6_cpu.conda
-  build_number: 6
-  sha256: 8436dc856ca4bd9f51beae98b411547a5711b68c7aabedaf8128c793fc0b53d8
-  md5: a68e084ce204a1242a98fa82a4497ce0
+  size: 481859
+  timestamp: 1781923057138
+- conda: https://prefix.dev/conda-forge/osx-arm64/libarrow-substrait-24.0.0-h05be00f_8_cpu.conda
+  build_number: 8
+  sha256: 1ae21b67f081aea9f136141b95691e2e98596ab733bbc261577f998dd08f88bf
+  md5: 6d82f177aff9e47fed86ae793318b4ad
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
   - libabseil >=20260107.1,<20260108.0a0
-  - libarrow 24.0.0 hc887bfb_6_cpu
-  - libarrow-acero 24.0.0 ha4f4840_6_cpu
-  - libarrow-dataset 24.0.0 ha4f4840_6_cpu
+  - libarrow 24.0.0 h6045e8e_8_cpu
+  - libarrow-acero 24.0.0 ha4f4840_8_cpu
+  - libarrow-dataset 24.0.0 ha4f4840_8_cpu
   - libcxx >=21
   - libprotobuf >=6.33.5,<6.33.6.0a0
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow-substrait >=24.0.0,<24.1.0a0
-  size: 454608
-  timestamp: 1781583430224
+  size: 454799
+  timestamp: 1782185112950
 - conda: https://prefix.dev/conda-forge/osx-arm64/libavif16-1.4.2-h1c659b6_1.conda
   sha256: 4dd35db5347b955350b96281020f015e81999be99db2429b3ee4d04f03a0826b
   md5: 91706a918713506ef5a43ecc8e0a7e6b
@@ -50058,6 +50122,28 @@ packages:
     - libgoogle-cloud >=3.5.0,<3.6.0a0
   size: 1812401
   timestamp: 1780031033935
+- conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-3.6.0-h688a705_0.conda
+  sha256: 650f0605bed3048ca69b547cc31e1d6c70b7371fb3212b00b103da6fd2f11d77
+  md5: be005bcbd77890a199ee583ba7a74bec
+  depends:
+  - __osx >=11.0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libcxx >=19
+  - libgrpc >=1.78.1,<1.79.0a0
+  - libopentelemetry-cpp >=1.27.0,<1.28.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - openssl >=3.5.7,<4.0a0
+  constrains:
+  - libgoogle-cloud 3.6.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - libgoogle-cloud >=3.6.0,<3.7.0a0
+  size: 1839082
+  timestamp: 1781921657626
 - conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-storage-2.23.0-h8a76758_1.conda
   sha256: 3173b65b7e36e9fa0e6ddec69f39e4dd0e7ada38dbf2c1be006fddc2e7257b0c
   md5: 356c74978867e07e12a939a092dcf30d
@@ -50133,6 +50219,25 @@ packages:
     - libgoogle-cloud-storage >=3.5.0,<3.6.0a0
   size: 527597
   timestamp: 1780031485452
+- conda: https://prefix.dev/conda-forge/osx-arm64/libgoogle-cloud-storage-3.6.0-ha114238_0.conda
+  sha256: a01821942ab88a433a81ec9a0e6aa72ed5f7ceb5e11a295f3eb28dd22a0a24bf
+  md5: b7c9ec99242e620133106438ccfcf08e
+  depends:
+  - __osx >=11.0
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libcxx >=19
+  - libgoogle-cloud 3.6.0 h688a705_0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - libgoogle-cloud-storage >=3.6.0,<3.7.0a0
+  size: 528490
+  timestamp: 1781921815114
 - conda: https://prefix.dev/conda-forge/osx-arm64/libgrpc-1.62.2-h9c18a4f_0.conda
   sha256: d2c5b5a828f6f1242c11e8c91968f48f64446f7dd5cbfa1197545e465eb7d47a
   md5: e624fc11026dbb84c549435eccd08623
@@ -50654,15 +50759,15 @@ packages:
     - libparquet >=20.0.0,<20.1.0a0
   size: 906358
   timestamp: 1774280214549
-- conda: https://prefix.dev/conda-forge/osx-arm64/libparquet-22.0.0-h4b95741_24_cpu.conda
-  build_number: 24
-  sha256: 695957cfbcb9c3b4213070639ef2883cea54cee3e0031ca342e2a7d09900563c
-  md5: 4c15a1a6564d8c92c1e06dd341518110
+- conda: https://prefix.dev/conda-forge/osx-arm64/libparquet-22.0.0-h4b95741_25_cpu.conda
+  build_number: 25
+  sha256: 33d6ca31df5744ba2d3c5ed539dc5b0f48437c01fcf2ff1b604d60c0b3761c1c
+  md5: 959caebe70d2bf4edfe6f13e2da51810
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
   - libabseil >=20260107.1,<20260108.0a0
-  - libarrow 22.0.0 h8abb18b_24_cpu
+  - libarrow 22.0.0 h2f99e73_25_cpu
   - libcxx >=19
   - libopentelemetry-cpp >=1.27.0,<1.28.0a0
   - libprotobuf >=6.33.5,<6.33.6.0a0
@@ -50673,29 +50778,28 @@ packages:
   run_exports:
     weak:
     - libparquet >=22.0.0,<22.1.0a0
-  size: 1069866
-  timestamp: 1781582301175
-- conda: https://prefix.dev/conda-forge/osx-arm64/libparquet-24.0.0-h840b369_6_cpu.conda
-  build_number: 6
-  sha256: f64f2e41e1a18d9592190370afda91c1bbe254f85d9772d745836f6629bfcab1
-  md5: f89a7c188db55c4307129dd3f4de42b7
+  size: 1069918
+  timestamp: 1781922624722
+- conda: https://prefix.dev/conda-forge/osx-arm64/libparquet-24.0.0-h840b369_8_cpu.conda
+  build_number: 8
+  sha256: 1c09305b9799442be75ece3565ea9b25195fe7d8d038d68a483f55c70037b620
+  md5: d1c458dee7223a02a095c27b86fa6fea
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
   - libabseil >=20260107.1,<20260108.0a0
-  - libarrow 24.0.0 hc887bfb_6_cpu
+  - libarrow 24.0.0 h6045e8e_8_cpu
   - libcxx >=21
   - libopentelemetry-cpp >=1.27.0,<1.28.0a0
   - libprotobuf >=6.33.5,<6.33.6.0a0
   - libthrift >=0.22.0,<0.22.1.0a0
   - openssl >=3.5.7,<4.0a0
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libparquet >=24.0.0,<24.1.0a0
-  size: 1097819
-  timestamp: 1781583076416
+  size: 1098749
+  timestamp: 1782184832374
 - conda: https://prefix.dev/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
   sha256: 66eae34546df1f098a67064970c92aa14ae7a7505091889e00468294d2882c36
   md5: 2259ae0949dbe20c0665850365109b27
@@ -51785,18 +51889,18 @@ packages:
     - mbedtls >=3.6.3.1,<3.7.0a0
   size: 879161
   timestamp: 1747803487126
-- conda: https://prefix.dev/conda-forge/osx-arm64/menuinst-2.5.0-py314h4dc9dd8_0.conda
-  sha256: 1c4d3e1defda64afee1a5fbc7e5a3dc9326ee6be4316d8358a05e4477208638b
-  md5: 486c262310ecd22db195a866e8e87a41
+- conda: https://prefix.dev/conda-forge/osx-arm64/menuinst-2.5.0-py314hcec6336_1.conda
+  sha256: 0c6499e1ff5294fb33615e5d93990b7e29c8caa742d627016072b15f51becf1d
+  md5: 5a2e8415a1cddef0de8461327bd96bf5
   depends:
-  - python >=3.14,<3.15.0a0
-  - python >=3.14,<3.15.0a0 *_cp314
-  - python_abi 3.14.* *_cp314
+  - python
   - tomli-w
+  - python 3.14.* *_cp314
+  - python_abi 3.14.* *_cp314
   license: BSD-3-Clause AND MIT
   run_exports: {}
-  size: 195884
-  timestamp: 1780907303154
+  size: 212016
+  timestamp: 1782062817762
 - conda: https://prefix.dev/conda-forge/osx-arm64/mmh3-3.0.0-py310h0f1eb42_3.tar.bz2
   sha256: 99eeae0afe346bcf1cdad77e6577ccd773ae6f43f406fd426aa6971cbe84e215
   md5: bdcbbe9320fc6e9b1687d8a0f23fe5bf
@@ -51921,9 +52025,9 @@ packages:
     - mpfr >=4.2.2,<5.0a0
   size: 348767
   timestamp: 1773414111071
-- conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py310h1c35771_0.conda
-  sha256: e0b86d5ed5d9a4e9e9c94f47611690fdad749135d9511fb1a62342977fab05e0
-  md5: c2aa4c8f92749f548af578c5921098e0
+- conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py310h1c35771_0.conda
+  sha256: 07cce6cc1d8011f4777fdc488c8104acb5ac240406008b65b07a6f11e528dc07
+  md5: ec90386eda088681d2eb6659fdb8e025
   depends:
   - __osx >=11.0
   - libcxx >=19
@@ -51933,11 +52037,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 84282
-  timestamp: 1781786642773
-- conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py311h572238d_0.conda
-  sha256: 0a536e6375fffa6144200bdf8cb9da4aa899f18ea44b2feab5e284feb38bb660
-  md5: ac448b598457ce801cff45dda633b48a
+  size: 84484
+  timestamp: 1782070679708
+- conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py311h572238d_0.conda
+  sha256: e3f25153bfc67bbf42ca275b7bd053a8871bb78fa81665014aee7fdb07cc7351
+  md5: ccf003024840fd39abde3bb3322582ec
   depends:
   - __osx >=11.0
   - libcxx >=19
@@ -51947,11 +52051,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 90609
-  timestamp: 1781786605206
-- conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py312h766f71e_0.conda
-  sha256: eecce72621c540487698c64dec2b6cdaad09ea74d73a4b817857f2ed6f19b2a4
-  md5: 135caacbdc87ea276cdc4e37666edb7e
+  size: 90982
+  timestamp: 1782070787034
+- conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py312h766f71e_0.conda
+  sha256: 342a8d6976c198d741844d51268beaffd5dec56a2b688b9350dbf9f4fa1004f9
+  md5: 86d034fc6116be109bbbbe9079ac73f8
   depends:
   - __osx >=11.0
   - libcxx >=19
@@ -51961,11 +52065,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 91104
-  timestamp: 1781786608555
-- conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py313h5c29297_0.conda
-  sha256: 6aaee6f7e5d4331daa1d36ee1527609074778e0a4b75127f756fa78d879ea213
-  md5: a06340de4a44617c94feb34ec5876bab
+  size: 90998
+  timestamp: 1782070951579
+- conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py313h5c29297_0.conda
+  sha256: 12f2c785c34a465f399e7af89e6b88a86684bde704e25460789e83efc0d8fd87
+  md5: b929e2af3d4059fedfb0a5da0007556f
   depends:
   - __osx >=11.0
   - libcxx >=19
@@ -51975,11 +52079,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 91063
-  timestamp: 1781786681753
-- conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py314h3a9a55a_0.conda
-  sha256: ea61b65775fa4735aafcee6d3e65eef0bbff6a85e68b03e47029bafaa550346e
-  md5: e37f256951bb3e4a93ef35c53bd6e7ad
+  size: 91552
+  timestamp: 1782070886759
+- conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py314h3a9a55a_0.conda
+  sha256: b3592f889c0b6098ccc2c5aaa33898989c63c2e7d7b5a5bb037b1080974934de
+  md5: 49f7c09f698b2b161872ba31cce75603
   depends:
   - __osx >=11.0
   - libcxx >=19
@@ -51989,11 +52093,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 96309
-  timestamp: 1781786502267
-- conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.0-py314h6cfcd04_0.conda
-  sha256: fafc391582184c942191176ffa714eca584088b6fc9384bd15071c951db2dde7
-  md5: f6ba612048168ccb92148c962e36c88b
+  size: 96345
+  timestamp: 1782071008019
+- conda: https://prefix.dev/conda-forge/osx-arm64/msgpack-python-1.2.1-py314h6cfcd04_0.conda
+  sha256: 09ea486f9248fdd987430a3519c31a0331e903edecc9740586a3e0abd590f840
+  md5: 7f80c3267c4b89767d7bbdf36d69fe80
   depends:
   - __osx >=11.0
   - libcxx >=19
@@ -52003,10 +52107,10 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/msgpack?source=hash-mapping
+  - pkg:pypi/msgpack?source=compressed-mapping
   run_exports: {}
-  size: 92004
-  timestamp: 1781786647663
+  size: 92074
+  timestamp: 1782070774684
 - conda: https://prefix.dev/conda-forge/osx-arm64/multidict-6.7.1-py310h53a546b_0.conda
   sha256: edc0badb9e15c87709c36be2844b04aa3d332d39c2cbdd92d89612b5ebc62761
   md5: d72819750e65277b9dfd1a50ade82e8d
@@ -52567,26 +52671,6 @@ packages:
     - numpy >=1.21,<3
   size: 6437085
   timestamp: 1747545094808
-- conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.4.6-py312ha003a3f_0.conda
-  sha256: b09e03dace335a6f303352fc4e167243e04d7026d55008546fa643d224fb0bad
-  md5: 9f554fdfa902971390975b489e678c03
-  depends:
-  - python
-  - __osx >=11.0
-  - libcxx >=19
-  - python_abi 3.12.* *_cp312
-  - liblapack >=3.9.0,<4.0a0
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - numpy >=1.23,<3
-  size: 6843172
-  timestamp: 1779169213435
 - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.4.6-py313hce9b930_0.conda
   sha256: 3f79e4755d6feafe2d9ce9e42cf28a2054ce404c5b9a89fde16eb48fd25e89c5
   md5: 13243cfdfeece38ffd42780e315129cf
@@ -52647,6 +52731,26 @@ packages:
     - numpy >=1.23,<3
   size: 6995531
   timestamp: 1779169217034
+- conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.5.0-py312ha003a3f_0.conda
+  sha256: 36f7062ce484ce45b8fdb2ee48cbbc7c0023004ba01e692efd5cd70034d93609
+  md5: f223ea9a1ca019ddbcfe28ce02ec366c
+  depends:
+  - python
+  - libcxx >=19
+  - __osx >=11.0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python_abi 3.12.* *_cp312
+  - libblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - numpy >=1.25,<3
+  size: 6964084
+  timestamp: 1782112554625
 - conda: https://prefix.dev/conda-forge/osx-arm64/openjdk-21.0.10-h258754b_0.conda
   sha256: 3d8ce3f6488a5a4b097f78add3c4749a36748d4f3e7446007ba83306173bd135
   md5: 4ea4ff11e1fb5557dde55f6070e9cd7e
@@ -52688,20 +52792,20 @@ packages:
     - openjph >=0.27.4,<0.28.0a0
   size: 184559
   timestamp: 1780596967363
-- conda: https://prefix.dev/conda-forge/osx-arm64/openjph-0.29.0-h2a4d681_0.conda
-  sha256: ad55021631260ed6ccc31aa275f00f06a664d042e65b6b86df352bc5cda3b28a
-  md5: 75c56113cb9657ae2982345c8259f8bc
+- conda: https://prefix.dev/conda-forge/osx-arm64/openjph-0.30.1-h2a4d681_0.conda
+  sha256: d4022be925a3d6ad3e4d482da914a98076b2031737b0ca79b2bcc2db9f162963
+  md5: 1b1d7b258c71a33d01458ad1c8e04d44
   depends:
-  - __osx >=11.0
   - libcxx >=19
+  - __osx >=11.0
   - libtiff >=4.7.1,<4.8.0a0
   license: BSD-2-Clause
   license_family: BSD
   run_exports:
     weak:
-    - openjph >=0.29.0,<0.30.0a0
-  size: 187682
-  timestamp: 1781694597411
+    - openjph >=0.30.1,<0.31.0a0
+  size: 191106
+  timestamp: 1782091346378
 - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
   sha256: b3e3ca895c336d4eb91c5d2f244a312bdb59a0de8cfa0cc4c179225ab2f6bbfb
   md5: 8187a86242741725bfa74785fe812979
@@ -53517,23 +53621,22 @@ packages:
   run_exports: {}
   size: 10707077
   timestamp: 1781020721263
-- conda: https://prefix.dev/conda-forge/osx-arm64/py-rattler-build-0.66.1-py310he76dbf2_0.conda
+- conda: https://prefix.dev/conda-forge/osx-arm64/py-rattler-build-0.67.0-py310he76dbf2_0.conda
   noarch: python
-  sha256: 1da593703876569b909bb12f3ecd27f39443fd8ddcec8a9179867138823c3406
-  md5: 502d172a7a2368217ede783d90bcbfd5
+  sha256: 5e17755cd1fac8fb5f0ed269de313eaeb6a440565023adac74026cc026a42a59
+  md5: 02ce6af3af6dbda87b75064513cbb28c
   depends:
   - python
   - __osx >=11.0
-  - openssl >=3.5.7,<4.0a0
   - _python_abi3_support 1.*
   - cpython >=3.10
+  - openssl >=3.5.7,<4.0a0
   constrains:
   - __osx >=11.0
   license: BSD-3-Clause
-  license_family: BSD
   run_exports: {}
-  size: 15894734
-  timestamp: 1781383832186
+  size: 15340627
+  timestamp: 1782144252313
 - conda: https://prefix.dev/conda-forge/osx-arm64/pyarrow-16.0.0-py310h7ed268f_0.conda
   sha256: 865ed62d01f3acaaea59870086e7754c08f6132a94275166d4a8de3c23a672e3
   md5: 7f1fb12eabab3d85f9cfc0dbdf8730c9
@@ -54629,19 +54732,18 @@ packages:
     - qhull >=2020.2,<2020.3.0a0
   size: 516376
   timestamp: 1720814307311
-- conda: https://prefix.dev/conda-forge/osx-arm64/rattler-build-0.66.2-h20b3172_0.conda
-  sha256: 4dc4b86a85b2423704439d90fef9ca1f1ca3c23d75dfa0fe2ecf6d5ebbeb4e76
-  md5: d3c33e27df8aebd3f2c28b58cc168382
+- conda: https://prefix.dev/conda-forge/osx-arm64/rattler-build-0.67.0-h20b3172_0.conda
+  sha256: 61425a531cee651a7583c9fe1e8961d0eed483f72c4a01a2e248816452dcbee3
+  md5: 4110e4931d5ad742288235688c786ad7
   depends:
   - __osx >=11.0
   - libcxx >=19
   constrains:
   - __osx >=11.0
   license: BSD-3-Clause
-  license_family: BSD
   run_exports: {}
-  size: 17244552
-  timestamp: 1781721832394
+  size: 17366355
+  timestamp: 1782150862478
 - conda: https://prefix.dev/conda-forge/osx-arm64/rav1e-0.8.1-h8246384_0.conda
   sha256: 925e35b71fe513e0380ecd2fe137e3f4f248bf7ce4bad96946c7c704b7a50d26
   md5: 4706a8a71474c692482c3f86c2175454
@@ -55350,9 +55452,9 @@ packages:
   run_exports: {}
   size: 13954661
   timestamp: 1779874558902
-- conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.17.1-py312h4519d97_1.conda
-  sha256: c0ed2cbfa3485bac8570e52b577475778c603ee92d078a8b164d1ddec992e577
-  md5: 173d5eeba324363d9171946e86a81687
+- conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.18.0-py312h4519d97_0.conda
+  sha256: 708f27ae8ccf62cf714dc5c6f728ae733dc14315c842e935ed7f491d214df2b0
+  md5: 5a352ca7e4f49ca6585dd30a4812bd20
   depends:
   - __osx >=11.0
   - libblas >=3.9.0,<4.0a0
@@ -55363,17 +55465,17 @@ packages:
   - liblapack >=3.9.0,<4.0a0
   - numpy <2.7
   - numpy >=1.23,<3
-  - numpy >=1.25.2
+  - numpy >=2.0.0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 13936510
-  timestamp: 1779874824714
-- conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.17.1-py313h52f5312_1.conda
-  sha256: b828f5d0f77e890bc5ec8b2a391bf27c01d468a8b83667bf7786e9a6a1ff12e8
-  md5: f441d9cefca60be8589c309e3af2e6d8
+  size: 14165071
+  timestamp: 1781912652942
+- conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
+  sha256: d1bf4f384b822df098eddf66ac71e407c63148b1fb3b5cf4d536f6ae40269cca
+  md5: 110ff05ffef908af95192bb17c4006a0
   depends:
   - __osx >=11.0
   - libblas >=3.9.0,<4.0a0
@@ -55384,17 +55486,17 @@ packages:
   - liblapack >=3.9.0,<4.0a0
   - numpy <2.7
   - numpy >=1.23,<3
-  - numpy >=1.25.2
+  - numpy >=2.0.0
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 14049103
-  timestamp: 1779874780525
-- conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.17.1-py314h122b93a_1.conda
-  sha256: a9bc87e56d8630c09547a21b85b49ef51f53739a071c3eb147d98bd3b9f6d02c
-  md5: 6685628e3afcf982bc7fe0f25619e9e2
+  size: 14094513
+  timestamp: 1781912946907
+- conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.18.0-py314h122b93a_0.conda
+  sha256: 098fb9acbbec11d8b180f61f145e92785fef76843f40170ebf9eb76f4517f417
+  md5: 848362dce7876529d00d75ac008a5d72
   depends:
   - __osx >=11.0
   - libblas >=3.9.0,<4.0a0
@@ -55405,17 +55507,17 @@ packages:
   - liblapack >=3.9.0,<4.0a0
   - numpy <2.7
   - numpy >=1.23,<3
-  - numpy >=1.25.2
+  - numpy >=2.0.0
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314t
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 14274565
-  timestamp: 1779874641501
-- conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.17.1-py314h18e1515_1.conda
-  sha256: d9742c04d44f78d2628899ad017f23e404e08f28118fcfbbf6722259cbd56eab
-  md5: 9958307c22c5b53165e46719ebe8972d
+  size: 14449172
+  timestamp: 1781912637021
+- conda: https://prefix.dev/conda-forge/osx-arm64/scipy-1.18.0-py314h18e1515_0.conda
+  sha256: 7ce218a4e1c55775547835d21a7ead0d50e5ac348fd638ce6ba316c48c8547b7
+  md5: e55fe08bb5d43e7120672338dd129030
   depends:
   - __osx >=11.0
   - libblas >=3.9.0,<4.0a0
@@ -55426,14 +55528,14 @@ packages:
   - liblapack >=3.9.0,<4.0a0
   - numpy <2.7
   - numpy >=1.23,<3
-  - numpy >=1.25.2
+  - numpy >=2.0.0
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 13975038
-  timestamp: 1779874613589
+  size: 14122215
+  timestamp: 1781912992503
 - conda: https://prefix.dev/conda-forge/osx-arm64/setuptools-60.10.0-py310hbe9552e_0.tar.bz2
   sha256: c51c18a1a06ad2e6015eabe1f3b26cff4c66399de3ef1d5ab5f26851ad6b3ba1
   md5: 1051237995dd93bee6a0fae177a23b80
@@ -55701,41 +55803,6 @@ packages:
     - tiledb >=2.26.2,<2.27.0a0
   size: 3407179
   timestamp: 1732208771419
-- conda: https://prefix.dev/conda-forge/osx-arm64/tiledb-2.30.1-h16333d0_12.conda
-  sha256: b684414e1c4a9e782dbabe2f0c242b2b37cdafa7d3c786d3bcd88b4fe605cffb
-  md5: e7b6ac5fabc2d8f094b7033f72113fef
-  depends:
-  - __osx >=11.0
-  - aws-crt-cpp >=0.40.0,<0.40.1.0a0
-  - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
-  - azure-core-cpp >=1.16.3,<1.16.4.0a0
-  - azure-identity-cpp >=1.13.3,<1.13.4.0a0
-  - azure-storage-blobs-cpp >=12.18.0,<12.18.1.0a0
-  - azure-storage-common-cpp >=12.14.0,<12.14.1.0a0
-  - azure-storage-files-datalake-cpp >=12.16.0,<12.16.1.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - c-blosc2 >=3.1.3,<3.2.0a0
-  - capnproto >=1.4.0,<1.4.1.0a0
-  - fmt >=12.1.0,<12.2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libcxx >=19
-  - libgoogle-cloud >=3.5.0,<3.6.0a0
-  - libgoogle-cloud-storage >=3.5.0,<3.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - openssl >=3.5.7,<4.0a0
-  - spdlog >=1.17.0,<1.18.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: MIT
-  license_family: MIT
-  run_exports:
-    weak:
-    - tiledb >=2.30.1,<2.31.0a0
-  size: 2973891
-  timestamp: 1781620915984
 - conda: https://prefix.dev/conda-forge/osx-arm64/tiledb-2.30.1-h22e6f27_6.conda
   sha256: ac2bb02b2e9ed3085c263ab6e1d24552ceedb1624d9b01a0d9da62c2e79c64e9
   md5: f8f56fcdb7d95a9743cfd4d45d811d9e
@@ -55771,6 +55838,41 @@ packages:
     - tiledb >=2.30.1,<2.31.0a0
   size: 2970077
   timestamp: 1777733432929
+- conda: https://prefix.dev/conda-forge/osx-arm64/tiledb-2.30.1-h6cfd315_13.conda
+  sha256: 3d89079188ea218ae70445226ca5baa85caeadb7e6b19ad6dfa49ae2f66db1cd
+  md5: 868cf4f4ced3db21e5b092dd3dcf62ca
+  depends:
+  - __osx >=11.0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
+  - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
+  - azure-core-cpp >=1.16.3,<1.16.4.0a0
+  - azure-identity-cpp >=1.13.3,<1.13.4.0a0
+  - azure-storage-blobs-cpp >=12.18.0,<12.18.1.0a0
+  - azure-storage-common-cpp >=12.14.0,<12.14.1.0a0
+  - azure-storage-files-datalake-cpp >=12.16.0,<12.16.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-blosc2 >=3.1.4,<3.2.0a0
+  - capnproto >=1.4.0,<1.4.1.0a0
+  - fmt >=12.1.0,<12.2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libcxx >=19
+  - libgoogle-cloud >=3.5.0,<3.6.0a0
+  - libgoogle-cloud-storage >=3.5.0,<3.6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - openssl >=3.5.7,<4.0a0
+  - spdlog >=1.17.0,<1.18.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - tiledb >=2.30.1,<2.31.0a0
+  size: 2976943
+  timestamp: 1781892245165
 - conda: https://prefix.dev/conda-forge/osx-arm64/tiledb-py-0.27.0-py310h04650ac_0.conda
   sha256: 845b3b399119052304f4e287c73fe7d4c7ab8bff09383a6352a8c7b5c9b6fb93
   md5: b9aba3135747f8d35d7a7399ab7259be
@@ -56003,98 +56105,92 @@ packages:
   run_exports: {}
   size: 416130
   timestamp: 1770909728445
-- conda: https://prefix.dev/conda-forge/osx-arm64/uv-0.11.22-hc169f86_0.conda
-  sha256: 38cc32de4de8e7239f14d34b3734e94f074adcdb14a4d913fd915acbe8c8a890
-  md5: a3328d0f6cecefd63a38f2c8767df6cf
+- conda: https://prefix.dev/conda-forge/osx-arm64/uv-0.11.23-hc169f86_0.conda
+  sha256: d070b708c8fcffcf8ef3b9ae30d68a3581186257a8524d259bb37e8289641db5
+  md5: f480e5e4f064a52cd71cb77f28dbb9f8
   depends:
-  - libcxx >=19
   - __osx >=11.0
+  - libcxx >=19
   constrains:
   - __osx >=11.0
   license: Apache-2.0 OR MIT
   run_exports: {}
-  size: 17024192
-  timestamp: 1781836355734
-- conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.1-py310h72544b6_0.conda
-  sha256: d17e29c05d2eeda00e78aad094356e47bc1ca67da56f9b0d1d901e004d9a6206
-  md5: 9c5e657ed3dc9d7b5ee5c4941e31c084
+  size: 17028243
+  timestamp: 1781912362661
+- conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.2-py310h72544b6_0.conda
+  sha256: aa0d3e4debbd0b25dd6c6742a944e5ec0d406cff1f222486a053da55b8b77a8c
+  md5: cdfccea1e181bd56e7400a980845cea3
   depends:
   - __osx >=11.0
   - python >=3.10,<3.11.0a0
   - python >=3.10,<3.11.0a0 *_cpython
   - python_abi 3.10.* *_cp310
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 97405
-  timestamp: 1779478046800
-- conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.1-py311hc949640_0.conda
-  sha256: 2541189672f4ab14af7df4e9b92adc03029c955023d5819e531790a7f423c63f
-  md5: 7961f1a5c00e95c91a4e7c1ed4d7a860
+  size: 98995
+  timestamp: 1782134177477
+- conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.2-py311hc949640_0.conda
+  sha256: e0ed3808fef0d3afcccb23a172e8257003d1a4594ccdfa08a0d084d6cae5ab4e
+  md5: a83b675267cb319b59a69db13755d7f5
   depends:
   - __osx >=11.0
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 112977
-  timestamp: 1779477735853
-- conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.1-py312h2bbb03f_0.conda
-  sha256: baefb9a73519863a70f6e7a6f6acb982ee5485ae986a16960ff1e8cb99f1a023
-  md5: a82ae4e18607e068c9259136d07e4f87
+  size: 114057
+  timestamp: 1782134457398
+- conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.2-py312h2bbb03f_0.conda
+  sha256: 0ea6de1d6b8bc70b0fae3856e1e8c99c15f0fa5bb9863282b90f2da63ffcc953
+  md5: f7115a8060360996f419b397727293ab
   depends:
   - __osx >=11.0
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 111458
-  timestamp: 1779477998634
-- conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.1-py313h0997733_0.conda
-  sha256: 87680be2386d1e7ec183a58981d8ca0e9e4319ec80e1cc76abb8eaf6429370af
-  md5: 6fc1287399a77a61f4ae182ccdd692fd
+  size: 112459
+  timestamp: 1782134073014
+- conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.2-py313h0997733_0.conda
+  sha256: 1b9bb35df4119949d36874e8e753d0f61a0f6f235deea43818e97af8bf6da768
+  md5: 8446508b88050b1a78d5b575de80518b
   depends:
   - __osx >=11.0
   - python >=3.13,<3.14.0a0
   - python >=3.13,<3.14.0a0 *_cp313
   - python_abi 3.13.* *_cp313
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 112898
-  timestamp: 1779477822259
-- conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.1-py314h6c2aa35_0.conda
-  sha256: 2f419160ec31de3ca3501e8a831a386a471f6c5e1dc43a57f3f3bcd1cf77e6b0
-  md5: b7af50eb697b32997d38bc0af06010d3
+  size: 113551
+  timestamp: 1782133966372
+- conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.2-py314h6c2aa35_0.conda
+  sha256: 3fff09a8c28dbdd3280c767f0b09ab5a25bcda2ed3b0a07b48a5b986e0ff12df
+  md5: abca357e08d7ceaaeebafa6d7f5a7fad
   depends:
   - __osx >=11.0
   - python >=3.14,<3.15.0a0
   - python >=3.14,<3.15.0a0 *_cp314
   - python_abi 3.14.* *_cp314
   license: BSD-2-Clause
-  license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=hash-mapping
+  - pkg:pypi/wrapt?source=compressed-mapping
   run_exports: {}
-  size: 114356
-  timestamp: 1779477743708
-- conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.1-py314ha0ac461_0.conda
-  sha256: 1879026d8d8671f78eda3cdf0341b30699e65d815399f2d98aa6e4d80a533223
-  md5: f1c9c1a38ef1a72188a736bcfc07fac3
+  size: 115243
+  timestamp: 1782134346100
+- conda: https://prefix.dev/conda-forge/osx-arm64/wrapt-2.2.2-py314ha0ac461_0.conda
+  sha256: 74d3ba1abcd789988f6b0585913ec1aa76f0cdc0b0f9d2b2f618f5a163896ca7
+  md5: ec562591119351a4c9347afae3014d14
   depends:
   - __osx >=11.0
   - python >=3.14,<3.15.0a0
   - python >=3.14,<3.15.0a0 *_cp314t
   - python_abi 3.14.* *_cp314t
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 115295
-  timestamp: 1779478357063
+  size: 116488
+  timestamp: 1782134218047
 - conda: https://prefix.dev/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
   sha256: adae11db0f66f86156569415ed79cda75b2dbf4bea48d1577831db701438164f
   md5: 78b548eed8227a689f93775d5d23ae09
@@ -56546,25 +56642,25 @@ packages:
     - aws-c-auth >=0.10.1,<0.10.2.0a0
   size: 127421
   timestamp: 1774275018076
-- conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.3-h75b6777_2.conda
-  sha256: 24a2fed6fd65e5af176025bbe1af91baf43d0beb037ee8513ae47f3221a8f89e
-  md5: f19119948955d3f12c96e1922f92159b
+- conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.10.3-h4ad2c79_3.conda
+  sha256: 590ab6432edcbd9cab6e48bb10f22f42c4a5d17592c3d8b88beebe53249c42ce
+  md5: 6aedfd77c6667e5b107c7907002e98a4
   depends:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - aws-c-common >=0.14.0,<0.14.1.0a0
   - aws-c-cal >=0.9.14,<0.9.15.0a0
-  - aws-c-http >=0.11.0,<0.11.1.0a0
-  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
   - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
     - aws-c-auth >=0.10.3,<0.10.4.0a0
-  size: 127447
-  timestamp: 1780598365717
+  size: 127434
+  timestamp: 1781802978944
 - conda: https://prefix.dev/conda-forge/win-64/aws-c-auth-0.7.20-h6823eb1_0.conda
   sha256: 793d992fd896784263483d5428a3ec797f42ab6ce896fcb549e0a4b6c48540d4
   md5: bdb3ab44dcc47c12d640fc6c14888bc1
@@ -57018,23 +57114,6 @@ packages:
     - aws-c-mqtt >=0.11.0,<0.11.1.0a0
   size: 186691
   timestamp: 1731735208782
-- conda: https://prefix.dev/conda-forge/win-64/aws-c-mqtt-0.15.2-h10b66d2_4.conda
-  sha256: a2bd3f799866fe82c29e1b0a16f7c8c19f76cb67e26caaf454d23695f5f5e007
-  md5: 59085b30e82152df2c9fa58e358ac9db
-  depends:
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - aws-c-io >=0.26.3,<0.26.4.0a0
-  - aws-c-http >=0.11.0,<0.11.1.0a0
-  - aws-c-common >=0.14.0,<0.14.1.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  run_exports:
-    weak:
-    - aws-c-mqtt >=0.15.2,<0.15.3.0a0
-  size: 212239
-  timestamp: 1780599030492
 - conda: https://prefix.dev/conda-forge/win-64/aws-c-mqtt-0.15.2-h904b250_1.conda
   sha256: f99bf60673f0d5a143450009c9454087c9bca01be74ae08394f8fc47789fa56a
   md5: fbccf4b054995b97bf98c38f0989a9a3
@@ -57052,6 +57131,23 @@ packages:
     - aws-c-mqtt >=0.15.2,<0.15.3.0a0
   size: 212290
   timestamp: 1774275592614
+- conda: https://prefix.dev/conda-forge/win-64/aws-c-mqtt-0.16.0-h10b66d2_0.conda
+  sha256: c77d3431ac4e4d3512ebc10e3ae82370f82183ec2c771f7f763392f5c1c471fc
+  md5: 2ce70960360c7672e456e8dd963f5bee
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-mqtt >=0.16.0,<0.16.1.0a0
+  size: 214746
+  timestamp: 1780681862128
 - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.11.5-h87bd87b_5.conda
   sha256: 62367b6d4d8aa1b43fb63e51d779bb829dfdd53d908c1b6700efa23255dd38db
   md5: 2d90128559ec4b3c78d1b889b8b13b50
@@ -57072,26 +57168,26 @@ packages:
     - aws-c-s3 >=0.11.5,<0.11.6.0a0
   size: 141733
   timestamp: 1774282227215
-- conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.12.5-h425879c_1.conda
-  sha256: bde30210fe7d355227bf303a582ff11e340ac685156139cd7a9ef08dfe6c037f
-  md5: 0329818a49b00c486916f6d7d5b65a71
+- conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.12.6-h425879c_0.conda
+  sha256: 79480a3e2cdc9996bcf956c40da69af7f0c381025d3a3767bca3bfd9ab7ad5a7
+  md5: d48ab0822e0cd063f28f9bdc3b131025
   depends:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
   - aws-c-common >=0.14.0,<0.14.1.0a0
   - aws-c-auth >=0.10.3,<0.10.4.0a0
-  - aws-checksums >=0.2.10,<0.2.11.0a0
   - aws-c-http >=0.11.0,<0.11.1.0a0
-  - aws-c-io >=0.26.3,<0.26.4.0a0
+  - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-checksums >=0.2.10,<0.2.11.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
-    - aws-c-s3 >=0.12.5,<0.12.6.0a0
-  size: 143806
-  timestamp: 1780609582441
+    - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  size: 144210
+  timestamp: 1781253046025
 - conda: https://prefix.dev/conda-forge/win-64/aws-c-s3-0.5.9-h7a83f0e_0.conda
   sha256: dc43a11f938365792455dfe2b2d26194dfaa4c3367967ab156f2af8666923012
   md5: 1fcee9f1b1ffa9ef65a3c54330b73f0e
@@ -57162,21 +57258,6 @@ packages:
     - aws-c-sdkutils >=0.2.1,<0.2.2.0a0
   size: 55188
   timestamp: 1731687352327
-- conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.4-h1f21522_6.conda
-  sha256: bd47b93b91ecb7d7ff82be44bb70e109f7cbb7c512c4579772652c46cbdf6597
-  md5: c1380960068cc10d06ddcab8cb97f439
-  depends:
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - aws-c-common >=0.14.0,<0.14.1.0a0
-  license: Apache-2.0
-  license_family: APACHE
-  run_exports:
-    weak:
-    - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
-  size: 56463
-  timestamp: 1780568566781
 - conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.4-hcb3a2da_4.conda
   sha256: c86c30edba7457e04d905c959328142603b62d7d1888aed893b2e21cca9c302c
   md5: 3c97faee5be6fd0069410cf2bca71c85
@@ -57192,6 +57273,21 @@ packages:
     - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
   size: 56509
   timestamp: 1764610148907
+- conda: https://prefix.dev/conda-forge/win-64/aws-c-sdkutils-0.2.5-h1f21522_0.conda
+  sha256: d81e792b5196631fb94bebe889dbb553934c82395c83da434fe20c0931b279a0
+  md5: a9f7e722616c9d49c1bfd50907f96af4
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - aws-c-common >=0.14.0,<0.14.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  run_exports:
+    weak:
+    - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
+  size: 62623
+  timestamp: 1781063655067
 - conda: https://prefix.dev/conda-forge/win-64/aws-checksums-0.1.18-hc83774a_4.conda
   sha256: 401aa17135aea3af343e7d4730c2ea878bee3da72824850423168549667d3008
   md5: 197196903f52fbd3e55a26b1e30561a6
@@ -57321,29 +57417,29 @@ packages:
     - aws-crt-cpp >=0.37.4,<0.37.5.0a0
   size: 304084
   timestamp: 1774286995597
-- conda: https://prefix.dev/conda-forge/win-64/aws-crt-cpp-0.40.0-hcaec180_1.conda
-  sha256: 524e7fcb31c88150f51e4f2750a8e0a083a374abcad29c9cf1b064f5a7971b2e
-  md5: efcf4340a1d932d462cc333d1be7862d
+- conda: https://prefix.dev/conda-forge/win-64/aws-crt-cpp-0.40.1-hccacdf3_1.conda
+  sha256: 6f719b087dc3d7d9782c415b7881d8f4e8a93db33fa0e80b300f1527156c2ec7
+  md5: 10925fdb0adcf0d06a920a0a188459c3
   depends:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
-  - aws-c-http >=0.11.0,<0.11.1.0a0
-  - aws-c-mqtt >=0.15.2,<0.15.3.0a0
-  - aws-c-io >=0.26.3,<0.26.4.0a0
-  - aws-c-auth >=0.10.3,<0.10.4.0a0
-  - aws-c-s3 >=0.12.5,<0.12.6.0a0
   - aws-c-common >=0.14.0,<0.14.1.0a0
-  - aws-c-event-stream >=0.7.1,<0.7.2.0a0
+  - aws-c-io >=0.26.3,<0.26.4.0a0
   - aws-c-cal >=0.9.14,<0.9.15.0a0
+  - aws-c-mqtt >=0.16.0,<0.16.1.0a0
+  - aws-c-http >=0.11.0,<0.11.1.0a0
+  - aws-c-auth >=0.10.3,<0.10.4.0a0
+  - aws-c-event-stream >=0.7.1,<0.7.2.0a0
+  - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
-    - aws-crt-cpp >=0.40.0,<0.40.1.0a0
-  size: 311489
-  timestamp: 1780917946841
+    - aws-crt-cpp >=0.40.1,<0.40.2.0a0
+  size: 311449
+  timestamp: 1781814094455
 - conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.267-h12f3f85_8.conda
   sha256: 8717821ee98cc8c4f9f1e5be8a89a40ff68f6139be7b0461640c2db60ebcaf2a
   md5: 7f43d81e0a58785839ed2b5bd92984d1
@@ -57382,24 +57478,24 @@ packages:
     - aws-sdk-cpp >=1.11.449,<1.11.450.0a0
   size: 2854344
   timestamp: 1732185022211
-- conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.747-h5d5b8b4_6.conda
-  sha256: 3401c3f8a9968319ba1a697bd5f23b51d01958995c91c8c8bcda03ded0039dff
-  md5: 3b7f809b73ed77b3394f2c5ea743db8b
+- conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.747-h042817b_7.conda
+  sha256: 76497781286198ccfaf9cdd75f38d59ec4c3e9cbcc96e0035056ce16ca869b18
+  md5: 9dbe27ef0270e0e26e0b8746c2cc91d0
   depends:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - aws-c-event-stream >=0.7.1,<0.7.2.0a0
-  - aws-crt-cpp >=0.40.0,<0.40.1.0a0
-  - libzlib >=1.3.2,<2.0a0
   - aws-c-common >=0.14.0,<0.14.1.0a0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - aws-c-event-stream >=0.7.1,<0.7.2.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
     - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
-  size: 23790964
-  timestamp: 1781003644763
+  size: 23791002
+  timestamp: 1781874260282
 - conda: https://prefix.dev/conda-forge/win-64/aws-sdk-cpp-1.11.747-hd55a107_3.conda
   sha256: b2ca74995fecfc1029f95c6256dea6d7e035e24633870a52665a8d48f49331f8
   md5: 48efab184702deb479a3766b1462efec
@@ -58488,9 +58584,9 @@ packages:
   run_exports: {}
   size: 247437
   timestamp: 1769155978556
-- conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py310hdb0e946_0.conda
-  sha256: d17d7a12ead876dd09f1b34f798e175d3721edbef9224dd92318d657f09ab8f3
-  md5: fdceaa71d5c53f4aabffe51b7b6184a4
+- conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py310hdb0e946_0.conda
+  sha256: 920a457a997e0d406ef3ddc523c0f6e71b9ae820f067cb4f8c921d2236a2dd34
+  md5: 1902f106da2e2c74a630106eb46cbac0
   depends:
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
@@ -58499,13 +58595,12 @@ packages:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 340094
-  timestamp: 1779838004649
-- conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py311h3f79411_0.conda
-  sha256: 491d53a03c413dc3699862d96feecbe22b0fda5d2f9e91066ed1eae6cb220793
-  md5: 0aa2991504a7e9144b5dae2f684fd4d6
+  size: 342590
+  timestamp: 1782178172908
+- conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py311h3f79411_0.conda
+  sha256: e97365777e3c50d7de2dd463ab2d5565415ee95f033b72e0c223c5e43f2e4fb2
+  md5: bc45a9bc9b619ca4b987f1e968500242
   depends:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
@@ -58514,13 +58609,12 @@ packages:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 424714
-  timestamp: 1779838002255
-- conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py312h05f76fc_0.conda
-  sha256: a37669c35673713cd5b1006958754d2f5ba8f0c10a85796579eea2dc9260f94c
-  md5: 4b355df4eedcf321296c32d8ca3fcfb7
+  size: 429286
+  timestamp: 1782178181364
+- conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py312h05f76fc_0.conda
+  sha256: 106b77b7571b9fd757852748eadfed4b5ae1169e25fdf312519bb1d0d201ccd9
+  md5: 94d6d73754f86ab89c9ad51e43b5433d
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -58529,13 +58623,12 @@ packages:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 413239
-  timestamp: 1779838010995
-- conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py313hd650c13_0.conda
-  sha256: cda15c313312f6fe90489df9b37dd0277fa7dbd4d52f3ea0aad2c48806bc1e55
-  md5: b814bf3906ccacfef0904c17b8e46d69
+  size: 420296
+  timestamp: 1782178183189
+- conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py313hd650c13_0.conda
+  sha256: 6f625e0bb29dc70030c68c897f2536f275d5fa1e1e008bda0412baa76185e4e7
+  md5: 2182f8aff2b7bcabe704336e943eaaa9
   depends:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
@@ -58544,13 +58637,12 @@ packages:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 422801
-  timestamp: 1779838006532
-- conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.1-py314h2359020_0.conda
-  sha256: 9bd2e2e705d44961482bc58339fe3d456cbbdbc16520c607be9609601c39e5ba
-  md5: 442d8dfea629c6a1c46347db9a5ec974
+  size: 424963
+  timestamp: 1782178171864
+- conda: https://prefix.dev/conda-forge/win-64/coverage-7.14.3-py314h2359020_0.conda
+  sha256: 1879a89f00d90166db5d3eaa455aa329f5a2fbeab5662630548e477047074125
+  md5: 2d2497e3c3b759375810139e7ccc0328
   depends:
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314
@@ -58559,10 +58651,9 @@ packages:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: Apache-2.0
-  license_family: APACHE
   run_exports: {}
-  size: 440396
-  timestamp: 1779838003568
+  size: 443224
+  timestamp: 1782178194098
 - conda: https://prefix.dev/conda-forge/win-64/cpp-expected-1.3.1-h477610d_0.conda
   sha256: cd24ac6768812d53c3b14c29b468cc9a5516b71e1880d67f58d98d9787f4cc3a
   md5: 444e9f7d9b3f69006c3af5db59e11364
@@ -59796,20 +59887,20 @@ packages:
     - hdf5 >=1.14.4,<1.14.5.0a0
   size: 2048450
   timestamp: 1733003052575
-- conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_h693361b_107.conda
-  sha256: 855d0e8eed8284c438d032a030b9a19abebe0b7fa5acc888adff6c782bffb33a
-  md5: 077380e6979650049695d5b2765385ed
+- conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_ha9ae7cf_108.conda
+  sha256: 3c13bd2e6c2b3946cace7b3b09518002fc61109629ec46040c7df14392e35847
+  md5: a5f85ab8aa403db6a0a78075b6bc4ff5
   depends:
   - aws-c-auth >=0.10.3,<0.10.4.0a0
   - aws-c-common >=0.14.0,<0.14.1.0a0
   - aws-c-http >=0.11.0,<0.11.1.0a0
   - aws-c-io >=0.26.3,<0.26.4.0a0
-  - aws-c-s3 >=0.12.5,<0.12.6.0a0
-  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-s3 >=0.12.6,<0.12.7.0a0
+  - aws-c-sdkutils >=0.2.5,<0.2.6.0a0
   - libaec >=1.1.5,<2.0a0
   - libcurl >=8.20.0,<9.0a0
   - libzlib >=1.3.2,<2.0a0
-  - openssl >=3.5.6,<4.0a0
+  - openssl >=3.5.7,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
@@ -59818,8 +59909,8 @@ packages:
   run_exports:
     weak:
     - hdf5 >=2.1.0,<3.0a0
-  size: 2607082
-  timestamp: 1780923575192
+  size: 2557385
+  timestamp: 1781836888760
 - conda: https://prefix.dev/conda-forge/win-64/hdf5-2.1.0-nompi_hd96b29f_104.conda
   sha256: ad660bf000e2a905ebdc8c297d9b3851ac48834284b673e655adda490425f652
   md5: 37c1890c40a1514fa92ba13e27d5b1c3
@@ -59945,9 +60036,9 @@ packages:
   run_exports: {}
   size: 1670232
   timestamp: 1777731649873
-- conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py312he323553_2.conda
-  sha256: f6e206480298367633b805aed92c42108848dac79fc477e56995b76756acb5b5
-  md5: 968d818e7eae2e82d39fd6edc9ea74fe
+- conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py312h006af62_3.conda
+  sha256: 495fccc91313968985d45be1a528a20818e6c5449cc4a05837cc066d6655b0f8
+  md5: e46c68718dfeedc8d93f4f9fa1a67892
   depends:
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
@@ -59974,7 +60065,7 @@ packages:
   - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - openjpeg >=2.5.4,<3.0a0
-  - openjph >=0.29.0,<0.30.0a0
+  - openjph >=0.30.1,<0.31.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - snappy >=1.2.2,<1.3.0a0
@@ -59987,11 +60078,11 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 1981954
-  timestamp: 1781743251309
-- conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py313h1f6e778_2.conda
-  sha256: 0129f8037b1ff583d25883265a15027de20e538d136a56e66e4aab25bfa57edc
-  md5: 6fe53faa9bb87ba1d2ae1be5257375bb
+  size: 1971700
+  timestamp: 1782111908144
+- conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py313hf6ffc8e_3.conda
+  sha256: 80baec6017a6f3e31a78e58b43549dd409805bcf92dc5ee5ee7b634bd645d96e
+  md5: ae5527f722e23edbc8b0aaa9ab33d584
   depends:
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
@@ -60018,7 +60109,7 @@ packages:
   - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - openjpeg >=2.5.4,<3.0a0
-  - openjph >=0.29.0,<0.30.0a0
+  - openjph >=0.30.1,<0.31.0a0
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - snappy >=1.2.2,<1.3.0a0
@@ -60031,11 +60122,11 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 1975203
-  timestamp: 1781743256931
-- conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py314h1bed58d_2.conda
-  sha256: ebcfb5e3afe1ae6ebc457faefc24adb7fd07c63fe81c9095b2b87d91881b3849
-  md5: 643883e53ff755cca1152803a76236b3
+  size: 1969239
+  timestamp: 1782111906711
+- conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py314h18e65a1_3.conda
+  sha256: 80a08d9943fb7d29eeaa256b508cea1e27226350a7afbacd3ab44a9de72da3fd
+  md5: b97b1b938638fb38b0cbf93fe21b18e3
   depends:
   - blosc >=1.21.6,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
@@ -60062,51 +60153,7 @@ packages:
   - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - openjpeg >=2.5.4,<3.0a0
-  - openjph >=0.29.0,<0.30.0a0
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
-  - snappy >=1.2.2,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - zfp >=1.0.1,<2.0a0
-  - zlib-ng >=2.3.3,<2.4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports: {}
-  size: 1983453
-  timestamp: 1781743255306
-- conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py314h6714266_2.conda
-  sha256: e8fef7ab51291300298d950c38959e31817a79e05e3e8ec2ccf09e413213c0ef
-  md5: f5efa0101809355685cf788beffb7224
-  depends:
-  - blosc >=1.21.6,<2.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - c-blosc2 >=3.1.4,<3.2.0a0
-  - charls >=2.4.4,<2.5.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - jxrlib >=1.1,<1.2.0a0
-  - lcms2 >=2.19.1,<3.0a0
-  - lerc >=4.1.0,<5.0a0
-  - libaec >=1.1.5,<2.0a0
-  - libavif16 >=1.4.2,<2.0a0
-  - libbrotlicommon >=1.2.0,<1.3.0a0
-  - libbrotlidec >=1.2.0,<1.3.0a0
-  - libbrotlienc >=1.2.0,<1.3.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libjxl >=0.11,<1.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libzopfli >=1.0.3,<1.1.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - numpy >=1.23,<3
-  - openjpeg >=2.5.4,<3.0a0
-  - openjph >=0.29.0,<0.30.0a0
+  - openjph >=0.30.1,<0.31.0a0
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314t
   - snappy >=1.2.2,<1.3.0a0
@@ -60119,8 +60166,52 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 2248749
-  timestamp: 1781743317386
+  size: 2247110
+  timestamp: 1782111986746
+- conda: https://prefix.dev/conda-forge/win-64/imagecodecs-2026.6.6-py314h37ae81f_3.conda
+  sha256: 8b2cfa90f066023a0c204541233b8c0b65e91c6dba8ee869508d6f1b5cac6c03
+  md5: 386ce929ba3ab9d2a418e58ad9512da0
+  depends:
+  - blosc >=1.21.6,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-blosc2 >=3.1.4,<3.2.0a0
+  - charls >=2.4.4,<2.5.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - jxrlib >=1.1,<1.2.0a0
+  - lcms2 >=2.19.1,<3.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libaec >=1.1.5,<2.0a0
+  - libavif16 >=1.4.2,<2.0a0
+  - libbrotlicommon >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libzopfli >=1.0.3,<1.1.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - numpy >=1.23,<3
+  - openjpeg >=2.5.4,<3.0a0
+  - openjph >=0.30.1,<0.31.0a0
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  - snappy >=1.2.2,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zfp >=1.0.1,<2.0a0
+  - zlib-ng >=2.3.3,<2.4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 1982163
+  timestamp: 1782111897418
 - conda: https://prefix.dev/conda-forge/win-64/ipython-7.30.1-py310h5588dad_0.tar.bz2
   sha256: 94c7c03ba25f57c0fdad6aac4463abf6b3dd46463af5a3c04d6605dd8ff5ea0f
   md5: 9dffa6829dc3b4df4bf81d4cd9fbe54a
@@ -60564,12 +60655,12 @@ packages:
     - libarrow >=20.0.0,<20.1.0a0
   size: 5596071
   timestamp: 1774283478907
-- conda: https://prefix.dev/conda-forge/win-64/libarrow-22.0.0-hbef6419_24_cpu.conda
-  build_number: 24
-  sha256: 0899623d8f5053ee98f2530163e2ad3a0c818032778a9a8ffe26f1a509af25a4
-  md5: 9cf63f6b3725ca34d743ce929ec4d540
+- conda: https://prefix.dev/conda-forge/win-64/libarrow-22.0.0-h54e786e_25_cpu.conda
+  build_number: 25
+  sha256: f1f6aba53690eb296b5823b661299420b81cd70d764bb67d8a68c9dc9fad81a1
+  md5: 7905cfc3870848dbc60d835d389d67d3
   depends:
-  - aws-crt-cpp >=0.40.0,<0.40.1.0a0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
   - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
   - azure-core-cpp >=1.16.3,<1.16.4.0a0
   - azure-identity-cpp >=1.13.3,<1.13.4.0a0
@@ -60594,22 +60685,22 @@ packages:
   - vc14_runtime >=14.44.35208
   - zstd >=1.5.7,<1.6.0a0
   constrains:
+  - arrow-cpp <0.0a0
   - apache-arrow-proc =*=cpu
   - parquet-cpp <0.0a0
-  - arrow-cpp <0.0a0
   license: Apache-2.0
   license_family: APACHE
   run_exports:
     weak:
     - libarrow >=22.0.0,<22.1.0a0
-  size: 4308839
-  timestamp: 1781585906384
-- conda: https://prefix.dev/conda-forge/win-64/libarrow-24.0.0-hbef6419_6_cpu.conda
-  build_number: 6
-  sha256: 8fcfe6bcd2646ab2a56319bd46d4672a0cf4bf6a7efda25b99328460ea034959
-  md5: a8be617f165d8f087a526e311d7f817a
+  size: 4292637
+  timestamp: 1781912035808
+- conda: https://prefix.dev/conda-forge/win-64/libarrow-24.0.0-h9dce539_8_cpu.conda
+  build_number: 8
+  sha256: 0881121701206aa0f1eeb5e1be1d5477eb280e5263d12e36a42e60825e946f70
+  md5: e462e521999f15f3a9167044ce93a11a
   depends:
-  - aws-crt-cpp >=0.40.0,<0.40.1.0a0
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
   - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
   - azure-core-cpp >=1.16.3,<1.16.4.0a0
   - azure-identity-cpp >=1.13.3,<1.13.4.0a0
@@ -60622,8 +60713,8 @@ packages:
   - libbrotlienc >=1.2.0,<1.3.0a0
   - libcrc32c >=1.1.2,<1.2.0a0
   - libcurl >=8.20.0,<9.0a0
-  - libgoogle-cloud >=3.5.0,<3.6.0a0
-  - libgoogle-cloud-storage >=3.5.0,<3.6.0a0
+  - libgoogle-cloud >=3.6.0,<3.7.0a0
+  - libgoogle-cloud-storage >=3.6.0,<3.7.0a0
   - libprotobuf >=6.33.5,<6.33.6.0a0
   - libzlib >=1.3.2,<2.0a0
   - lz4-c >=1.10.0,<1.11.0a0
@@ -60634,16 +60725,15 @@ packages:
   - vc14_runtime >=14.44.35208
   - zstd >=1.5.7,<1.6.0a0
   constrains:
+  - parquet-cpp <0.0a0
   - arrow-cpp <0.0a0
   - apache-arrow-proc =*=cpu
-  - parquet-cpp <0.0a0
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow >=24.0.0,<24.1.0a0
-  size: 4368698
-  timestamp: 1781585776653
+  size: 4395327
+  timestamp: 1782188286274
 - conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-16.0.0-he0c23c2_1_cpu.conda
   build_number: 1
   sha256: bf472ee7c1b695faeebc75baf347d840338ae5ec8419d4c1901f292e5855793b
@@ -60692,13 +60782,13 @@ packages:
     - libarrow-acero >=20.0.0,<20.1.0a0
   size: 466450
   timestamp: 1774283598578
-- conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-22.0.0-h7d8d6a5_24_cpu.conda
-  build_number: 24
-  sha256: 2c6d0d232d7a5a0919973e8aa317dab6d6bf554d4df27330bb1bb730384ef3ed
-  md5: 8b7d827235006ee30a38e27e9d6de5a6
+- conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-22.0.0-h7d8d6a5_25_cpu.conda
+  build_number: 25
+  sha256: 40dc4311c5def1102881a3fd29925f84cad50a710b7c877f55c8d20e0a31e0a7
+  md5: 52984f79bf0c6bdfc4c1bdb3e9bb83a7
   depends:
-  - libarrow 22.0.0 hbef6419_24_cpu
-  - libarrow-compute 22.0.0 h081cd8e_24_cpu
+  - libarrow 22.0.0 h54e786e_25_cpu
+  - libarrow-compute 22.0.0 h081cd8e_25_cpu
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
@@ -60707,31 +60797,30 @@ packages:
   run_exports:
     weak:
     - libarrow-acero >=22.0.0,<22.1.0a0
-  size: 474327
-  timestamp: 1781586151288
-- conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-24.0.0-h7d8d6a5_6_cpu.conda
-  build_number: 6
-  sha256: 59841c31b3758da96f26839f0952bc31c39dc4e4f75cb3099aac24ec5fb3f41c
-  md5: a15f4455bcd961cf4445e43c988a2063
+  size: 473776
+  timestamp: 1781912340838
+- conda: https://prefix.dev/conda-forge/win-64/libarrow-acero-24.0.0-h7d8d6a5_8_cpu.conda
+  build_number: 8
+  sha256: 0c3421c60a0a3b38d368c4fea9468086c845e62f3fd5e4ee0ffef87ce3c62f32
+  md5: fdf4cb9cd72e1c0053d63f18e5c1ff0e
   depends:
-  - libarrow 24.0.0 hbef6419_6_cpu
-  - libarrow-compute 24.0.0 h081cd8e_6_cpu
+  - libarrow 24.0.0 h9dce539_8_cpu
+  - libarrow-compute 24.0.0 h081cd8e_8_cpu
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow-acero >=24.0.0,<24.1.0a0
-  size: 446197
-  timestamp: 1781586027336
-- conda: https://prefix.dev/conda-forge/win-64/libarrow-compute-22.0.0-h081cd8e_24_cpu.conda
-  build_number: 24
-  sha256: 37ac9bb0bd6975eb33ad957e96555eab200c19ac3b655b7c3bb81d1690a7f9bd
-  md5: bb1d02f9580b0535cd0ba027ddb1e48c
+  size: 446066
+  timestamp: 1782188561191
+- conda: https://prefix.dev/conda-forge/win-64/libarrow-compute-22.0.0-h081cd8e_25_cpu.conda
+  build_number: 25
+  sha256: 34a44c7f058c1e71b6e2ad9775cacb2247217cbf6c40b7d6ab4d44dfe9909367
+  md5: d18bc1d53c3e0eb5533986d2c7f250db
   depends:
-  - libarrow 22.0.0 hbef6419_24_cpu
+  - libarrow 22.0.0 h54e786e_25_cpu
   - libre2-11 >=2025.11.5
   - libutf8proc >=2.11.3,<2.12.0a0
   - re2
@@ -60743,14 +60832,14 @@ packages:
   run_exports:
     weak:
     - libarrow-compute >=22.0.0,<22.1.0a0
-  size: 1786052
-  timestamp: 1781585995967
-- conda: https://prefix.dev/conda-forge/win-64/libarrow-compute-24.0.0-h081cd8e_6_cpu.conda
-  build_number: 6
-  sha256: 55ae30e2892555289fece185f02477e04bc5385a7aefea6512142923dbdbb5f6
-  md5: 88d7e5f4d9ee62baaee25ff145994e52
+  size: 1784851
+  timestamp: 1781912134626
+- conda: https://prefix.dev/conda-forge/win-64/libarrow-compute-24.0.0-h081cd8e_8_cpu.conda
+  build_number: 8
+  sha256: ee7eec54a2f1538ff117e37046af31812e2ac98ae60abe049fe0f72d26562aa2
+  md5: 4e25e77f9d106635ebb0999283898169
   depends:
-  - libarrow 24.0.0 hbef6419_6_cpu
+  - libarrow 24.0.0 h9dce539_8_cpu
   - libre2-11 >=2025.11.5
   - libutf8proc >=2.11.3,<2.12.0a0
   - re2
@@ -60758,12 +60847,11 @@ packages:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow-compute >=24.0.0,<24.1.0a0
-  size: 1754078
-  timestamp: 1781585852183
+  size: 1755117
+  timestamp: 1782188380565
 - conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-16.0.0-he0c23c2_1_cpu.conda
   build_number: 1
   sha256: 566e3ee4c69be5d1416fc696c8bc043e055c4f30af377ede50a1768ae99f971f
@@ -60818,15 +60906,15 @@ packages:
     - libarrow-dataset >=20.0.0,<20.1.0a0
   size: 451589
   timestamp: 1774283813404
-- conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-22.0.0-h7d8d6a5_24_cpu.conda
-  build_number: 24
-  sha256: 930a66e905ba52e1b5f076e454f3669148f81f7b6408a2361ce5d38772208d5c
-  md5: ebe8d705a598064f30bc3539f9ad78d1
+- conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-22.0.0-h7d8d6a5_25_cpu.conda
+  build_number: 25
+  sha256: 86bb12ace6e5c7606207820bf56c06a24018d9b6f8cd927cd7415e9fd2926b26
+  md5: 49ae5e5be5182caae87b4840c75bb494
   depends:
-  - libarrow 22.0.0 hbef6419_24_cpu
-  - libarrow-acero 22.0.0 h7d8d6a5_24_cpu
-  - libarrow-compute 22.0.0 h081cd8e_24_cpu
-  - libparquet 22.0.0 h7051d1f_24_cpu
+  - libarrow 22.0.0 h54e786e_25_cpu
+  - libarrow-acero 22.0.0 h7d8d6a5_25_cpu
+  - libarrow-compute 22.0.0 h081cd8e_25_cpu
+  - libparquet 22.0.0 h7051d1f_25_cpu
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
@@ -60835,27 +60923,26 @@ packages:
   run_exports:
     weak:
     - libarrow-dataset >=22.0.0,<22.1.0a0
-  size: 457790
-  timestamp: 1781586251442
-- conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-24.0.0-h7d8d6a5_6_cpu.conda
-  build_number: 6
-  sha256: 9b37ed77dfeeb1b8850e8645e486f2112468a7a89dbbcfa7c322e855c569ac52
-  md5: 12cd47306cce5e5fbbc19430b6115f72
+  size: 457981
+  timestamp: 1781912459526
+- conda: https://prefix.dev/conda-forge/win-64/libarrow-dataset-24.0.0-h7d8d6a5_8_cpu.conda
+  build_number: 8
+  sha256: fd80c9b7062d45e1b696975ba3ade7b568cad9c5d65437bab52324fa0f0cb931
+  md5: 5e3bba785b5005c49442ab808fb92679
   depends:
-  - libarrow 24.0.0 hbef6419_6_cpu
-  - libarrow-acero 24.0.0 h7d8d6a5_6_cpu
-  - libarrow-compute 24.0.0 h081cd8e_6_cpu
-  - libparquet 24.0.0 h7051d1f_6_cpu
+  - libarrow 24.0.0 h9dce539_8_cpu
+  - libarrow-acero 24.0.0 h7d8d6a5_8_cpu
+  - libarrow-compute 24.0.0 h081cd8e_8_cpu
+  - libparquet 24.0.0 h7051d1f_8_cpu
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow-dataset >=24.0.0,<24.1.0a0
-  size: 428287
-  timestamp: 1781586132971
+  size: 428335
+  timestamp: 1782188679589
 - conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-16.0.0-h1f0e801_1_cpu.conda
   build_number: 1
   sha256: af0c822c5e96f78f7eee94e9948a4e308b99d2b316986f3c3732043ed165c15b
@@ -60919,16 +61006,16 @@ packages:
     - libarrow-substrait >=20.0.0,<20.1.0a0
   size: 369202
   timestamp: 1774283981103
-- conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-22.0.0-h524e9bd_24_cpu.conda
-  build_number: 24
-  sha256: 95435edf9621da315462d3f908b8a481e88df93b371a4f0ca4f73457a63973db
-  md5: 65d07aba46c5a3adc6f0ae6e33aab70b
+- conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-22.0.0-h524e9bd_25_cpu.conda
+  build_number: 25
+  sha256: 0d9dbbfe8032eb2606863625df983bdb96d7f74e0f502f1fd36b48db742ad887
+  md5: c6898835285fc2565b3de78800041bff
   depends:
   - libabseil * cxx17*
   - libabseil >=20260107.1,<20260108.0a0
-  - libarrow 22.0.0 hbef6419_24_cpu
-  - libarrow-acero 22.0.0 h7d8d6a5_24_cpu
-  - libarrow-dataset 22.0.0 h7d8d6a5_24_cpu
+  - libarrow 22.0.0 h54e786e_25_cpu
+  - libarrow-acero 22.0.0 h7d8d6a5_25_cpu
+  - libarrow-dataset 22.0.0 h7d8d6a5_25_cpu
   - libprotobuf >=6.33.5,<6.33.6.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
@@ -60938,29 +61025,28 @@ packages:
   run_exports:
     weak:
     - libarrow-substrait >=22.0.0,<22.1.0a0
-  size: 389068
-  timestamp: 1781586287268
-- conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-24.0.0-h524e9bd_6_cpu.conda
-  build_number: 6
-  sha256: 8e1147f34608300d9ba55c911b748f552d62688651ada3b3f4025be1899b51d7
-  md5: d6728d7115be6ffe329293898dfc7d66
+  size: 389193
+  timestamp: 1781912501393
+- conda: https://prefix.dev/conda-forge/win-64/libarrow-substrait-24.0.0-h524e9bd_8_cpu.conda
+  build_number: 8
+  sha256: a6419bd428e449d340229369529806b2d38ba3ed2030a6db495a9d0ea054b58d
+  md5: 26cc2bc5c369c96eeaf10289e80970d9
   depends:
   - libabseil * cxx17*
   - libabseil >=20260107.1,<20260108.0a0
-  - libarrow 24.0.0 hbef6419_6_cpu
-  - libarrow-acero 24.0.0 h7d8d6a5_6_cpu
-  - libarrow-dataset 24.0.0 h7d8d6a5_6_cpu
+  - libarrow 24.0.0 h9dce539_8_cpu
+  - libarrow-acero 24.0.0 h7d8d6a5_8_cpu
+  - libarrow-dataset 24.0.0 h7d8d6a5_8_cpu
   - libprotobuf >=6.33.5,<6.33.6.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libarrow-substrait >=24.0.0,<24.1.0a0
-  size: 362211
-  timestamp: 1781586167538
+  size: 361992
+  timestamp: 1782188719264
 - conda: https://prefix.dev/conda-forge/win-64/libavif16-1.4.2-h7e7b026_1.conda
   sha256: a1c7aa4a6a5031704d362edf937f9a1849761efa074d5c3a0a10a3b1dda5a42a
   md5: 0cfadc4acdc50ea30484a372cf3207b5
@@ -61444,6 +61530,28 @@ packages:
     - libgoogle-cloud >=3.5.0,<3.6.0a0
   size: 18087
   timestamp: 1780034913635
+- conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-3.6.0-he22669a_0.conda
+  sha256: 11cb7ec822abcf6feedcd778f1f71d889b4c1b270949927aa468a6b24abe230d
+  md5: 24239981d980d39030515bc50f696e2f
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libgrpc >=1.78.1,<1.79.0a0
+  - libopentelemetry-cpp >=1.27.0,<1.28.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - libgoogle-cloud 3.6.0 *_0
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - libgoogle-cloud >=3.6.0,<3.7.0a0
+  size: 17255
+  timestamp: 1781928103484
 - conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-storage-2.23.0-hb581fae_1.conda
   sha256: b7be440cb21b2c8c41064f1a334b9117ed5e4f0b98c5315650194161f7702283
   md5: af19093e2d4171ddef39e9d6457c4e2e
@@ -61520,6 +61628,25 @@ packages:
     - libgoogle-cloud-storage >=3.5.0,<3.6.0a0
   size: 18067
   timestamp: 1780035234126
+- conda: https://prefix.dev/conda-forge/win-64/libgoogle-cloud-storage-3.6.0-he04ea4c_0.conda
+  sha256: 5c62334045397f97437f7cb2d44672914eb2facc12839aaac87386f2aeebd05b
+  md5: 0f4a153aa13c9a98de0be992cfd9f6bb
+  depends:
+  - libabseil
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl
+  - libgoogle-cloud 3.6.0 he22669a_0
+  - libzlib >=1.3.2,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - libgoogle-cloud-storage >=3.6.0,<3.7.0a0
+  size: 17216
+  timestamp: 1781928427840
 - conda: https://prefix.dev/conda-forge/win-64/libgrpc-1.62.2-h5273850_0.conda
   sha256: 08794bf5ea0e19ac23ed47d0f8699b5c05c46f14334b41f075e53bac9bbf97d8
   md5: 2939e4b5baecfeac1e8dee5c4f579f1a
@@ -62039,12 +62166,12 @@ packages:
     - libparquet >=20.0.0,<20.1.0a0
   size: 841340
   timestamp: 1774283764941
-- conda: https://prefix.dev/conda-forge/win-64/libparquet-22.0.0-h7051d1f_24_cpu.conda
-  build_number: 24
-  sha256: 99f7a946b2140f1b640bddce2a27deccdf1c545c6b3c5f53d88206659a1ca1ac
-  md5: 42a40edd7fa53ad0be1b97a89f29d3cd
+- conda: https://prefix.dev/conda-forge/win-64/libparquet-22.0.0-h7051d1f_25_cpu.conda
+  build_number: 25
+  sha256: 29ad79cb72dcbb905751521735777aa26a9000e2e6cb62136e456654c6084078
+  md5: 9ae7784ecc697c73e5b1ad3196bb538f
   depends:
-  - libarrow 22.0.0 hbef6419_24_cpu
+  - libarrow 22.0.0 h54e786e_25_cpu
   - libthrift >=0.22.0,<0.22.1.0a0
   - openssl >=3.5.7,<4.0a0
   - ucrt >=10.0.20348.0
@@ -62055,26 +62182,25 @@ packages:
   run_exports:
     weak:
     - libparquet >=22.0.0,<22.1.0a0
-  size: 946098
-  timestamp: 1781586117711
-- conda: https://prefix.dev/conda-forge/win-64/libparquet-24.0.0-h7051d1f_6_cpu.conda
-  build_number: 6
-  sha256: 82f29cee77126d36bf8d2450dd6b3cfd4968bc9f38411421c493aafa3ef18ed0
-  md5: ed38600249557831d87e5fe9f5bf7ee7
+  size: 945475
+  timestamp: 1781912299030
+- conda: https://prefix.dev/conda-forge/win-64/libparquet-24.0.0-h7051d1f_8_cpu.conda
+  build_number: 8
+  sha256: 0e7710a5b804f0e202a89d03a8fc587d0c795a2e9a050fb8d4765a3b4d2bd1f5
+  md5: 743708ec12c6c7ae1570b80e0f0067e9
   depends:
-  - libarrow 24.0.0 hbef6419_6_cpu
+  - libarrow 24.0.0 h9dce539_8_cpu
   - libthrift >=0.22.0,<0.22.1.0a0
   - openssl >=3.5.7,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: Apache-2.0
-  license_family: APACHE
   run_exports:
     weak:
     - libparquet >=24.0.0,<24.1.0a0
-  size: 966970
-  timestamp: 1781585990338
+  size: 966046
+  timestamp: 1782188523630
 - conda: https://prefix.dev/conda-forge/win-64/libpng-1.6.58-h7351971_0.conda
   sha256: 218913aeee391460bd0e341b834dbd9c6fa6ae0a4276c0c300266cc99a816a28
   md5: 52f1280563f3b48b5f75414cd2d15dd1
@@ -63324,20 +63450,20 @@ packages:
     - mbedtls >=3.6.3.1,<3.7.0a0
   size: 1208550
   timestamp: 1747803445770
-- conda: https://prefix.dev/conda-forge/win-64/menuinst-2.5.0-py314h13fbf68_0.conda
-  sha256: f972f3a24e0d3d66396d9de2103be67eb27650692a8050e435ef0ee483ef2a74
-  md5: 0fa4ffd1a0b474de70a2c37824faecff
+- conda: https://prefix.dev/conda-forge/win-64/menuinst-2.5.0-py314hb98de8c_1.conda
+  sha256: 60b54e04e997471f697872c64cbab4d52bca06286a74b3ef898ced58bcdaff78
+  md5: bc069b5b1bd007235f46cf21989ae558
   depends:
-  - python >=3.14,<3.15.0a0
-  - python_abi 3.14.* *_cp314
+  - python
   - tomli-w
-  - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.14.* *_cp314
   license: BSD-3-Clause AND MIT
   run_exports: {}
-  size: 187980
-  timestamp: 1780907009769
+  size: 198561
+  timestamp: 1782062732702
 - conda: https://prefix.dev/conda-forge/win-64/mkl-2024.2.2-h57928b3_16.conda
   sha256: ce841e7c3898764154a9293c0f92283c1eb28cdacf7a164c94b632a6af675d91
   md5: 5cddc979c74b90cf5e5cda4f97d5d8bb
@@ -63493,9 +63619,9 @@ packages:
     - mpfr >=4.2.2,<5.0a0
   size: 734113
   timestamp: 1773415369651
-- conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.0-py310he9f1925_0.conda
-  sha256: 92f2502740ff08daa474d05a5173b0a2f6c2ee64c24123c47883c1b2678df265
-  md5: 418c76f28bdc85b2b39b860ed36404db
+- conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.1-py310he9f1925_0.conda
+  sha256: d5d43239e2461218271e84269164f444cdbe2270e43379e6530889cd84e817cb
+  md5: 433aee5401006f5869af0841c0a42edc
   depends:
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
@@ -63505,11 +63631,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 82245
-  timestamp: 1781786182341
-- conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.0-py311h3fd045d_0.conda
-  sha256: a900bd9957be03e9d7512d798ed7280833505962ac78effe36ecd47e96b647e7
-  md5: 3dbeedef316851cc21ed73317a466254
+  size: 82152
+  timestamp: 1782070468719
+- conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.1-py311h3fd045d_0.conda
+  sha256: 8dc33bccd136a749b3abe3c8e983bcaf7570c44d3e9620bcf5320a8411ce415d
+  md5: ccd830e80867f0a0b0eb729636818976
   depends:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
@@ -63519,11 +63645,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 89522
-  timestamp: 1781786254149
-- conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.0-py312hf90b1b7_0.conda
-  sha256: 025797912d97f871cc22ad876ec75e18dc444c96fda0b7dedefc97804369a8a8
-  md5: 39976dfa176ff03e1cd55f493c311899
+  size: 89550
+  timestamp: 1782070466727
+- conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.1-py312hf90b1b7_0.conda
+  sha256: 706651825726865f4b93f8437507da94b5d7060476a3be09d33d8d4176aef886
+  md5: 7be9af13377c126be5c6a2fd28af9b6c
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -63533,11 +63659,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 89093
-  timestamp: 1781786199855
-- conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.0-py313hf069bd2_0.conda
-  sha256: a1e62fdcb37a9b721a5972a4ef633b0c05e3c593495d36c69fb81ee036f2e388
-  md5: f64d6bdb420a87e3c89d05b5791c88a0
+  size: 89264
+  timestamp: 1782070483584
+- conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.1-py313hf069bd2_0.conda
+  sha256: 08cfc45c7160779556abc25ea2ac1352fc68c05a7db5c8f7eaa051c928ce93b8
+  md5: 83ede6d6d5227244621c126264ccaea9
   depends:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
@@ -63547,11 +63673,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 89392
-  timestamp: 1781786187620
-- conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.0-py314h0fe37e9_0.conda
-  sha256: 47efb1ab6f6169ac2e58136608441f862517eeac771cc428ecdc19ab1f1aa83f
-  md5: 343488eb1935c6c5c0063ed6119ad21b
+  size: 89970
+  timestamp: 1782070487087
+- conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.1-py314h0fe37e9_0.conda
+  sha256: 7f920dd29d94b436a9f88fdabcc6897deeba809a6c6b42b236bb4a2dff41ac64
+  md5: b45e7e63b88f81eda2dec763688c19b5
   depends:
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314t
@@ -63561,11 +63687,11 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 97605
-  timestamp: 1781786200576
-- conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.0-py314h909e829_0.conda
-  sha256: 05e90a31a89b72ed70163114e502e6def0cee6fdf1e3cbcce6fe12cad3748e60
-  md5: b69aea584bb63ae7847793743b02296e
+  size: 97712
+  timestamp: 1782070480496
+- conda: https://prefix.dev/conda-forge/win-64/msgpack-python-1.2.1-py314h909e829_0.conda
+  sha256: 5dc2c51a980e406faf3f06c3674792fb987f20fbcb5620c6860b6982f93f995f
+  md5: a2bf7491b2d71489532f20db59f470c3
   depends:
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314
@@ -63575,8 +63701,8 @@ packages:
   license: Apache-2.0
   license_family: Apache
   run_exports: {}
-  size: 89649
-  timestamp: 1781786179014
+  size: 90559
+  timestamp: 1782070458677
 - conda: https://prefix.dev/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
   sha256: 99358d58d778abee4dca82ad29fb58058571f19b0f86138363c260049d4ac7f1
   md5: b0309b72560df66f71a9d5e34a5efdfa
@@ -64113,27 +64239,6 @@ packages:
     - numpy >=1.21,<3
   size: 7028854
   timestamp: 1747545411647
-- conda: https://prefix.dev/conda-forge/win-64/numpy-2.4.6-py312ha3f287d_0.conda
-  sha256: 9abf760418f2497f87715fa35d1c9cea5416be9edd1b166a218dfabe3b16e5be
-  md5: 1dd6f497cc8369359f024463426e323c
-  depends:
-  - python
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - liblapack >=3.9.0,<4.0a0
-  - python_abi 3.12.* *_cp312
-  - libcblas >=3.9.0,<4.0a0
-  - libblas >=3.9.0,<4.0a0
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  run_exports:
-    weak:
-    - numpy >=1.23,<3
-  size: 7169449
-  timestamp: 1779169226122
 - conda: https://prefix.dev/conda-forge/win-64/numpy-2.4.6-py313ha8dc839_0.conda
   sha256: 012fabf6b70d8a58ce608ae5ece3a59f8cc6d582847f9a8ff42d9a10b4215a51
   md5: 1546190d6b2a2605ad960693018b874b
@@ -64197,6 +64302,27 @@ packages:
     - numpy >=1.23,<3
   size: 7482657
   timestamp: 1779169231603
+- conda: https://prefix.dev/conda-forge/win-64/numpy-2.5.0-py312ha3f287d_0.conda
+  sha256: 995e108a43e85fd3cbd17f76e3ecc04a7ee5537bc242190e1c5e227867d9db03
+  md5: 2d395ffbe339689fb2b0a4b051960ec9
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - liblapack >=3.9.0,<4.0a0
+  - libblas >=3.9.0,<4.0a0
+  - python_abi 3.12.* *_cp312
+  - libcblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    weak:
+    - numpy >=1.25,<3
+  size: 7287417
+  timestamp: 1782112572174
 - conda: https://prefix.dev/conda-forge/win-64/onemkl-license-2026.0.0-h57928b3_908.conda
   sha256: 42ad15cbb3bf31830efa04d4b86dd2d5c0dd590c86f98adcd3c8c1f75acf5dd5
   md5: 9c9303e08b50e09f5c23e1dac99d0936
@@ -64250,9 +64376,9 @@ packages:
     - openjph >=0.27.4,<0.28.0a0
   size: 217745
   timestamp: 1780596842400
-- conda: https://prefix.dev/conda-forge/win-64/openjph-0.29.0-hf13a347_0.conda
-  sha256: 948a43fc97ea0f0ba940dd745d59a4a2fed35ba8e894d800c048043e7db6a8b8
-  md5: 8df87358281e793020720136f9fe4b39
+- conda: https://prefix.dev/conda-forge/win-64/openjph-0.30.1-hf13a347_0.conda
+  sha256: 5deaf995e476e6928dedced3254025b568a70a905f04ad23fd150d9abe558b91
+  md5: 47ed976bdc702ab527737d6dc0d7e6d7
   depends:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
@@ -64262,9 +64388,9 @@ packages:
   license_family: BSD
   run_exports:
     weak:
-    - openjph >=0.29.0,<0.30.0a0
-  size: 223775
-  timestamp: 1781694348626
+    - openjph >=0.30.1,<0.31.0a0
+  size: 226246
+  timestamp: 1782091209917
 - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
   sha256: cb6e7ba0d010ee0d3249ce9886de3d7613d26d9965d4c95666fa66b9c4c31001
   md5: e99f95734a326c0fd4d02bbd995150d4
@@ -65116,10 +65242,10 @@ packages:
   run_exports: {}
   size: 13201940
   timestamp: 1781020758113
-- conda: https://prefix.dev/conda-forge/win-64/py-rattler-build-0.66.1-py310hdba2031_0.conda
+- conda: https://prefix.dev/conda-forge/win-64/py-rattler-build-0.67.0-py310hdba2031_0.conda
   noarch: python
-  sha256: 3648c035158fc3ec65770dce69b2cd4563978e2ca1696e3da25fd6dd8322ca2f
-  md5: 024391a87154c906a0923137bca5bd69
+  sha256: a88c6f1c8c850957e0b2c4b53d412f053a83a214cfb8fd86818616cf74730505
+  md5: 038cc830eed2591d0b5eb40ebbd76234
   depends:
   - python
   - vc >=14.3,<15
@@ -65128,10 +65254,9 @@ packages:
   - _python_abi3_support 1.*
   - cpython >=3.10
   license: BSD-3-Clause
-  license_family: BSD
   run_exports: {}
-  size: 18692144
-  timestamp: 1781383708454
+  size: 18128813
+  timestamp: 1782144075352
 - conda: https://prefix.dev/conda-forge/win-64/pyarrow-16.0.0-py310h3bcd3f7_0.conda
   sha256: 61e98a6ddd199ce0c10fe3c1421226105f65c53f826aceae1bb21be4bf1493e8
   md5: 9fa1aafe7d85893231667e55ae2565cb
@@ -66549,18 +66674,17 @@ packages:
     - qt6-main >=6.11.1,<7.0a0
   size: 89576886
   timestamp: 1780400596481
-- conda: https://prefix.dev/conda-forge/win-64/rattler-build-0.66.2-he94b42d_0.conda
-  sha256: 6af89e1a8181450fce908129e24474c5c14883f69775ed1a5186d2c17146b05e
-  md5: 7c7623e4fac72805bc515d0e6dbf0ddd
+- conda: https://prefix.dev/conda-forge/win-64/rattler-build-0.67.0-he94b42d_0.conda
+  sha256: d444b237181df08ff14d6b40101832cb1aabb4e88ed73633a58ee70318ab802a
+  md5: 93bf7de134af404e183be6089766060a
   depends:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   license: BSD-3-Clause
-  license_family: BSD
   run_exports: {}
-  size: 19710927
-  timestamp: 1781721867394
+  size: 19876803
+  timestamp: 1782150883801
 - conda: https://prefix.dev/conda-forge/win-64/rav1e-0.8.1-h007690e_0.conda
   sha256: 4ee3caf1260c946e756f2be4cadf720592391b24fce652a67255e4386880249b
   md5: b0ab2fc43381024f5a694e6f5f54c973
@@ -67254,16 +67378,16 @@ packages:
   run_exports: {}
   size: 15241561
   timestamp: 1779876161272
-- conda: https://prefix.dev/conda-forge/win-64/scipy-1.17.1-py312h9b3c559_1.conda
-  sha256: b8a13caeb04f2b943e7c617a4b76805450618716b38688ee8d3f79b60d529e84
-  md5: 0b8c96ed1c04732ff8eb5d481b44c43c
+- conda: https://prefix.dev/conda-forge/win-64/scipy-1.18.0-py312h9b3c559_0.conda
+  sha256: 68e7c49be1e409ed2ac44f2977581d58a9a4d12e6724a4a5c5470348e5e40f34
+  md5: e1fee578f6c533ff532693143919afde
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
   - numpy <2.7
   - numpy >=1.23,<3
-  - numpy >=1.25.2
+  - numpy >=2.0.0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
@@ -67272,18 +67396,18 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 15078490
-  timestamp: 1779876221509
-- conda: https://prefix.dev/conda-forge/win-64/scipy-1.17.1-py313he51e9a2_1.conda
-  sha256: a12318ed880dacdc573b73a34532f0c08daa883cd2dc7294ac68b8bab9b94196
-  md5: 0f727c3f9910796063e5ba4c2c7d9c89
+  size: 15077907
+  timestamp: 1781914327034
+- conda: https://prefix.dev/conda-forge/win-64/scipy-1.18.0-py313he51e9a2_0.conda
+  sha256: 8533a4b49bca970a5eaad9d0534bcc4ecb05e606735ffdb1032d95c47fc0673a
+  md5: ddf3fb8bab2ad4ffefad64803ffdbdfb
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
   - numpy <2.7
   - numpy >=1.23,<3
-  - numpy >=1.25.2
+  - numpy >=2.0.0
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   - ucrt >=10.0.20348.0
@@ -67292,18 +67416,18 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 15055761
-  timestamp: 1779876196348
-- conda: https://prefix.dev/conda-forge/win-64/scipy-1.17.1-py314h221f224_1.conda
-  sha256: f807e97b237b8528118557ef05073a9f4586c845f2431b25466aa88d268e7274
-  md5: 4e015e3de1f22a035a29ceba386f91aa
+  size: 15248913
+  timestamp: 1781914321655
+- conda: https://prefix.dev/conda-forge/win-64/scipy-1.18.0-py314h221f224_0.conda
+  sha256: 952db1642d707d2572b511b1207bfd8e8c114fdc99930c400b547eb8ab92ac19
+  md5: a925cfb1429da2b1312c86516ae7c418
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
   - numpy <2.7
   - numpy >=1.23,<3
-  - numpy >=1.25.2
+  - numpy >=2.0.0
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314
   - ucrt >=10.0.20348.0
@@ -67312,18 +67436,18 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 15229740
-  timestamp: 1779876154782
-- conda: https://prefix.dev/conda-forge/win-64/scipy-1.17.1-py314h9c5632b_1.conda
-  sha256: 20577acc20105a7281f807f906242394149d73976583e42e2a8f501489315695
-  md5: 4e3bf6fcbb827ea0e69193c1a10bbdb1
+  size: 15353018
+  timestamp: 1781914001107
+- conda: https://prefix.dev/conda-forge/win-64/scipy-1.18.0-py314h9c5632b_0.conda
+  sha256: 08dadda9209e1693953ec244c71d1f97410eb5dcbe458e7a08a89dc0d378fae4
+  md5: 0450441520a30089f6ef8953802cf565
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
   - numpy <2.7
   - numpy >=1.23,<3
-  - numpy >=1.25.2
+  - numpy >=2.0.0
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314t
   - ucrt >=10.0.20348.0
@@ -67332,8 +67456,8 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   run_exports: {}
-  size: 15506983
-  timestamp: 1779875914035
+  size: 15466992
+  timestamp: 1781914347820
 - conda: https://prefix.dev/conda-forge/win-64/setuptools-60.10.0-py310h5588dad_0.tar.bz2
   sha256: 6f6a82902e346f679f8c90a5a082d2e93de471deaafc1a19400589dacf886fc8
   md5: fc0761e47be17fac91b83e277788b1da
@@ -67655,6 +67779,43 @@ packages:
     - tiledb >=2.26.2,<2.27.0a0
   size: 3120562
   timestamp: 1732208766769
+- conda: https://prefix.dev/conda-forge/win-64/tiledb-2.30.1-h3779ff6_13.conda
+  sha256: c25dfd17decd15321599e8733733d2f8ff606d23a5d937b4189726b7630dffc3
+  md5: c80b62fa187696f5b874f89f6bda8532
+  depends:
+  - aws-crt-cpp >=0.40.1,<0.40.2.0a0
+  - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
+  - azure-core-cpp >=1.16.3,<1.16.4.0a0
+  - azure-identity-cpp >=1.13.3,<1.13.4.0a0
+  - azure-storage-blobs-cpp >=12.18.0,<12.18.1.0a0
+  - azure-storage-common-cpp >=12.14.0,<12.14.1.0a0
+  - azure-storage-files-datalake-cpp >=12.16.0,<12.16.1.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-blosc2 >=3.1.4,<3.2.0a0
+  - capnproto >=1.4.0,<1.4.1.0a0
+  - fmt >=12.1.0,<12.2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libgoogle-cloud >=3.5.0,<3.6.0a0
+  - libgoogle-cloud-storage >=3.5.0,<3.6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - openssl >=3.5.7,<4.0a0
+  - spdlog >=1.17.0,<1.18.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - tiledb >=2.30.1,<2.31.0a0
+  size: 2960468
+  timestamp: 1781892424735
 - conda: https://prefix.dev/conda-forge/win-64/tiledb-2.30.1-h3c24166_6.conda
   sha256: 1fb6ffa9cc6647fba53117043695dc04e8a90326019f095214efedc44db55eac
   md5: f497bd06b6c2824ea374286d75aa5966
@@ -67692,43 +67853,6 @@ packages:
     - tiledb >=2.30.1,<2.31.0a0
   size: 2917614
   timestamp: 1777733744259
-- conda: https://prefix.dev/conda-forge/win-64/tiledb-2.30.1-hcf33648_12.conda
-  sha256: 6af53401ad1953549088280db21542f7ff394e93b371b2828ba0988b586df284
-  md5: ea2c57c7e70c8fa4ddf806231db15595
-  depends:
-  - aws-crt-cpp >=0.40.0,<0.40.1.0a0
-  - aws-sdk-cpp >=1.11.747,<1.11.748.0a0
-  - azure-core-cpp >=1.16.3,<1.16.4.0a0
-  - azure-identity-cpp >=1.13.3,<1.13.4.0a0
-  - azure-storage-blobs-cpp >=12.18.0,<12.18.1.0a0
-  - azure-storage-common-cpp >=12.14.0,<12.14.1.0a0
-  - azure-storage-files-datalake-cpp >=12.16.0,<12.16.1.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - c-blosc2 >=3.1.3,<3.2.0a0
-  - capnproto >=1.4.0,<1.4.1.0a0
-  - fmt >=12.1.0,<12.2.0a0
-  - libabseil * cxx17*
-  - libabseil >=20260107.1,<20260108.0a0
-  - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libgoogle-cloud >=3.5.0,<3.6.0a0
-  - libgoogle-cloud-storage >=3.5.0,<3.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - openssl >=3.5.7,<4.0a0
-  - spdlog >=1.17.0,<1.18.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - zstd >=1.5.7,<1.6.0a0
-  license: MIT
-  license_family: MIT
-  run_exports:
-    weak:
-    - tiledb >=2.30.1,<2.31.0a0
-  size: 2960995
-  timestamp: 1781620225777
 - conda: https://prefix.dev/conda-forge/win-64/tiledb-py-0.27.0-py310h44f0d9c_0.conda
   sha256: b17aad7aa2926b7e559988c608a2b66c86ef9952f2ee7935c3e36631e495429a
   md5: 367e16cf0945c77cee990cc9d8fdbfe8
@@ -67980,17 +68104,17 @@ packages:
   run_exports: {}
   size: 406126
   timestamp: 1770909191618
-- conda: https://prefix.dev/conda-forge/win-64/uv-0.11.22-h2229357_0.conda
-  sha256: 1f3de05734ffe66e8d51e4a983e2d97cb6405a86c2ba9fd3c2d976a2b4b7f93f
-  md5: 3583025bdb3cbf793eb3e96dad92784f
+- conda: https://prefix.dev/conda-forge/win-64/uv-0.11.23-h2229357_0.conda
+  sha256: 48e2c6f4f467b20869ea687d405f6322e31596d6a9d86c681c89bbc5961afc86
+  md5: ca6931cee038567aae0b9bb80d9fe27a
   depends:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   license: Apache-2.0 OR MIT
   run_exports: {}
-  size: 20194796
-  timestamp: 1781836450212
+  size: 20225500
+  timestamp: 1781912805899
 - conda: https://prefix.dev/conda-forge/win-64/vc-14.5-h1b7c187_39.conda
   sha256: 17693b60cb54f80c60275f003f3bfc1b128af56dbfd65c4fae37c64eeb755ce1
   md5: 2eacea63f545b97342da520df6854276
@@ -68047,9 +68171,9 @@ packages:
   license_family: MIT
   run_exports: {}
   size: 1176306
-- conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.1-py310h29418f3_0.conda
-  sha256: ee2ac060f13614d0ab8704b575fde7a01bb5a98553dca247a2b30484d56e2cc6
-  md5: 10dc2ab1c2723bd43625f7008d17eee9
+- conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.2-py310h29418f3_0.conda
+  sha256: 7848e84917e6ad109d9a4b6e05ce05df6d4e8a605b80bb66d4b69fa034545c6b
+  md5: 9c3e7f2be0a303181ac4ab6c691ab7e9
   depends:
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
@@ -68057,13 +68181,12 @@ packages:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 98705
-  timestamp: 1779477553854
-- conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.1-py311h3485c13_0.conda
-  sha256: 485da0c7198443673e0751f24cd2859aa9bb635f18a4442279cb67a5fec1fbfa
-  md5: 8704eb4796a7f8b168ad17d304f6e6ec
+  size: 100140
+  timestamp: 1782133736179
+- conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.2-py311h3485c13_0.conda
+  sha256: 75a9ba8643451f10f564f6df2151d1ae42b4841fa89f062441bc37b5e067f780
+  md5: 7b1b711eae41811be82ad2407103d8cc
   depends:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
@@ -68071,13 +68194,12 @@ packages:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 113973
-  timestamp: 1779477573169
-- conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.1-py312he06e257_0.conda
-  sha256: 81ac3d1b792ace6ef6994a87cc374459d946479fac122f7d57251727d39a0795
-  md5: 1f8d2f7e4468f75b510c98310e5a9a8e
+  size: 115115
+  timestamp: 1782133736690
+- conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.2-py312he06e257_0.conda
+  sha256: 8fa16daca416ab83f64b8731c33a6f211f4e703f02d03c7eabda45a6a3320657
+  md5: 573f686209e82c06daef1e43ee79975f
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -68085,13 +68207,12 @@ packages:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 112334
-  timestamp: 1779477535349
-- conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.1-py313h5ea7bf4_0.conda
-  sha256: e85fad137b29fd85443e58aeb3ee112a94735e68ff284914184c313f58b75192
-  md5: 8cdae7c5ce1da55e934aee78e105444a
+  size: 113162
+  timestamp: 1782133745435
+- conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.2-py313h5ea7bf4_0.conda
+  sha256: d928cb683d6acc009f535cb250a1b817b3ccedc1bb3ba710dc0b9ad280719b7f
+  md5: 58665753e89a90fa11f81bffd6f700f6
   depends:
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
@@ -68099,13 +68220,12 @@ packages:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 114190
-  timestamp: 1779477543719
-- conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.1-py314h5a2d7ad_0.conda
-  sha256: 6b683117cae0cff35bdb046f3922953e4abf76879241685cffa9972c72111bcd
-  md5: 96d29e6db8474a40cc4b24e4cc3e5361
+  size: 114396
+  timestamp: 1782133745518
+- conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.2-py314h5a2d7ad_0.conda
+  sha256: 93cbcaf37eff31ccb2cdaca883f8be991e7c5098b925e8372c3ac615fef47197
+  md5: db00af109424ec883fe7d239a4ccee44
   depends:
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314
@@ -68113,13 +68233,12 @@ packages:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 115257
-  timestamp: 1779477545905
-- conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.1-py314hac7e1cd_0.conda
-  sha256: dc6b0dcd3db521df46c658100151bf2d00c1f7ceb09f7883eeb2dc8669693a23
-  md5: a2cf1bb5cf443f4963b048d31968cedb
+  size: 115544
+  timestamp: 1782133735742
+- conda: https://prefix.dev/conda-forge/win-64/wrapt-2.2.2-py314hac7e1cd_0.conda
+  sha256: abc7d621f36ec16ad82bb2aa682ac9ea327c83eb0a9c592e8bb40d86866bc1d9
+  md5: 4657570b603207c61ecd5f8c7fe491b2
   depends:
   - python >=3.14,<3.15.0a0
   - python_abi 3.14.* *_cp314t
@@ -68127,10 +68246,9 @@ packages:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: BSD-2-Clause
-  license_family: BSD
   run_exports: {}
-  size: 117090
-  timestamp: 1779477563205
+  size: 117572
+  timestamp: 1782133747456
 - conda: https://prefix.dev/conda-forge/win-64/xorg-kbproto-1.0.7-hcd874cb_1002.tar.bz2
   sha256: 5b16e1ca1ecc0d2907f236bc4d8e6ecfd8417db013c862a01afb7f9d78e48c09
   md5: 8d11c1dac4756ca57e78c1bfe173bba4
@@ -68709,36 +68827,7 @@ packages:
     - zstd >=1.5.7,<1.6.0a0
   size: 388453
   timestamp: 1764777142545
-- conda_source: brotli-python[40f8be4d] @ continuous_integration/pixi-recipes/brotli
-  variants:
-    target_platform: noarch
-  depends:
-  - python
-  - python *
-  source:
-    path: ''
-  host_packages:
-  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-  - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
-  - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
-  - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
-  - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.53.2-hf5d6505_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
-  - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/python-3.14.6-h4b44e0e_100_cp314.conda
-  - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
-  - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/uv-0.11.22-h2229357_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/vc-14.5-h1b7c187_39.conda
-  - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
-  - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
-  - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-- conda_source: brotli-python[d832c062] @ continuous_integration/pixi-recipes/brotli
+- conda_source: brotli-python[8a448670] @ continuous_integration/pixi-recipes/brotli
   variants:
     target_platform: noarch
   depends:
@@ -68765,13 +68854,13 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
   - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/uv-0.11.22-h26efc2c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/uv-0.11.23-h26efc2c_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
   - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-- conda_source: brotli-python[dc880c4c] @ continuous_integration/pixi-recipes/brotli
+- conda_source: brotli-python[ad886b61] @ continuous_integration/pixi-recipes/brotli
   variants:
     target_platform: noarch
   depends:
@@ -68799,13 +68888,42 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-aarch64/python-3.14.6-hc679e19_100_cp314.conda
   - conda: https://prefix.dev/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
   - conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/uv-0.11.22-haa595b2_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/uv-0.11.23-haa595b2_0.conda
   - conda: https://prefix.dev/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
   - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-- conda_source: brotli-python[ef28090b] @ continuous_integration/pixi-recipes/brotli
+- conda_source: brotli-python[cb55e4df] @ continuous_integration/pixi-recipes/brotli
+  variants:
+    target_platform: noarch
+  depends:
+  - python
+  - python *
+  source:
+    path: ''
+  host_packages:
+  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+  - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
+  - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
+  - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
+  - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.53.2-hf5d6505_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
+  - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/python-3.14.6-h4b44e0e_100_cp314.conda
+  - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
+  - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/uv-0.11.23-h2229357_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/vc-14.5-h1b7c187_39.conda
+  - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
+  - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
+  - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
+- conda_source: brotli-python[ccbc29f2] @ continuous_integration/pixi-recipes/brotli
   variants:
     target_platform: noarch
   depends:
@@ -68832,9 +68950,105 @@ packages:
   - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
   - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
   - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/uv-0.11.22-hc169f86_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/uv-0.11.23-hc169f86_0.conda
   - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-- conda_source: dask-core[058df287] @ .
+- conda_source: dask-core[7581a683] @ .
+  variants:
+    target_platform: noarch
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.9.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - pyyaml >=5.4.1
+  - toolz >=0.12.0
+  - python >=3.10
+  - python *
+  license: BSD-3-Clause
+  source:
+    path: ''
+  host_packages:
+  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
+  - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+  - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-2.1.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
+  - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
+  - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
+  - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.53.2-hf5d6505_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
+  - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/python-3.14.6-h4b44e0e_100_cp314.conda
+  - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
+  - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/uv-0.11.23-h2229357_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/vc-14.5-h1b7c187_39.conda
+  - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
+  - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
+  - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
+- conda_source: dask-core[ac39bd18] @ .
+  variants:
+    target_platform: noarch
+  depends:
+  - click >=8.1
+  - cloudpickle >=3.0.0
+  - fsspec >=2021.9.0
+  - packaging >=20.0
+  - partd >=1.4.0
+  - pyyaml >=5.4.1
+  - toolz >=0.12.0
+  - python >=3.10
+  - python *
+  license: BSD-3-Clause
+  source:
+    path: ''
+  host_packages:
+  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
+  - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+  - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-2.1.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/uv-0.11.23-hc169f86_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+- conda_source: dask-core[f372236f] @ .
   variants:
     target_platform: noarch
   depends:
@@ -68870,60 +69084,24 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-aarch64/python-3.14.6-hc679e19_100_cp314.conda
   - conda: https://prefix.dev/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
   - conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/uv-0.11.22-haa595b2_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/uv-0.11.23-haa595b2_0.conda
   - conda: https://prefix.dev/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
   - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
   - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
-- conda_source: dask-core[4daf6a12] @ .
-  variants:
-    target_platform: noarch
-  depends:
-  - click >=8.1
-  - cloudpickle >=3.0.0
-  - fsspec >=2021.9.0
-  - packaging >=20.0
-  - partd >=1.4.0
-  - pyyaml >=5.4.1
-  - toolz >=0.12.0
-  - python >=3.10
-  - python *
-  license: BSD-3-Clause
-  source:
-    path: ''
-  host_packages:
-  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-  - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/uv-0.11.22-hc169f86_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-- conda_source: dask-core[cfea4cc3] @ .
+  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-2.1.0-pyhd8ed1ab_0.conda
+- conda_source: dask-core[f391cbf4] @ .
   variants:
     target_platform: noarch
   depends:
@@ -68958,60 +69136,24 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
   - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/uv-0.11.22-h26efc2c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/uv-0.11.23-h26efc2c_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
   - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
   - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
-- conda_source: dask-core[e7cea6b0] @ .
-  variants:
-    target_platform: noarch
-  depends:
-  - click >=8.1
-  - cloudpickle >=3.0.0
-  - fsspec >=2021.9.0
-  - packaging >=20.0
-  - partd >=1.4.0
-  - pyyaml >=5.4.1
-  - toolz >=0.12.0
-  - python >=3.10
-  - python *
-  license: BSD-3-Clause
-  source:
-    path: ''
-  host_packages:
-  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-  - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
-  - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
-  - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
-  - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.53.2-hf5d6505_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
-  - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/python-3.14.6-h4b44e0e_100_cp314.conda
-  - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
-  - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/uv-0.11.22-h2229357_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/vc-14.5-h1b7c187_39.conda
-  - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
-  - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
-  - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-- conda_source: distributed[208732bf] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-2.1.0-pyhd8ed1ab_0.conda
+- conda_source: distributed[298b9d04] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
   version: 2099.0.0
   build: pyh4616a5c_0
   subdir: noarch
@@ -69053,114 +69195,24 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-aarch64/python-3.14.6-hc679e19_100_cp314.conda
   - conda: https://prefix.dev/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
   - conda: https://prefix.dev/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
-  - conda: https://prefix.dev/conda-forge/linux-aarch64/uv-0.11.22-haa595b2_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-aarch64/uv-0.11.23-haa595b2_0.conda
   - conda: https://prefix.dev/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
   - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
   - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
-- conda_source: distributed[2f8bebff] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
-  version: 2099.0.0
-  build: pyh4616a5c_0
-  subdir: noarch
-  noarch: python
-  variants:
-    target_platform: noarch
-  depends:
-  - dask-core
-  - jinja2 >=2.10.3
-  - locket >=1.0.0
-  - msgpack-python >=1.0.2
-  - psutil >=5.8.0
-  - sortedcontainers >=2.0.5
-  - tblib >=1.6.0,!=3.2.0,!=3.2.1
-  - tornado >=6.2.0
-  - zict >=3.0.0
-  - python >=3.10
-  - python *
-  license: BSD-3-Clause
-  source:
-    path: ''
-  host_packages:
-  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-  - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
-  - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
-  - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
-  - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.53.2-hf5d6505_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
-  - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/python-3.14.6-h4b44e0e_100_cp314.conda
-  - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
-  - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/uv-0.11.22-h2229357_0.conda
-  - conda: https://prefix.dev/conda-forge/win-64/vc-14.5-h1b7c187_39.conda
-  - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
-  - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
-  - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-- conda_source: distributed[a8efca05] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
-  version: 2099.0.0
-  build: pyh4616a5c_0
-  subdir: noarch
-  noarch: python
-  variants:
-    target_platform: noarch
-  depends:
-  - dask-core
-  - jinja2 >=2.10.3
-  - locket >=1.0.0
-  - msgpack-python >=1.0.2
-  - psutil >=5.8.0
-  - sortedcontainers >=2.0.5
-  - tblib >=1.6.0,!=3.2.0,!=3.2.1
-  - tornado >=6.2.0
-  - zict >=3.0.0
-  - python >=3.10
-  - python *
-  license: BSD-3-Clause
-  source:
-    path: ''
-  host_packages:
-  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-  - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/uv-0.11.22-hc169f86_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-- conda_source: distributed[f47febc1] @ git+https://github.com/dask/distributed#f05085abe7dd4601fcd79985a8c162789eee7eac
+  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-2.1.0-pyhd8ed1ab_0.conda
+- conda_source: distributed[45a1d59d] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
   version: 2099.0.0
   build: pyh4616a5c_0
   subdir: noarch
@@ -69201,18 +69253,132 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
   - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/uv-0.11.22-h26efc2c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/uv-0.11.23-h26efc2c_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
   - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
   - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
-- conda_source: fsspec[c3b6eeef] @ continuous_integration/pixi-recipes/fsspec
+  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-2.1.0-pyhd8ed1ab_0.conda
+- conda_source: distributed[ae0f1589] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
+  version: 2099.0.0
+  build: pyh4616a5c_0
+  subdir: noarch
+  noarch: python
+  variants:
+    target_platform: noarch
+  depends:
+  - dask-core
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.2
+  - psutil >=5.8.0
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0,!=3.2.0,!=3.2.1
+  - tornado >=6.2.0
+  - zict >=3.0.0
+  - python >=3.10
+  - python *
+  license: BSD-3-Clause
+  source:
+    path: ''
+  host_packages:
+  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
+  - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+  - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-2.1.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
+  - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
+  - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.3-hfd05255_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
+  - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.53.2-hf5d6505_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
+  - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/python-3.14.6-h4b44e0e_100_cp314.conda
+  - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
+  - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/uv-0.11.23-h2229357_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/vc-14.5-h1b7c187_39.conda
+  - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_39.conda
+  - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_39.conda
+  - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
+- conda_source: distributed[de5a2f6f] @ git+https://github.com/dask/distributed#3b0ba32760d0400199cfc152ebb0fd34c4a1aeee
+  version: 2099.0.0
+  build: pyh4616a5c_0
+  subdir: noarch
+  noarch: python
+  variants:
+    target_platform: noarch
+  depends:
+  - dask-core
+  - jinja2 >=2.10.3
+  - locket >=1.0.0
+  - msgpack-python >=1.0.2
+  - psutil >=5.8.0
+  - sortedcontainers >=2.0.5
+  - tblib >=1.6.0,!=3.2.0,!=3.2.1
+  - tornado >=6.2.0
+  - zict >=3.0.0
+  - python >=3.10
+  - python *
+  license: BSD-3-Clause
+  source:
+    path: ''
+  host_packages:
+  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
+  - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+  - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-2.1.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/uv-0.11.23-hc169f86_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+- conda_source: fsspec[4d3e4f2e] @ continuous_integration/pixi-recipes/fsspec
   variants:
     target_platform: noarch
   depends:
@@ -69221,7 +69387,54 @@ packages:
   license: BSD-3-Clause
   source:
     git: https://github.com/fsspec/filesystem_spec
-    rev: 2a2416a75ebc09debe708b5a5435d39871b55e3b
+    rev: 65d58d4346c235747b9c2166aa60c25a3031a590
+  host_packages:
+  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/editables-0.6-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/hatch-vcs-0.5.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/hatchling-1.30.1-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
+  - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+  - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/trove-classifiers-2026.6.1.19-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-2.1.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/uv-0.11.23-hc169f86_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+- conda_source: fsspec[871d8b59] @ continuous_integration/pixi-recipes/fsspec
+  variants:
+    target_platform: noarch
+  depends:
+  - python
+  - python *
+  license: BSD-3-Clause
+  source:
+    git: https://github.com/fsspec/filesystem_spec
+    rev: 65d58d4346c235747b9c2166aa60c25a3031a590
   host_packages:
   - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
@@ -69241,15 +69454,20 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
   - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/uv-0.11.22-h26efc2c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/uv-0.11.23-h26efc2c_0.conda
   - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   - conda: https://prefix.dev/conda-forge/noarch/editables-0.6-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/hatch-vcs-0.5.0-pyhd8ed1ab_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/hatchling-1.30.1-pyhcf101f3_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pytest-9.1.1-pyhc364b38_2.conda
   - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
   - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
@@ -69257,50 +69475,41 @@ packages:
   - conda: https://prefix.dev/conda-forge/noarch/trove-classifiers-2026.6.1.19-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
-- conda_source: fsspec[d78c3b1e] @ continuous_integration/pixi-recipes/fsspec
+  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-2.1.0-pyhd8ed1ab_0.conda
+- conda_source: s3fs[4eac6e49] @ continuous_integration/pixi-recipes/s3fs
   variants:
     target_platform: noarch
   depends:
   - python
   - python *
-  license: BSD-3-Clause
-  source:
-    git: https://github.com/fsspec/filesystem_spec
-    rev: 2a2416a75ebc09debe708b5a5435d39871b55e3b
+  - aiobotocore
+  - aiohttp
+  - fsspec
   host_packages:
+  - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/editables-0.6-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/hatch-vcs-0.5.0-pyhd8ed1ab_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/hatchling-1.30.1-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
   - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/trove-classifiers-2026.6.1.19-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.8-h55c6f16_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.53.2-h1ae2325_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.3-hd24854e_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/uv-0.11.22-hc169f86_0.conda
-  - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-- conda_source: s3fs[45be35c0] @ continuous_integration/pixi-recipes/s3fs
+- conda_source: s3fs[f7deada0] @ continuous_integration/pixi-recipes/s3fs
   variants:
     target_platform: noarch
   depends:
@@ -69311,21 +69520,10 @@ packages:
   - fsspec
   host_packages:
   - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/editables-0.6-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/hatch-vcs-0.5.0-pyhd8ed1ab_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/hatchling-1.30.1-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
   - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
   - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/trove-classifiers-2026.6.1.19-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
   - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
   - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
   - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
   - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
@@ -69340,50 +69538,6 @@ packages:
   - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
   - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
   - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-- conda_source: s3fs[cf1e09ba] @ continuous_integration/pixi-recipes/s3fs
-  variants:
-    target_platform: noarch
-  depends:
-  - python
-  - python *
-  - aiobotocore
-  - aiohttp
-  - fsspec
-  host_packages:
-  - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.53.2-h0c1763c_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.42.2-h5347b49_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.3-h35e630c_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
-  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/editables-0.6-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/hatch-vcs-0.5.0-pyhd8ed1ab_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/hatchling-1.30.1-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/pip-26.1.2-pyh145f28c_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
-  - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/setuptools-scm-10.0.5-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/trove-classifiers-2026.6.1.19-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
-  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-  - conda: https://prefix.dev/conda-forge/noarch/vcs_versioning-1.1.1-pyhd8ed1ab_0.conda
 - pypi: git+https://github.com/bokeh/bokeh#9eeb3e083fa27285cfc81c3867efcb7cd17e1b08
   name: bokeh
   version: 3.10.0.dev5+8.g9eeb3e08.dirty
@@ -69402,9 +69556,9 @@ packages:
   - selenium~=4.2 ; extra == 'export'
   - bokeh[export,extra,sampledata] ; extra == 'all'
   requires_python: '>=3.11'
-- pypi: git+https://github.com/zarr-developers/zarr-python#4e79f1bca6cb0fb4a1e763ae8b2706a17d0fde7e
+- pypi: git+https://github.com/zarr-developers/zarr-python#a63ebd5390c2ddcc145f41c9baba70ec70225358
   name: zarr
-  version: 3.2.2.dev70+g4e79f1bc
+  version: 3.2.2.dev77+ga63ebd53
   requires_dist:
   - donfig>=0.8
   - google-crc32c>=1.5
@@ -69783,14 +69937,14 @@ packages:
   - xlsxwriter>=3.2.0 ; extra == 'all'
   - zstandard>=0.23.0 ; extra == 'all'
   requires_python: '>=3.11'
-- pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/pyarrow/25.0.0.dev168/pyarrow-25.0.0.dev168-cp314-cp314-macosx_12_0_arm64.whl
+- pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/pyarrow/25.0.0.dev174/pyarrow-25.0.0.dev174-cp314-cp314-macosx_12_0_arm64.whl
   name: pyarrow
-  version: 25.0.0.dev168
+  version: 25.0.0.dev174
   index: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
   requires_python: '>=3.10'
-- pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/pyarrow/25.0.0.dev168/pyarrow-25.0.0.dev168-cp314-cp314-manylinux_2_28_x86_64.whl
+- pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/pyarrow/25.0.0.dev174/pyarrow-25.0.0.dev174-cp314-cp314-manylinux_2_28_x86_64.whl
   name: pyarrow
-  version: 25.0.0.dev168
+  version: 25.0.0.dev174
   index: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
   requires_python: '>=3.10'
 - pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/scipy/1.19.0.dev0/scipy-1.19.0.dev0-cp314-cp314-macosx_12_0_arm64.whl
@@ -69813,9 +69967,9 @@ packages:
   - threadpoolctl ; extra == 'all'
   - matplotlib ; extra == 'all'
   requires_python: '>=3.12'
-- pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/xarray/2026.4.1.dev23+g214450fd5/xarray-2026.4.1.dev23+g214450fd5-py3-none-any.whl
+- pypi: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/xarray/2026.4.1.dev25+g12fc7628d/xarray-2026.4.1.dev25+g12fc7628d-py3-none-any.whl
   name: xarray
-  version: 2026.4.1.dev23+g214450fd5
+  version: 2026.4.1.dev25+g12fc7628d
   index: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
   requires_dist:
   - numpy>=1.26


### PR DESCRIPTION
Also run pixi update. Note: no numpy 2.5 in py314 yet, as numba pins numpy<=2.4.