### PR TITLE
docs: fix incorrect API cross-references

### DIFF
--- a/docs/source/array.rst
+++ b/docs/source/array.rst
@@ -69,7 +69,7 @@ New duck array chunk types (types below Dask on
 not registered will be deferred to in binary operations and NumPy
 ufuncs/functions (that is, Dask will return ``NotImplemented``). Note, however,
 that *any* ndarray-like type can be inserted into a Dask Array using
-:func:`~dask.array.Array.from_array`.
+:func:`~dask.array.from_array`.
 
 Common Uses
 -----------

--- a/docs/source/spec.rst
+++ b/docs/source/spec.rst
@@ -41,7 +41,7 @@ A **key** is a str, int, float, or tuple thereof:
    'x'
    ('x', 2, 3)
 
-A **task** is a computation that Dask can perform and is expressed using the :class:`dask.Task` class.  Tasks represent atomic
+A **task** is a computation that Dask can perform and is expressed using the :class:`~dask._task_spec.Task` class.  Tasks represent atomic
 units of work meant to be run by a single worker.  Example:
 
 .. code-block:: python
@@ -61,7 +61,7 @@ units of work meant to be run by a single worker.  Example:
    The legacy representation of a task is a tuple with the first element being a
    callable function.  The rest of the elements are arguments to that function.
    The legacy representation is deprecated and will be removed in a future
-   version of Dask.  Use the :class:`dask.Task` class instead.
+   version of Dask.  Use the :class:`~dask._task_spec.Task` class instead.
 
 
 A **computation** may be one of the following:


### PR DESCRIPTION
A few `:class:`/`:func:` cross-references in the docs point at dotted paths
that don't exist:

- `array.rst` referenced `dask.array.Array.from_array`, but there's no
  `Array.from_array` — it's the module-level `dask.array.from_array`. Fixed so
  the link resolves.
- `spec.rst` referenced `dask.Task` in two places, which isn't a real import
  path. Changed to `dask._task_spec.Task`, matching the form already used
  everywhere else in the same file.

Found these by checking every `dask.` cross-reference target against the installed package; verified the corrected paths import and (for `from_array`) that it's a documented, public function.

Docs-only fix, no code changed.

Used an AI assistant to find and verify these; I reviewed and approved every change.