### PR TITLE
Document that Series.unique order may differ from pandas

### DIFF
--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -4323,6 +4323,15 @@ class Series(FrameBase):
         Returns
         -------
         uniques : Series
+
+        Notes
+        -----
+        Unlike :meth:`pandas.Series.unique`, the order of the returned values is
+        not guaranteed to match the order in which they first appear in the data.
+        By default the unique values are combined across partitions using a
+        shuffle, which does not preserve the input order. Pass ``split_out=1`` to
+        compute the result on a single partition and preserve the original order
+        (only suitable for low-cardinality data).
         """
         shuffle_method = _get_shuffle_preferring_order(shuffle_method)
         return new_collection(Unique(self, split_every, split_out, shuffle_method))


### PR DESCRIPTION
Closes #11758.

Adds a `Notes` section to `Series.unique` documenting that the order of the
returned values is not guaranteed to match pandas, because the unique values are
combined across partitions with a shuffle (which does not preserve input order),
and that passing `split_out=1` preserves the original order for low-cardinality
data.

This follows the maintainers' explanation in the issue:
- @phofl: "This is expected. We are triggering a shuffle under the hood ... a shuffle won't preserve the input order. I'll label this as a documentation issue."
- @rjzamora: the "tree-reduction" version (`split_out=1`) preserves the original order.

Docstring-only change.

<sub>Disclosure: this documentation change was prepared with the assistance of Claude Code and reviewed against the maintainers' comments in the issue.</sub>
