### PR TITLE
Prevent hash-dependent high-level graph culling

### DIFF
--- a/dask/_task_spec.py
+++ b/dask/_task_spec.py
@@ -1193,7 +1193,9 @@ def cull(
             f"Expected list, set or tuple for keys, got {type(keys).__name__}"
         )
     if len(keys) == len(dsk):
-        return dsk
+        keys_set = keys if isinstance(keys, set) else set(keys)
+        if keys_set == dsk.keys():
+            return dsk
     work = set(keys)
     seen: set[KeyType] = set()
     dsk2 = {}

--- a/dask/array/tests/test_optimization.py
+++ b/dask/array/tests/test_optimization.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+import json
+import os
+import re
+import subprocess
+import sys
+
 import pytest
 
 from dask._task_spec import Alias, DataNode
@@ -38,6 +44,97 @@ def _check_get_task_eq(a, b) -> bool:
         elif ae != be:
             return False
     return True
+
+
+def _hash_seed_cull_result():
+    block_size = 32
+    nt, ny, nx = 2, 2, 4
+
+    def identity(block):
+        return block
+
+    def read(i, j, t):
+        value = t * 10_000 + i * 100 + j
+        return np.full((block_size, block_size), value, dtype=float)
+
+    times = []
+    for t in range(nt):
+        rows = []
+        for i in range(ny):
+            row = [
+                da.from_delayed(
+                    dask.delayed(read)(
+                        i,
+                        j,
+                        t,
+                        dask_key_name=f"read-{t}-{i}-{j}",
+                    ),
+                    (block_size, block_size),
+                    dtype=float,
+                )
+                for j in range(nx)
+            ]
+            rows.append(da.concatenate(row, axis=1))
+        times.append(da.concatenate(rows, axis=0)[None])
+
+    source = da.concatenate(times, axis=0)
+    overlapped = source.map_overlap(
+        identity,
+        depth={1: 2, 2: 2},
+        boundary="none",
+    )
+    selected = overlapped.rechunk((nt, block_size, block_size))[:, :8, :8]
+    (optimized,) = dask.optimize(selected)
+    result = optimized.compute(scheduler="sync", optimize_graph=False)
+    expected = np.broadcast_to(
+        np.arange(nt, dtype=float)[:, None, None] * 10_000,
+        (nt, 8, 8),
+    )
+
+    def normalize_key(key):
+        if isinstance(key, tuple):
+            name, *coordinates = key
+            return (re.sub(r"-[0-9a-f]{32}", "", name), *coordinates)
+        return re.sub(r"-[0-9a-f]{32}", "", key)
+
+    return {
+        "task_count": len(optimized.__dask_graph__()),
+        "normalized_keys": sorted(
+            map(str, map(normalize_key, optimized.__dask_graph__()))
+        ),
+        "shape": result.shape,
+        "dtype": str(result.dtype),
+        "time_values": result[:, 0, 0].tolist(),
+        "matches_expected": np.array_equal(result, expected),
+    }
+
+
+def test_cull_is_hash_seed_independent():
+    code = (
+        "import json; "
+        "from dask.array.tests.test_optimization import _hash_seed_cull_result; "
+        "print(json.dumps(_hash_seed_cull_result(), sort_keys=True))"
+    )
+    results = {}
+    for seed in (0, 7):
+        env = os.environ.copy()
+        env["PYTHONHASHSEED"] = str(seed)
+        completed = subprocess.run(
+            [sys.executable, "-c", code],
+            check=True,
+            capture_output=True,
+            env=env,
+            text=True,
+        )
+        results[seed] = json.loads(completed.stdout)
+
+    assert results[0]["task_count"] == results[7]["task_count"] == 22
+    assert results[0]["normalized_keys"] == results[7]["normalized_keys"]
+    for result in results.values():
+        assert result["shape"] == [2, 8, 8]
+        assert result["dtype"] == "float64"
+        assert result["time_values"] == [0.0, 10_000.0]
+        assert result["matches_expected"]
 
 
 def test_optimize_with_getitem_fusion():

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -150,7 +150,7 @@ class Layer(Graph):
         """
 
         if self.has_legacy_tasks:
-            if len(keys) == len(self):
+            if len(keys) == len(self) and keys == self.keys():
                 # Nothing to cull if preserving all existing keys
                 return (
                     self,
@@ -763,20 +763,21 @@ class HighLevelGraph(Graph):
         layer_dependencies = {}
         tok = tokenize(keys_set)
         for layer_name in reversed(self._toposort_layers()):
+            if not keys_set:
+                break
             new_layer_name = f"{layer_name}-{tok}"
             layer = self.layers[layer_name]
-            if keys_set:
-                culled_layer, culled_deps = layer.cull(keys_set, all_ext_keys)
-                if not culled_deps:
-                    continue
+            culled_layer, culled_deps = layer.cull(keys_set, all_ext_keys)
+            if not culled_deps:
+                continue
 
-                # Update `keys` with all layer's external key dependencies,
-                # which are all the layer's dependencies (`culled_deps`)
-                # excluding the layer's output keys.
-                for k, d in culled_deps.items():
-                    keys_set |= d
-                    keys_set.discard(k)
-                layer = culled_layer
+            # Update `keys` with all layer's external key dependencies,
+            # which are all the layer's dependencies (`culled_deps`)
+            # excluding the layer's output keys.
+            for k, d in culled_deps.items():
+                keys_set |= d
+                keys_set.discard(k)
+            layer = culled_layer
             # Save the culled layer and its key dependencies
             ret_layers[new_layer_name] = layer
             layer_dependencies[new_layer_name] = self.dependencies[layer_name]

--- a/dask/tests/test_highgraph.py
+++ b/dask/tests/test_highgraph.py
@@ -9,6 +9,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 import dask
+from dask._task_spec import DataNode
 from dask.base import collections_to_expr, tokenize
 from dask.blockwise import Blockwise
 from dask.delayed import Delayed
@@ -101,12 +102,28 @@ def test_cull():
     a = {"x": 1, "y": (inc, "x")}
     hg = HighLevelGraph({"a": a}, {"a": set()})
 
+    assert not hg.cull([])
+
     culled_by_x = hg.cull({"x"})
     assert dict(culled_by_x) == {"x": 1}
 
     # parameter is the raw output of __dask_keys__()
     culled_by_y = hg.cull([[["y"]]])
     assert dict(culled_by_y) == a
+
+
+@pytest.mark.parametrize("task_spec", [False, True])
+def test_cull_filters_same_cardinality_foreign_keys(task_spec):
+    def value(key):
+        return DataNode(key, 1) if task_spec else 1
+
+    layers = {
+        name: {(name, i): value((name, i)) for i in range(2)} for name in ("a", "b")
+    }
+    hg = HighLevelGraph(layers, {name: set() for name in layers})
+    requested = {("a", 0), ("b", 0)}
+
+    assert set(hg.cull(requested)) == requested
 
 
 def test_cull_layers():


### PR DESCRIPTION
> [!NOTE]
> Codex and Claude Code assisted with the investigation, implementation, and review. I have personally reviewed, understood, and approved the final changes, and I take responsibility for the contribution and follow-up.

## Summary

- verify exact key ownership before equal-cardinality culling shortcuts retain an entire layer
- stop reverse-topological culling once no required keys remain
- add causal legacy/task-spec coverage and a subprocess hash-seed regression with a numerical output oracle

## Validation

- `python -m pytest dask/tests/test_highgraph.py -q`
- `python -m pytest dask/array/tests/test_optimization.py -q`
- `python -m pytest dask/tests/test_task_spec.py -q`
- `python -m pytest dask/tests/test_delayed.py -q`
- issue reproducer: seeds 0 through 7 all optimize to 82 tasks; seeds 0 and 7 compute the expected `(8, 100, 100)` float64 coordinate-encoded result
- Ruff 0.15.10, Black 26.3.1, and `git diff --check`

- [x] Closes #12507
- [x] Tests added / passed
- [ ] Passes `pixi run lint` — Pixi is unavailable locally; the repository-pinned Ruff and Black checks pass.