### PR TITLE
DOC fix npartition -> npartitions typo in shuffle_group docstring

### DIFF
--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -183,7 +183,7 @@ def shuffle_group(df, cols, stage, k, npartitions, ignore_index, nfinal):
         we're in, starting from zero up to some small integer
     k: int
         Desired number of splits from this dataframe
-    npartition: int
+    npartitions: int
         Total number of output partitions for the full dataframe
     nfinal: int
         Total number of output partitions after repartitioning


### PR DESCRIPTION
The `shuffle_group` function in `dask/dataframe/shuffle.py` documents parameter `npartition` (singular) but the actual function signature uses `npartitions` (plural):

```python
def shuffle_group(df, cols, stage, k, npartitions, ignore_index, nfinal):
    ...
    npartition: int   # <-- typo: missing 's'
```

One-line docstring fix.