### PR TITLE
PLEASE IGNORE: unsupervised AI pr — Repair test-report workflow

### DIFF
--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -2,63 +2,78 @@ name: Test Report
 
 on:
   schedule:
-    # Run 2h after the daily tests.yaml
+    # Run 2h after the daily tests.yml
     - cron: "0 8,20 * * *"
   workflow_dispatch:
+  pull_request:
+    types: [labeled, opened, reopened, synchronize]
 
 permissions:
+  # Read the artifacts of the tests.yml runs
+  actions: read
+  # Deploy to GitHub Pages
   contents: write
 
 jobs:
   test-report:
     name: Test Report
-    # Do not run the report job on forks
-    if: github.repository == 'dask/dask' || github.event_name == 'workflow_dispatch'
+    # Do not run the report job on forks.
+    # On PRs, run only if the `test-report` label is set.
+    if: >
+      (github.event_name == 'pull_request'
+       && contains(github.event.pull_request.labels.*.name, 'test-report'))
+      || (github.event_name != 'pull_request'
+          && (github.repository == 'dask/dask' || github.event_name == 'workflow_dispatch'))
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ github.token }}
-    defaults:
-      run:
-        shell: bash -l {0}
     steps:
+      # The test-report tooling lives in the dask/distributed repository
       - uses: actions/checkout@v7
         with:
           repository: dask/distributed
+          ref: refs/pull/9321/head  # DNM: remove once https://github.com/dask/distributed/pull/9321 is merged
 
-      - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v4.0.1
+      - uses: prefix-dev/setup-pixi@v0.10.0
         with:
-          miniforge-version: latest
-          condarc-file: continuous_integration/condarc
-          # Note: this file is in the dask/distributed repo
-          environment-file: continuous_integration/scripts/test-report-environment.yml
-          activate-environment: dask
-
-      - name: Show conda options
-        run: conda config --show
-
-      - name: conda list
-        run: conda list
+          pixi-version: v0.72.0
+          environments: test-report
+          cache: true
+          locked: true
 
       - uses: actions/cache@v6
         id: cache
         with:
-          # Suffix is depending on the backend / OS. Let's be agnostic here
-          # See https://docs.python.org/3/library/shelve.html#shelve.open
-          path: |
-            test_report*
-            !test_report.html
-          # Note: these files are in the dask/distributed repository
-          key: ${{ hashFiles('continuous_integration/scripts/test_report*') }}
+          # Local databases of downloaded test results, created by test_report.py
+          # (in the dask/distributed repository).
+          # Note that this pattern must not match test_report.html.
+          path: test_report_*
+          # Caches are immutable; use a fresh key to upload an updated database at
+          # the end of every run, and restore from the most recent one.
+          key: test-report-${{ hashFiles('continuous_integration/scripts/test_report.py') }}-${{ github.run_id }}
+          restore-keys: test-report-${{ hashFiles('continuous_integration/scripts/test_report.py') }}-
 
       - name: Generate report
         run: |
-          python continuous_integration/scripts/test_report.py --repo dask/dask --max-days 90 --max-runs 30 --nfails 1 -o test_report.html
-          python continuous_integration/scripts/test_report.py --repo dask/dask --max-days 7 --max-runs 30 --nfails 2 -o test_short_report.html --title "Test Short Report"
+          pixi run test-report dask/dask
           mkdir deploy
           mv test_report.html test_short_report.html deploy/
 
+      - name: Upload report as workflow artifact
+        # For debugging purposes on PRs; scheduled runs deploy to GitHub Pages instead
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-report
+          path: |
+            deploy
+            test_report_*
+
       - name: Deploy 🚀
+        # Never update GitHub Pages from PRs.
+        # Note: this deploys to the gh-pages branch of dask/dask (GITHUB_REPOSITORY),
+        # not of dask/distributed (the checkout).
+        if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           branch: gh-pages

--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -42,9 +42,8 @@ jobs:
         id: cache
         with:
           # Local databases of downloaded test results, created by test_report.py
-          # (in the dask/distributed repository).
-          # Note that this pattern must not match test_report.html.
-          path: test_report_*
+          # (in the dask/distributed repository)
+          path: test_report*.db
           # Caches are immutable; use a fresh key to upload an updated database at
           # the end of every run, and restore from the most recent one.
           key: test-report-${{ hashFiles('continuous_integration/scripts/test_report.py') }}-${{ github.run_id }}
@@ -70,7 +69,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: test-report-db
-          path: test_report_*
+          path: test_report*.db
 
   deploy:
     name: Deploy report

--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -8,15 +8,9 @@ on:
   pull_request:
     types: [labeled, opened, reopened, synchronize]
 
-permissions:
-  # Read the artifacts of the tests.yml runs
-  actions: read
-  # Deploy to GitHub Pages
-  contents: write
-
 jobs:
-  test-report:
-    name: Test Report
+  generate:
+    name: Generate report
     # Do not run the report job on forks.
     # On PRs, run only if the `test-report` label is set.
     if: >
@@ -25,6 +19,11 @@ jobs:
       || (github.event_name != 'pull_request'
           && (github.repository == 'dask/dask' || github.event_name == 'workflow_dispatch'))
     runs-on: ubuntu-latest
+    permissions:
+      # Read the artifacts of the tests.yml runs
+      actions: read
+      # actions/checkout
+      contents: read
     env:
       GITHUB_TOKEN: ${{ github.token }}
     steps:
@@ -60,20 +59,39 @@ jobs:
           mv test_report.html test_short_report.html deploy/
 
       - name: Upload report as workflow artifact
-        # For debugging purposes on PRs; scheduled runs deploy to GitHub Pages instead
-        if: github.event_name == 'pull_request'
+        # Downloaded by the deploy job; also for debugging purposes on PRs
         uses: actions/upload-artifact@v7
         with:
           name: test-report
-          path: |
-            deploy
-            test_report_*
+          path: deploy
+
+      - name: Upload databases as workflow artifact
+        # For debugging purposes on PRs; scheduled runs persist them through
+        # actions/cache above
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-report-db
+          path: test_report_*
+
+  deploy:
+    name: Deploy report
+    needs: generate
+    # Never update GitHub Pages from PRs
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      # Push to the gh-pages branch
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: test-report
+          path: deploy
 
       - name: Deploy 🚀
-        # Never update GitHub Pages from PRs.
-        # Note: this deploys to the gh-pages branch of dask/dask (GITHUB_REPOSITORY),
-        # not of dask/distributed (the checkout).
-        if: github.event_name != 'pull_request'
         uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           branch: gh-pages

--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -22,8 +22,6 @@ jobs:
     permissions:
       # Read the artifacts of the tests.yml runs
       actions: read
-      # actions/checkout
-      contents: read
     env:
       GITHUB_TOKEN: ${{ github.token }}
     steps:


### PR DESCRIPTION
> [!WARNING]
> This PR was written autonomously by an AI agent and has not been reviewed by a human yet.

Companion PR to dask/distributed#9321; see there for full details.

The Test Report workflow ([runs](https://github.com/dask/dask/actions/workflows/test-report.yaml)) has been failing ever since the CI migration to pixi (#12389) changed the job and artifact naming of `tests.yml`.

## Changes

- The workflow checks out dask/distributed (where the test-report tooling lives) and runs `pixi run test-report dask/dask`. Nothing is installed by hand and no pixi shims are added to this repository.
- On PRs, the workflow only runs when the `test-report` label is set, and it uploads the reports + databases as workflow artifacts instead of deploying to GitHub Pages. Scheduled/manual runs deploy to the gh-pages branch of dask/dask as before.
- Fixed `actions/cache` usage: the previous static key made the cache immutable after the first save, so it never picked up new runs.

## DNM

The checkout step temporarily points at the dask/distributed PR branch instead of dask/distributed main, marked with a single `# DNM` comment line. It must be reverted after dask/distributed#9321 is merged and before this PR is merged.

## Verified locally

`pixi run test-report dask/dask` from a dask/distributed checkout produces reports showing the actual dask/dask main-branch test failures since 2026-06-04 (`test_warn_bad_rechunking`, `test_bind[False]`, both py314t) and nothing from dask/distributed; the failures were cross-checked against the failed `Tests` runs on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)