### PR TITLE
[unsupervised AI] Fix Zarr writes for NumPy matrix chunks

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -4037,6 +4037,10 @@ def to_zarr(
             f"currently supported by Zarr.{unknown_chunk_message}"
         )
 
+    # Zarr v3 cannot encode np.matrix chunks, so normalize them to ndarrays.
+    if isinstance(arr._meta, np.matrix):
+        arr = arr.map_blocks(np.asarray, dtype=arr.dtype, meta=np.asarray(arr._meta))
+
     zarr_array_kwargs = {} if zarr_array_kwargs is None else dict(zarr_array_kwargs)
     if component is not None and "name" in zarr_array_kwargs:
         raise ValueError(

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4964,6 +4964,17 @@ def test_zarr_roundtrip():
         assert a2.chunks == a.chunks
 
 
+@pytest.mark.filterwarnings("ignore:the matrix subclass")
+def test_zarr_roundtrip_numpy_matrix(tmp_path):
+    pytest.importorskip("zarr", minversion="3.0.0")
+    matrix = np.matrix(np.arange(100).reshape(10, 10))
+    path = tmp_path / "matrix.zarr"
+
+    da.from_array(matrix).to_zarr(path, zarr_format=3)
+
+    assert_eq(da.from_zarr(path), np.asarray(matrix))
+
+
 @pytest.mark.slow
 @pytest.mark.parametrize(
     "chunks, shards",


### PR DESCRIPTION
> [!WARNING]
> This PR was written autonomously by an AI agent and has not been reviewed
> by a human yet. Maintainers should ignore it until the human author has **reviewed,
> understood, and approved** everything that the AI agent wrote.

- [x] Closes #12177
- [x] Tests added / passed
- [x] Passes `pixi run lint`

Fixes #12177.

`to_zarr` now normalizes NumPy matrix-backed chunks to plain ndarrays before handing them to Zarr. This preserves Dask's existing `numpy.matrix` behavior elsewhere while avoiding Zarr v3's one-dimensional buffer error.

Added a Zarr v3 regression test covering a matrix-backed Dask array.

Tests:

- `python -m pytest dask/array/tests/test_array_core.py::test_zarr_roundtrip_numpy_matrix -q` (1 passed)
- `python -m pytest dask/array/tests/test_array_core.py -k zarr -q` (31 passed, 3 skipped)
- `pre-commit run --files dask/array/core.py dask/array/tests/test_array_core.py` (passed, including Ruff, Black, and mypy)
