### PR TITLE
Don't rechunk in to_zarr when chunks already align with the target array

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3838,7 +3838,11 @@ def _write_dask_to_existing_zarr(
                 "the distributed scheduler."
             )
     zarr_write_chunks = _get_zarr_write_chunks(z)
-    if region is None and _chunks_aligned_with_zarr(arr.chunks, zarr_write_chunks):
+    if (
+        region is None
+        and arr.shape == z.shape
+        and _chunks_aligned_with_zarr(arr.chunks, zarr_write_chunks)
+    ):
         # The input array's chunks are already safe to write, keep them
         # instead of rechunking to the "auto" heuristic
         # https://github.com/dask/dask/issues/12458

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3838,6 +3838,13 @@ def _write_dask_to_existing_zarr(
                 "the distributed scheduler."
             )
     zarr_write_chunks = _get_zarr_write_chunks(z)
+    if region is None and _chunks_aligned_with_zarr(arr.chunks, zarr_write_chunks):
+        # The input array's chunks are already safe to write, keep them
+        # instead of rechunking to the "auto" heuristic
+        # https://github.com/dask/dask/issues/12458
+        return arr.store(
+            z, lock=False, regions=None, compute=compute, return_stored=return_stored
+        )
     dask_write_chunks = normalize_chunks(
         chunks="auto",
         shape=z.shape,
@@ -4146,6 +4153,30 @@ def _get_zarr_write_chunks(zarr_array) -> tuple[int, ...]:
         return zarr_array.shards
     # Zarr V3 array without shards, or Zarr V2 array
     return zarr_array.chunks
+
+
+def _chunks_aligned_with_zarr(dask_chunks, zarr_write_chunks):
+    """Check if dask chunks can be written to a zarr array without rechunking.
+
+    The chunks are safe to write when every chunk boundary lies on the zarr
+    chunk (or shard) grid, i.e. along every axis each chunk, except possibly
+    the last one, has a size divisible by the zarr chunk size.
+
+    Parameters
+    ----------
+    dask_chunks: tuple of tuples of ints
+        From the ``.chunks`` attribute of an ``Array``
+    zarr_write_chunks: tuple of ints
+        The chunk (or shard) shape of the target zarr array
+
+    Returns
+    -------
+    True if the dask chunks are aligned, else False
+    """
+    return all(
+        all(c % zw == 0 for c in dc[:-1])
+        for dc, zw in zip(dask_chunks, zarr_write_chunks, strict=True)
+    )
 
 
 def _check_regular_chunks(chunkset):

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -5067,6 +5067,40 @@ def test_zarr_existing_array():
     assert a2.chunks == a.chunks
 
 
+def test_zarr_existing_array_aligned_chunks(tmp_path):
+    zarr = pytest.importorskip("zarr")
+    # https://github.com/dask/dask/issues/12458
+    # Chunks aligned with the target array must be written as-is, without
+    # warning or rechunking to the "auto" heuristic
+    a = da.from_array(np.arange(50000), chunks=9999)
+    z = zarr.create_array(str(tmp_path), shape=a.shape, chunks=(9999,), dtype=a.dtype)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", PerformanceWarning)
+        store_delayed = a.to_zarr(z, compute=False)
+    assert not any("rechunk" in key_split(k) for k in dict(store_delayed.dask))
+    store_delayed.compute()
+    a2 = da.from_zarr(z)
+    assert_eq(a, a2)
+
+
+@pytest.mark.parametrize(
+    "dask_chunks,zarr_chunks,expected",
+    [
+        (((9999, 9999, 9999, 9999, 9999, 5),), (9999,), True),
+        (((10, 5, 2),), (5,), True),
+        (((7, 3, 5),), (5,), False),
+        (((5, 5),), (10,), False),
+        (((3,),), (5,), True),
+        (((4, 4), (6, 3)), (2, 3), True),
+        (((4, 4), (5, 4)), (2, 3), False),
+    ],
+)
+def test_chunks_aligned_with_zarr(dask_chunks, zarr_chunks, expected):
+    from dask.array.core import _chunks_aligned_with_zarr
+
+    assert _chunks_aligned_with_zarr(dask_chunks, zarr_chunks) == expected
+
+
 def test_to_zarr_unknown_chunks_raises():
     pytest.importorskip("zarr")
     a = da.random.default_rng().random((10,), chunks=(3,))

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -5067,13 +5067,13 @@ def test_zarr_existing_array():
     assert a2.chunks == a.chunks
 
 
-def test_zarr_existing_array_aligned_chunks(tmp_path):
+def test_zarr_existing_array_aligned_chunks():
     zarr = pytest.importorskip("zarr")
     # https://github.com/dask/dask/issues/12458
     # Chunks aligned with the target array must be written as-is, without
     # warning or rechunking to the "auto" heuristic
     a = da.from_array(np.arange(50000), chunks=9999)
-    z = zarr.create_array(str(tmp_path), shape=a.shape, chunks=(9999,), dtype=a.dtype)
+    z = zarr.zeros_like(a, chunks=(9999,))
     with warnings.catch_warnings():
         warnings.simplefilter("error", PerformanceWarning)
         store_delayed = a.to_zarr(z, compute=False)

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -5083,6 +5083,22 @@ def test_zarr_existing_array_aligned_chunks():
     assert_eq(a, a2)
 
 
+def test_zarr_existing_array_aligned_shards():
+    zarr = pytest.importorskip(
+        "zarr", minversion="3", reason="Zarr 3 or higher needed for sharding"
+    )
+    # https://github.com/dask/dask/issues/12458
+    # Chunks aligned with the shard grid must be written as-is too
+    a = da.from_array(np.arange(1000, dtype="uint8"), chunks=400)
+    z = zarr.create_array({}, shape=a.shape, chunks=(100,), shards=(200,), dtype=a.dtype)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", PerformanceWarning)
+        store_delayed = a.to_zarr(z, compute=False)
+    assert not any("rechunk" in key_split(k) for k in dict(store_delayed.dask))
+    store_delayed.compute()
+    assert_eq(a, da.from_zarr(z))
+
+
 @pytest.mark.parametrize(
     "dask_chunks,zarr_chunks,expected",
     [

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -5090,7 +5090,9 @@ def test_zarr_existing_array_aligned_shards():
     # https://github.com/dask/dask/issues/12458
     # Chunks aligned with the shard grid must be written as-is too
     a = da.from_array(np.arange(1000, dtype="uint8"), chunks=400)
-    z = zarr.create_array({}, shape=a.shape, chunks=(100,), shards=(200,), dtype=a.dtype)
+    z = zarr.create_array(
+        {}, shape=a.shape, chunks=(100,), shards=(200,), dtype=a.dtype
+    )
     with warnings.catch_warnings():
         warnings.simplefilter("error", PerformanceWarning)
         store_delayed = a.to_zarr(z, compute=False)


### PR DESCRIPTION
- [x] Closes #12458
- [x] Tests added / passed
- [x] Passes `pixi run lint`

Writing a dask array to an existing `zarr.Array` always recomputed the write chunks with the `"auto"` heuristic and rechunked to them, even when the input array's chunks already sit on the target's chunk (or shard) grid. In the issue's repro (dask chunks == zarr chunks == 9999) this emitted a spurious `PerformanceWarning` and inserted a pointless rechunk layer into the graph.

`_write_dask_to_existing_zarr` now checks alignment first (every chunk boundary on the zarr chunk grid, i.e. along each axis every chunk except the last is divisible by the zarr write chunk) and stores directly when it holds. Misaligned inputs keep the existing rechunk-and-warn behavior, and the `region=` path is unchanged.

Verified: issue repro produces no warning and no rechunk layer with correct data; misaligned and multiple-of-zarr-chunk inputs still round-trip correctly; the zarr tests in `test_array_core.py` pass; the new regression test fails without the fix.