### PR TITLE
reject non-http(s) urls in bag.from_url

### DIFF
--- a/dask/bag/core.py
+++ b/dask/bag/core.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Iterator, Sequence
 from functools import partial, reduce, wraps
 from random import Random
+from urllib.parse import urlsplit
 from urllib.request import urlopen
 
 import tlz as toolz
@@ -1813,6 +1814,17 @@ def from_sequence(seq, partition_size=None, npartitions=None):
     return Bag(d, name, len(d))
 
 
+def _open_url(url):
+    # from_url is meant for remote HTTP(S) fetches, but urlopen also honors
+    # file://, ftp:// and data: URLs, so an attacker-controlled url string
+    # turns into a local-file read or an SSRF request. Pin the scheme here,
+    # at the fetch site, so the check applies to the url actually opened.
+    scheme = urlsplit(url).scheme.lower()
+    if scheme not in ("http", "https"):
+        raise ValueError(f"from_url only supports http and https URLs, got {url!r}")
+    return urlopen(url)
+
+
 def from_url(urls):
     """Create a dask Bag from a url.
 
@@ -1841,7 +1853,7 @@ def from_url(urls):
     name = f"from_url-{uuid.uuid4().hex}"
     dsk = {}
     for i, u in enumerate(urls):
-        dsk[(name, i)] = (list, (urlopen, u))
+        dsk[(name, i)] = (list, (_open_url, u))
     return Bag(dsk, name, len(urls))
 
 

--- a/dask/bag/tests/test_bag.py
+++ b/dask/bag/tests/test_bag.py
@@ -689,6 +689,12 @@ def test_from_url():
     assert b"Dask\n" in b.take(10)
 
 
+@pytest.mark.parametrize("url", ["file:///etc/hostname", "ftp://x/y", "data:,hi"])
+def test_from_url_rejects_non_http(url):
+    with pytest.raises(ValueError, match="http"):
+        db.from_url(url).compute(scheduler="sync")
+
+
 def test_read_text():
     with filetexts({"a1.log": "A\nB", "a2.log": "C\nD"}) as fns:
         assert {line.strip() for line in db.read_text(fns)} == set("ABCD")


### PR DESCRIPTION
from_url builds tasks that call urllib.request.urlopen on each url, and urlopen also resolves file://, ftp:// and data: URLs, so a from_url call with an attacker-influenced string reads a local file (file:///etc/passwd) or reaches an internal host even though the helper is documented for http(s). Validate the scheme at the fetch site and reject anything other than http/https.

- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pixi run lint`