### PR TITLE
Preserve extension dtype in str.split(expand=True) (fixes #11884)

### DIFF
--- a/dask/dataframe/dask_expr/_str_accessor.py
+++ b/dask/dataframe/dask_expr/_str_accessor.py
@@ -186,6 +186,7 @@ class SplitMap(FunctionMap):
         meta = self.frame._meta._constructor(
             [delimiter.join(["a"] * (self.n + 1))],
             index=meta.iloc[:1].index,
+            dtype=self.frame._meta.dtype,
         )
         return make_meta(
             getattr(meta.str, self.attr)(n=self.n, expand=self.expand, pat=self.pat)

--- a/dask/dataframe/dask_expr/tests/test_string_accessor.py
+++ b/dask/dataframe/dask_expr/tests/test_string_accessor.py
@@ -140,6 +140,18 @@ def test_str_split_(index):
     assert_eq(dd_a, pd_a)
 
 
+def test_str_split_expand_preserves_dtype():
+    # str.split(expand=True) must preserve an extension dtype such as "string"
+    # instead of coercing the result columns to object, matching pandas.
+    # Regression test for GH#11884.
+    df = pd.DataFrame({"a": ["a,b,c", "d,e,f", "g,h,i"]}, dtype="string")
+    ddf = from_pandas(df, npartitions=1)
+    assert_eq(
+        ddf["a"].str.split(",", n=1, expand=True),
+        df["a"].str.split(",", n=1, expand=True),
+    )
+
+
 def test_str_accessor_not_available():
     pdf = pd.DataFrame({"a": [1, 2, 3]})
     df = from_pandas(pdf, npartitions=2)


### PR DESCRIPTION
## What

`Series.str.split(..., expand=True)` on a `string` / `string[pyarrow]` column returns `object` columns instead of preserving the input dtype, which is inconsistent with pandas.

Fixes #11884.

## Why

`SplitMap._meta` rebuilds a one-row sample so the split produces the right number of columns, but constructs it with the default dtype:

```python
meta = self.frame._meta._constructor(
    [delimiter.join(["a"] * (self.n + 1))],
    index=meta.iloc[:1].index,
)
```

`_constructor([...])` defaults to `object`, so `meta.str.split(expand=True)` runs on an object series and the resulting meta — and every partition's output — becomes `object`.

## Fix

Pass the source dtype when building the sample so the split preserves it:

```diff
             index=meta.iloc[:1].index,
+            dtype=self.frame._meta.dtype,
```

## Test

Added `test_str_split_expand_preserves_dtype`: splits a `dtype="string"` column with `expand=True` and asserts (via `assert_eq`, which checks dtypes) that the result matches pandas. It fails on `main` (object) and passes with this change. Uses the pandas `string` dtype, so no pyarrow dependency is required.