### PR TITLE
restrict unpickling of npy-stack info metadata in from_npy_stack

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -6122,6 +6122,25 @@ def to_npy_stack(dirname, x, axis=0):
     compute_as_if_collection(Array, graph, list(dsk))
 
 
+class _InfoUnpickler(pickle.Unpickler):
+    """Unpickler for the ``info`` metadata written by :func:`to_npy_stack`.
+
+    The metadata is only ``{"chunks": ..., "dtype": ..., "axis": ...}``, so the
+    single global it legitimately needs is ``numpy.dtype``. Restricting
+    ``find_class`` to that keeps a stack authored elsewhere from executing
+    arbitrary code while loading its ``info`` file.
+    """
+
+    _allowed = {("numpy", "dtype")}
+
+    def find_class(self, module, name):
+        if (module, name) in self._allowed:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"global '{module}.{name}' is not allowed in an npy-stack info file"
+        )
+
+
 def from_npy_stack(dirname, mmap_mode="r"):
     """Load dask array from stack of npy files
 
@@ -6137,7 +6156,7 @@ def from_npy_stack(dirname, mmap_mode="r"):
     to_npy_stack
     """
     with open(os.path.join(dirname, "info"), "rb") as f:
-        info = pickle.load(f)
+        info = _InfoUnpickler(f).load()
 
     dtype = info["dtype"]
     chunks = info["chunks"]

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -3576,6 +3576,30 @@ def test_to_npy_stack():
         assert_eq(d, e)
 
 
+def test_from_npy_stack_rejects_unsafe_info():
+    import pickle
+
+    x = da.from_array(np.arange(20).reshape((4, 5)), chunks=(2, 5))
+
+    with tmpdir() as dirname:
+        stackdir = os.path.join(dirname, "test")
+        da.to_npy_stack(stackdir, x, axis=0)
+
+        marker = os.path.join(dirname, "pwned")
+
+        class Evil:
+            def __reduce__(self):
+                return (os.system, (f"touch {marker}",))
+
+        info = {"chunks": ((2, 2), (5,)), "dtype": x.dtype, "axis": 0, "evil": Evil()}
+        with open(os.path.join(stackdir, "info"), "wb") as f:
+            pickle.dump(info, f)
+
+        with pytest.raises(pickle.UnpicklingError):
+            da.from_npy_stack(stackdir)
+        assert not os.path.exists(marker)
+
+
 def test_view():
     x = np.arange(56).reshape((7, 8))
     d = da.from_array(x, chunks=(2, 3))


### PR DESCRIPTION
from_npy_stack reads the stack's `info` metadata file with a bare `pickle.load`, so loading a stack produced by another party runs arbitrary code during unpickling (a value in the info dict reaches `os.system`/`exec` via `__reduce__`). A valid `info` file only ever references `numpy.dtype`, so I read it through a small `pickle.Unpickler` whose `find_class` allows exactly that global and raises `UnpicklingError` on anything else. The on-disk format is unchanged, so every existing stack still loads.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pixi run lint`