### PR TITLE
escape untrusted names in HighLevelGraph layer html repr

### DIFF
--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -300,11 +300,11 @@ class Layer(Graph):
 
         return get_template("highlevelgraph_layer.html.j2").render(
             materialized=self.is_materialized(),
-            shortname=shortname,
+            shortname=html.escape(str(shortname)),
             layer_index=layer_index,
-            highlevelgraph_key=highlevelgraph_key,
+            highlevelgraph_key=html.escape(str(highlevelgraph_key)),
             info=self.layer_info_dict(),
-            dependencies=dependencies,
+            dependencies=[html.escape(str(dep)) for dep in dependencies],
             svg_repr=svg_repr,
         )
 
@@ -316,12 +316,12 @@ class Layer(Graph):
         }
         if self.annotations is not None:
             for key, val in self.annotations.items():
-                info[key] = html.escape(str(val))
+                info[html.escape(str(key))] = html.escape(str(val))
         if self.collection_annotations is not None:
             for key, val in self.collection_annotations.items():
                 # Hide verbose chunk details from the HTML table
                 if key != "chunks":
-                    info[key] = html.escape(str(val))
+                    info[html.escape(str(key))] = html.escape(str(val))
         return info
 
 

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -147,6 +147,18 @@ def test_repr_html_hlg_layers():
         assert xml.etree.ElementTree.fromstring(layer._repr_html_()) is not None
 
 
+def test_repr_html_hlg_layers_escapes_names():
+    pytest.importorskip("jinja2")
+    payload = "<img src=x onerror=alert(1)>"
+    layer = MaterializedLayer({"a": 1}, annotations={payload: payload})
+    html = layer._repr_html_(
+        highlevelgraph_key=f"{payload}-abc", dependencies=[f"{payload}-dep"]
+    )
+    assert payload not in html
+    assert "&lt;img" in html
+    assert xml.etree.ElementTree.fromstring(html) is not None
+
+
 def annot_map_fn(key):
     return key[1:]
 


### PR DESCRIPTION
Layer._repr_html_ and layer_info_dict build the Jupyter HTML repr of a graph by interpolating layer names, keys, dependency names and annotation keys straight into the template, while only annotation values go through html.escape. A layer name is user-reachable (for example da.from_array(x, name=...)), so a name like `<img src=x onerror=alert(1)>` renders as live HTML when the collection or its graph is displayed in a notebook. Escape shortname, highlevelgraph_key, the dependency names and the annotation keys the same way values already are.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pixi run lint`