### PR TITLE
fix(dataframe): treat empty labels=[] as no-op in drop(axis=1)

### DIFF
--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -3314,7 +3314,9 @@ class DataFrame(FrameBase):
         axis = _validate_axis(axis)
 
         if axis == 1:
-            columns = labels or columns
+            # Use identity check so empty labels=[] is preserved (pandas-compatible).
+            # `labels or columns` treats [] as falsey and incorrectly becomes None (#12510).
+            columns = labels if columns is None else columns
         elif axis == 0 and columns is None:
             raise NotImplementedError(
                 "Drop currently only works for axis=1 or when columns is not None"

--- a/dask/dataframe/dask_expr/tests/test_collection.py
+++ b/dask/dataframe/dask_expr/tests/test_collection.py
@@ -872,6 +872,13 @@ def test_drop_not_implemented(pdf, df):
         df.drop(axis=0, labels=[0])
 
 
+def test_drop_empty_list_axis1_matches_pandas(pdf, df):
+    """Empty labels=[] must no-op like pandas, not raise ValueError (#12510)."""
+    assert_eq(df.drop([], axis=1), pdf.drop([], axis=1))
+    assert_eq(df.drop(labels=[], axis=1), pdf.drop(labels=[], axis=1))
+    assert_eq(df.drop(columns=[]), pdf.drop(columns=[]))
+
+
 @xfail_gpu("func not supported by cudf")
 @pytest.mark.parametrize(
     "func",


### PR DESCRIPTION
## Description

`DataFrame.drop` used:

```python
columns = labels or columns
```

for `axis=1`. An empty list is falsey, so `drop([], axis=1)` / `drop(labels=[], axis=1)` set `columns=None` and failed, while pandas no-ops.

## Fix

```python
columns = labels if columns is None else columns
```

## Test

Local verification:

```python
ddf.drop([], axis=1).compute()          # equals original
ddf.drop(labels=[], axis=1).compute()   # equals original
ddf.drop(columns=[]).compute()          # equals original
```

Added `test_drop_empty_list_axis1_matches_pandas`.

## Linked Issue

Closes #12510
