### PR TITLE
Avoid graph materialization in is_dask_collection for expr wrappers

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -253,10 +253,16 @@ def is_dask_collection(x) -> bool:
         if isinstance(expr, Expr):
             return True
 
-    # xarray, pint, and possibly other wrappers always define a __dask_graph__ method,
-    # but it may return None if they wrap around a non-dask object.
-    # In all known dask collections other than dask-expr,
-    # calling __dask_graph__ is cheap.
+    # Wrappers like xarray expose their dask expressions via __dask_exprs__.
+    # When those are dask expressions we can answer cheaply without
+    # materializing. Otherwise (e.g. xarray wrapping a legacy HighLevelGraph
+    # array, whose children aren't Exprs) fall back to __dask_graph__.
+    dask_exprs = getattr(x, "__dask_exprs__", None)
+    if dask_exprs is not None:
+        exprs = dask_exprs()
+        if exprs is not None and any(isinstance(e, Expr) for e in exprs):
+            return True
+
     return x.__dask_graph__() is not None
 
 

--- a/dask/tests/test_composite_expr.py
+++ b/dask/tests/test_composite_expr.py
@@ -181,6 +181,41 @@ def test_is_dask_collection_uses_expr_without_materializing():
     assert is_dask_collection(AbstractExpr("a", 1))
 
 
+def test_is_dask_collection_uses_dask_exprs_without_materializing():
+    class NoMaterialize(ExprTuple):
+        def __dask_graph__(self):
+            raise AssertionError("must not materialize")
+
+    coll = NoMaterialize(
+        ExprScalar(LiteralExpr("a", 1)), ExprScalar(LiteralExpr("b", 2))
+    )
+    assert is_dask_collection(coll)
+
+
+def test_is_dask_collection_falls_back_when_dask_exprs_not_exprs():
+    # A newer xarray defines __dask_exprs__ but, when wrapping a legacy
+    # HighLevelGraph-backed array, yields children that are not dask Exprs. We
+    # must fall back to __dask_graph__ rather than report "not a collection".
+    class LegacyWrapper(LegacyTuple):
+        def __dask_exprs__(self):
+            return ("not-an-expr",)
+
+    assert is_dask_collection(LegacyWrapper({"x": 1}, ["x"]))
+
+
+def test_is_dask_collection_false_when_no_dask_exprs_and_no_graph():
+    # A wrapper around non-dask data: __dask_exprs__ yields nothing and
+    # __dask_graph__ returns None (as xarray does with no dask variables).
+    class Empty(ExprTuple):
+        def __dask_exprs__(self):
+            return ()
+
+        def __dask_graph__(self):
+            return None
+
+    assert not is_dask_collection(Empty())
+
+
 def test_collections_to_expr_ignores_non_dask_expr_attribute():
     class ExprAttributeTuple(ExprTuple):
         @property


### PR DESCRIPTION
is_dask_collection(x) fell through to ``x.__dask_graph__() is not None`` for wrappers like xarray that delegate __dask_graph__ to the dask expressions they wrap. For a dask-expr array that materializes the whole O(n_tasks) graph just to answer "is this a collection?", which optimize/unpack_collections call repeatedly.

Use the __dask_exprs__ protocol instead (see #12457 and pydata/xarray#11382). Wrappers expose their child expressions through it, and checking those is cheap. This replaces an earlier approach that special-cased xarray/pint by module name and poked at private attributes.