### PR TITLE
Return an empty slice for negative-step slices that start before the array

### DIFF
--- a/dask/array/slicing.py
+++ b/dask/array/slicing.py
@@ -789,6 +789,12 @@ def normalize_slice(idx, dim):
             if stop is not None and start is not None and stop < start:
                 stop = start
         elif step < 0:
+            if start == -1:
+                # ``idx.indices`` returns ``start == -1`` as a sentinel for a
+                # negative-step slice that begins before the array (an empty
+                # selection). Keeping it would later be reinterpreted as the
+                # last element, so select nothing instead.
+                return slice(0, 0, step)
             if start >= dim - 1:
                 start = None
             if stop < 0:

--- a/dask/array/tests/test_slicing.py
+++ b/dask/array/tests/test_slicing.py
@@ -837,6 +837,21 @@ def test_negative_list_slicing():
     assert_eq(dx[[4, -1]], x[[4, -1]])
 
 
+def test_negative_step_slice_before_start():
+    # A negative-step slice that starts before the array is an empty selection
+    # (``idx.indices`` returns the ``start == -1`` sentinel); it must not wrap
+    # around to the last element, on read or on assignment.
+    x = np.arange(10)
+    dx = da.from_array(x, chunks=2)
+    assert_eq(dx[-11:-7:-2], x[-11:-7:-2])
+
+    xn = np.arange(10)
+    xd = da.arange(10, chunks=2)
+    xn[-11:-7:-2] = -1
+    xd[-11:-7:-2] = -1
+    assert_eq(xd, xn)
+
+
 def test_permit_oob_slices():
     x = np.arange(5)
     dx = da.from_array(x, chunks=2)


### PR DESCRIPTION
Fixes #10555.

### Problem

`normalize_slice` mishandles a negative-step slice that begins before the start of the array, producing wrong reads **and silent data corruption on assignment**:

```python
>>> import numpy as np, dask.array as da
>>> np.arange(10)[-11:-7:-2]
array([], dtype=int64)
>>> da.arange(10, chunks=2)[-11:-7:-2].compute()
array([9, 7, 5])                              # should be empty

>>> x = da.arange(10, chunks=2); x[-11:-7:-2] = -1; x.compute()
array([ 0,  1,  2,  3,  4, -1,  6, -1,  8, -1])   # numpy leaves x unchanged
```

The read is chunk-independent (a single chunk is wrong too), and the assignment case silently writes `-1` into indices 5/7/9 that numpy leaves untouched.

### Cause

For a negative step, `slice(-11, -7, -2).indices(10)` returns `(-1, 3, -2)`, where `start == -1` is Python's sentinel for "before the beginning" (an empty selection). `normalize_slice`'s `step < 0` branch only rewrites `start` when `start >= dim - 1`, so the `-1` survives into `slice(-1, 3, -2)` and is later reinterpreted as the last element (index 9), turning the empty selection into `[9, 7, 5]`.

### Fix

Return an explicitly empty slice when `start == -1`. `normalize_slice` feeds `__getitem__`, `parse_assignment_indices` (`__setitem__`), and the array-expr backend, so this single fix covers all three paths.

### Tests

Added `test_negative_step_slice_before_start` (read + assignment); it fails before the change and passes after. I also fuzzed `getitem` against numpy over dims 0..12 × start/stop in [-15, 15] × steps [-3..3] — **0 mismatches** with the fix (1620 wrong without it); `test_slicing.py` and `test_reshape.py` stay green (173 passed).

(Note: the fix suggested inside #10555, `return slice(*idx.indices(dim))`, is insufficient — it still yields `slice(-1, 3, -2)` and stays buggy; and the assignment-corruption manifestation isn't mentioned there.)
