### PR TITLE
fix: keep FrameBase.persist tuning consistent with distributed.Client.persist

### DIFF
--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -462,7 +462,19 @@ Expr={expr}"""
         return np.array(self.compute())
 
     def persist(self, fuse=True, **kwargs):
-        out = self.optimize(fuse=fuse)
+        # Wrap in `_ExprSequence` before optimizing, matching what
+        # `distributed.Client.persist` does via `collections_to_expr`: the
+        # "tune" optimization stage (e.g. FusedIO's IO-partition bucketing)
+        # only fires on a node that has a parent (see `Expr.rewrite`), so a
+        # bare root expr optimized on its own here would silently disagree
+        # with the (wrapped, and therefore tuned) expr that
+        # `distributed.Client.persist` submits for execution, leaving the
+        # returned collection's reported npartitions out of sync with the
+        # futures actually created (GH#12488).
+        from dask._expr import _ExprSequence
+
+        tuned_expr = _ExprSequence(self.expr).optimize(fuse=fuse)[0]
+        out = new_collection(tuned_expr)
         return DaskMethodsMixin.persist(out, **kwargs)
 
     def analyze(self, filename: str | None = None, format: str | None = None) -> None:

--- a/dask/dataframe/dask_expr/io/tests/test_distributed.py
+++ b/dask/dataframe/dask_expr/io/tests/test_distributed.py
@@ -54,6 +54,37 @@ def test_parquet_distributed(c, tmpdir, filesystem):
     assert_eq(c.gather(c.compute(df)), pdf)
 
 
+def test_persist_root_expr_npartitions_matches_futures(c, tmpdir):
+    # https://github.com/dask/dask/issues/12488
+    #
+    # `FrameBase.persist` used to optimize a bare (parent-less) root expr on
+    # its own, so the "tune" stage (e.g. FusedIO's IO-partition bucketing,
+    # triggered here by selecting few enough columns) never fired: `_tune_up`
+    # only runs when a parent calls it on a child during `Expr.rewrite`.
+    # `Client.persist` re-optimizes the same expr wrapped for submission,
+    # where it *does* have a parent, so it *does* get fused. The two passes
+    # would disagree on partition count, leaving the returned collection's
+    # npartitions out of sync with the futures actually created -- any later
+    # compute would fail with "lost dependencies".
+    pdf = pd.DataFrame({c: range(10) for c in "abcde"})
+    for i in range(2):
+        _make_file(tmpdir, df=pdf, filename=f"part.{i}.parquet")
+
+    # 2 of 5 columns selected -> low fusion_compression_factor -> IO fusion
+    df = read_parquet(str(tmpdir), columns=["a", "b"])
+    persisted = df.persist()
+
+    from distributed.client import futures_of
+
+    assert persisted.npartitions == len(futures_of(persisted))
+    assert_eq(
+        persisted.compute().sort_values("a", ignore_index=True),
+        pd.concat([pdf[["a", "b"]], pdf[["a", "b"]]], ignore_index=True).sort_values(
+            "a", ignore_index=True
+        ),
+    )
+
+
 def test_pickle_size(tmpdir, filesystem):
     pdf = pd.DataFrame({"x": [1, 4, 3, 2, 0, 5]})
     [_make_file(tmpdir, df=pdf, filename=f"{x}.parquet") for x in range(10)]


### PR DESCRIPTION
- [x] Closes #12488
- [x] Tests added / passed
- [x] Passes `pixi run lint` (ran `ruff check` / `ruff format --check` on the changed files directly; clean)

## Problem

Reported by @Dimitri-Schnider as a follow-up to #12484 -- same tune-stage desync class, different trigger:

```python
df = dd.read_parquet(tmpdir, columns=["a", "b"])  # column projection triggers IO fusion
df = df.persist()
wait(df)

print("npartitions:", df.npartitions)     # 2
print("futures:", [f.key for f in futures_of(df)])  # only 1 future
print(len(df))  # FutureCancelledError: lost dependencies
```

## Root cause

`FrameBase.persist` (`_collection.py`) optimized a bare root expr on its own:

```python
def persist(self, fuse=True, **kwargs):
    out = self.optimize(fuse=fuse)
    return DaskMethodsMixin.persist(out, **kwargs)
```

The "tune" optimization stage (where `FusedIO`'s IO-partition bucketing lives) only fires when a **parent** node calls `_tune_up` on a child during `Expr.rewrite` (`dask/_expr.py`). A truly parentless root -- like a bare `read_parquet(...)` handed directly to `.persist()` -- never gets that opportunity, so the returned collection kept the pre-fusion `npartitions`.

`distributed.Client.persist` (`distributed/client.py`) re-optimizes the same expr via `collections_to_expr` (actually defined in `dask/base.py`), which wraps it for submission -- giving it an effective parent for the first time in *that* pass. Tune/`FusedIO` *does* fire there, fusing multiple partitions into fewer physical tasks.

The two passes disagree: the collection returned to the user reports the un-fused partition count, while the futures actually created (and submitted to the cluster) correspond to the fused count. Any later `compute()`/`len()` on the persisted collection then fails with `FutureCancelledError: ... lost dependencies`.

## Fix

Wrap the expr in `_ExprSequence` before optimizing in `FrameBase.persist`, matching what `distributed.Client.persist` already does via `collections_to_expr`, so both optimization passes consistently agree on the tuned/fused partition count:

```python
def persist(self, fuse=True, **kwargs):
    from dask._expr import _ExprSequence

    tuned_expr = _ExprSequence(self.expr).optimize(fuse=fuse)[0]
    out = new_collection(tuned_expr)
    return DaskMethodsMixin.persist(out, **kwargs)
```

## Test

Added `test_persist_root_expr_npartitions_matches_futures` in `dask/dataframe/dask_expr/io/tests/test_distributed.py`, reproducing the reporter's exact trigger conditions (2 parquet files, column projection dropping the fusion-compression-factor below 1) against a live test cluster. Asserts `persisted.npartitions == len(futures_of(persisted))` and checks the computed data is correct.

Confirmed as a true regression guard: fails with `assert 2 == 1` when the fix is reverted, passes with it restored.

## Verification

- Reproduced the original bug against a live `LocalCluster`/`Client` (matching the reporter's MRE exactly)
- Confirmed the fix resolves it: `npartitions` now matches the future count, `len(df)` succeeds with correct data
- Checked plain threaded persist (no distributed), `persist(fuse=False)`, filtered persist, and multi-collection `dask.persist(a, b)` are all unaffected
- Ran the full `dask_expr` + `array_expr` + `io` test suites plus `test_base.py`'s persist tests: **4598 passed, 0 failed**
- Ran the live-cluster distributed test modules (`test_distributed.py` in both `dask_expr/tests` and `dask_expr/io/tests`): **43 passed**
- `ruff check` clean; `ruff format --check` clean on the changed lines (pre-existing formatting drift elsewhere in both touched files is unrelated, confirmed via diff inspection -- same pattern as #12484)