### PR TITLE
fix: don't let array conversion desync partition count from source collection

### DIFF
--- a/dask/array/_array_expr/_backends.py
+++ b/dask/array/_array_expr/_backends.py
@@ -37,7 +37,15 @@ def create_array_collection(expr):
 
             return Array(expr)
 
-    result = expr.optimize()
+    # Skip the "tune" optimization stage (e.g. FusedIO's IO-partition bucketing)
+    # here: it can reduce the *logical* partition count relative to what the
+    # source collection publicly reports via `.npartitions`/`.divisions`,
+    # which would silently desync the resulting array's chunk structure from
+    # e.g. its originating Index (see GH#12146).
+    result = expr.simplify()
+    result = result.lower_completely()
+    result = result.simplify()
+    result = result.fuse()
     dsk = result.__dask_graph__()
     name = result._name
     meta = result._meta

--- a/dask/dataframe/dask_expr/io/tests/test_parquet.py
+++ b/dask/dataframe/dask_expr/io/tests/test_parquet.py
@@ -577,6 +577,32 @@ def test_timestamp_divisions(tmpdir):
     )
 
 
+def test_read_parquet_boolean_array_indexing_after_fusion(tmpdir):
+    # https://github.com/dask/dask/issues/12146
+    #
+    # FusedIO ("tune" optimization stage) can reduce the *logical* partition
+    # count relative to what the un-optimized collection reports via
+    # `.npartitions`/`.divisions`. `to_dask_array`/`.values` used to build its
+    # array chunk structure from the *optimized* (post-fusion) expr, so a
+    # small, many-file parquet dataset would silently disagree with the
+    # source collection's partition count, and boolean-array `.loc` indexing
+    # (which relies on the two matching) would raise:
+    #   ValueError: The index and array have different numbers of blocks.
+    pdf = pd.DataFrame({"a": range(20)}, index=range(20))
+    ddf = from_pandas(pdf, npartitions=2)
+    ddf.to_parquet(str(tmpdir), write_index=True, overwrite=True)
+
+    back = read_parquet(str(tmpdir), calculate_divisions=True)
+    assert back.npartitions == 2
+
+    indexer = back.index > 3
+    assert indexer.npartitions == back.npartitions
+
+    result = back.loc[indexer]
+    expected = pdf.loc[pdf.index > 3]
+    assert_eq(result, expected)
+
+
 def test_read_parquet_index_projection(tmpdir):
     df = from_array(
         np.zeros((201 * 10, 8), dtype=np.int64),


### PR DESCRIPTION
- [x] Closes #12146
- [x] Tests added / passed
- [x] Passes `pixi run lint` (ran `ruff check` / `ruff format --check` on the changed files directly; clean)

## Problem

```python
back = dd.read_parquet(some_small_parquet_dir, calculate_divisions=True)
back.loc[back.index > 3]
# ValueError: The index and array have different numbers of blocks. (2 != 1)
```

Any boolean-array `.loc[]` filter on a DataFrame read from a small/many-file parquet dataset crashes.

## Root cause

`read_parquet` has an internal optimization (`FusedIO`, part of the "tune" optimizer stage) that merges multiple small partitions into fewer physical tasks -- a deliberate perf win for many-small-files datasets.

`create_array_collection` (backs `.values` / `to_dask_array()`, used internally by `.loc[bool_array]` via `_loc_array`/`from_dask_array`) calls `expr.optimize()`, which runs this same "tune" stage, then derives the resulting array's chunk count from the **post-fusion** partition count. But the source `DataFrame`/`Index` still reports its **un-fused**, logical `.npartitions` publicly. Whenever `FusedIO` decides to merge partitions -- which is exactly what happens for small parquet datasets -- these two numbers silently disagree, and the `.loc[]` validation that requires them to match raises.

## Fix

`create_array_collection` now runs the same optimization pipeline `expr.optimize()` normally would, except the "tune" stage where `FusedIO` lives:

```python
result = expr.simplify()
result = result.lower_completely()
result = result.simplify()
result = result.fuse()
```

Column projection, predicate pushdown, and blockwise fusion are unaffected -- only the partition-count-changing IO bucketing is skipped, and only for this one array-conversion code path (not for normal DataFrame computation elsewhere).

## Test

Added `test_read_parquet_boolean_array_indexing_after_fusion` in `dask/dataframe/dask_expr/io/tests/test_parquet.py`: writes a small 2-partition parquet dataset, reads it back with `calculate_divisions=True`, filters with `.loc[index > 3]`, and checks the result against plain pandas.

Confirmed as a true regression guard: fails with the original `ValueError` when the fix is reverted, passes with it restored.

## Verification

- Reproduced the original bug (both the reporter's full fastparquet/repartition scenario and a minimal ~15-line repro using only `to_parquet`/`read_parquet`)
- Ran the full `dask_expr` + `array_expr` test suites: **4544 passed, 0 failed**
- `ruff check` clean; `ruff format --check` clean on the changed lines (pre-existing formatting drift elsewhere in the touched test file is unrelated to this change, confirmed via `git stash`)