### PR TITLE
reject fixed-format hdf before deserializing in read_hdf

### DIFF
--- a/dask/dataframe/io/hdf.py
+++ b/dask/dataframe/io/hdf.py
@@ -409,6 +409,13 @@ def read_hdf(
     # Build metadata
     with pd.HDFStore(paths[0], mode=mode) as hdf:
         meta_key = _expand_key(key, hdf)[0]
+        # Only 'table'-format datasets are partitionable, so reject anything
+        # else up front. pd.read_hdf deserializes 'fixed'-format data (which
+        # may contain arbitrary pickled objects) the moment it is called, so
+        # this check has to happen before the read below and not just in
+        # _get_keys_stops_divisions.
+        if hdf.get_storer(meta_key).format_type != "table":
+            raise TypeError(dont_use_fixed_error_message)
         try:
             meta = pd.read_hdf(hdf, meta_key, stop=0)
         except IndexError:  # if file is empty, don't set stop

--- a/dask/dataframe/io/tests/test_hdf.py
+++ b/dask/dataframe/io/tests/test_hdf.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import pathlib
+import warnings
 from functools import cache
 from time import sleep
 
@@ -616,6 +617,34 @@ def test_read_hdf(data, compare):
         assert a.npartitions == 2
 
         compare(a.compute(), sorted_data)
+
+
+_unpickle_calls = []
+
+
+def _record_unpickle():
+    _unpickle_calls.append(True)
+    return "payload"
+
+
+class _ExecOnUnpickle:
+    def __reduce__(self):
+        return (_record_unpickle, ())
+
+
+def test_read_hdf_fixed_format_not_deserialized():
+    # 'fixed'-format stores pickle object columns, so reading one runs the
+    # embedded pickle. read_hdf only supports 'table' format, and must reject
+    # a fixed-format file before touching its contents.
+    pytest.importorskip("tables")
+    _unpickle_calls.clear()
+    with tmpfile("h5") as fn:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            pd.DataFrame({"x": [_ExecOnUnpickle()]}).to_hdf(fn, key="/data")
+        with pytest.raises(TypeError, match="format='table'"):
+            dd.read_hdf(fn, "/data", mode="r")
+    assert not _unpickle_calls
 
 
 def test_read_hdf_multiply_open():


### PR DESCRIPTION
- [ ] Closes #xxxx
- [x] Tests added / passed
- [x] Passes `pixi run lint`

**Fixed-format HDF deserialized before it is rejected in `read_hdf`**
`read_hdf` only supports `table`-format datasets, but the guard that enforces this lives in `_get_keys_stops_divisions`, which runs after the metadata read that calls `pd.read_hdf` on the store. A `fixed`-format file pickles its object columns, so reading one authored elsewhere runs its pickle payload before the format check fires. Moved the `format_type` guard ahead of the read so an unsupported file is refused without deserializing it.