### PR TITLE
Adding SeriesGroupBy.nlargest and nsmallest

### DIFF
--- a/dask/dataframe/dask_expr/_groupby.py
+++ b/dask/dataframe/dask_expr/_groupby.py
@@ -66,8 +66,10 @@ from dask.dataframe.groupby import (
     _groupby_slice_transform,
     _head_aggregate,
     _head_chunk,
+    _nlargest_aggregate,
     _non_agg_chunk,
     _normalize_spec,
+    _nsmallest_aggregate,
     _nunique_df_chunk,
     _nunique_df_combine,
     _tail_aggregate,
@@ -870,6 +872,19 @@ class Head(SingleAggregation):
 class Tail(Head):
     groupby_chunk = staticmethod(_tail_chunk)
     groupby_aggregate = staticmethod(_tail_aggregate)
+
+
+class NLargest(SingleAggregation):
+    # ``nlargest`` keeps the group keys in the index, so the intermediate
+    # results can be reduced again by regrouping on those levels. The extra
+    # levels that regrouping adds are dropped in the aggregation step.
+    groupby_chunk = M.nlargest
+    groupby_aggregate = staticmethod(_nlargest_aggregate)
+
+
+class NSmallest(SingleAggregation):
+    groupby_chunk = M.nsmallest
+    groupby_aggregate = staticmethod(_nsmallest_aggregate)
 
 
 class GroupByApply(Expr, GroupByBase):
@@ -2241,6 +2256,41 @@ class SeriesGroupBy(GroupBy):
     @derived_from(pd.core.groupby.SeriesGroupBy)
     def unique(self, **kwargs):
         return self._single_agg(Unique, **kwargs)
+
+    @derived_from(pd.core.groupby.SeriesGroupBy)
+    def nlargest(self, n=5, keep="first", split_every=None, split_out=None):
+        return self._n_largest_smallest(
+            NLargest, n=n, keep=keep, split_every=split_every, split_out=split_out
+        )
+
+    @derived_from(pd.core.groupby.SeriesGroupBy)
+    def nsmallest(self, n=5, keep="first", split_every=None, split_out=None):
+        return self._n_largest_smallest(
+            NSmallest, n=n, keep=keep, split_every=split_every, split_out=split_out
+        )
+
+    def _n_largest_smallest(self, expr_cls, n, keep, split_every, split_out):
+        if keep == "last":
+            # ``keep="last"`` returns tied values in reverse order of appearance,
+            # so the second pass over the per-partition results would break the
+            # tie in favour of the wrong row.
+            raise NotImplementedError(
+                "keep='last' is not supported for a dask SeriesGroupBy, only "
+                "keep='first' and keep='all'."
+            )
+        chunk_kwargs = {"n": n, "keep": keep}
+        aggregate_kwargs = {
+            "n": n,
+            "keep": keep,
+            "index_levels": len(self.by) if not isinstance(self.by, Expr) else 1,
+        }
+        return self._single_agg(
+            expr_cls,
+            split_every=split_every,
+            split_out=split_out,
+            chunk_kwargs=chunk_kwargs,
+            aggregate_kwargs=aggregate_kwargs,
+        )
 
     def idxmin(
         self,

--- a/dask/dataframe/groupby.py
+++ b/dask/dataframe/groupby.py
@@ -1260,3 +1260,13 @@ def _head_chunk(series_gb, **kwargs):
 def _head_aggregate(series_gb, **kwargs):
     levels = kwargs.pop("index_levels")
     return series_gb.head(**kwargs).droplevel(list(range(levels)))
+
+
+def _nlargest_aggregate(series_gb, **kwargs):
+    levels = kwargs.pop("index_levels")
+    return series_gb.nlargest(**kwargs).droplevel(list(range(levels)))
+
+
+def _nsmallest_aggregate(series_gb, **kwargs):
+    levels = kwargs.pop("index_levels")
+    return series_gb.nsmallest(**kwargs).droplevel(list(range(levels)))

--- a/dask/dataframe/tests/test_groupby.py
+++ b/dask/dataframe/tests/test_groupby.py
@@ -2110,6 +2110,62 @@ def test_groupby_unique(int_dtype):
     assert_eq(dd_gb.explode(), pd_gb.explode())
 
 
+@pytest.fixture
+def nlargest_frame():
+    rng = np.random.RandomState(42)
+    df = pd.DataFrame(
+        {
+            "foo": rng.randint(4, size=60),
+            "bar": rng.randint(3, size=60),
+            "baz": rng.rand(60),
+        }
+    )
+    # Ties, so that ``keep`` actually has something to break
+    df.loc[:20, "baz"] = 0.5
+    return df
+
+
+@pytest.mark.parametrize("method", ["nlargest", "nsmallest"])
+@pytest.mark.parametrize("by", ["foo", ["foo", "bar"]])
+@pytest.mark.parametrize("n", [1, 3, 10])
+@pytest.mark.parametrize("keep", ["first", "all"])
+def test_groupby_nlargest_nsmallest(nlargest_frame, method, by, n, keep):
+    df = nlargest_frame
+    ddf = dd.from_pandas(df, npartitions=5)
+
+    pd_gb = getattr(df.groupby(by).baz, method)(n=n, keep=keep)
+    dd_gb = getattr(ddf.groupby(by).baz, method)(n=n, keep=keep)
+    assert_eq(dd_gb, pd_gb)
+
+
+@pytest.mark.parametrize("method", ["nlargest", "nsmallest"])
+def test_groupby_nlargest_nsmallest_defaults(nlargest_frame, method):
+    df = nlargest_frame
+    ddf = dd.from_pandas(df, npartitions=5)
+
+    assert_eq(
+        getattr(ddf.groupby("foo").baz, method)(),
+        getattr(df.groupby("foo").baz, method)(),
+    )
+    # Grouping by a Series rather than a column name
+    assert_eq(
+        getattr(ddf.groupby(ddf.foo).baz, method)(2),
+        getattr(df.groupby(df.foo).baz, method)(2),
+    )
+    # split_every forces a multi-stage tree reduction
+    assert_eq(
+        getattr(ddf.groupby("foo").baz, method)(2, split_every=2),
+        getattr(df.groupby("foo").baz, method)(2),
+    )
+
+
+@pytest.mark.parametrize("method", ["nlargest", "nsmallest"])
+def test_groupby_nlargest_nsmallest_keep_last_raises(nlargest_frame, method):
+    ddf = dd.from_pandas(nlargest_frame, npartitions=5)
+    with pytest.raises(NotImplementedError, match="keep='last'"):
+        getattr(ddf.groupby("foo").baz, method)(2, keep="last")
+
+
 @pytest.mark.parametrize("by", ["foo", ["foo", "bar"]])
 @pytest.mark.parametrize("int_dtype", ["uint8", "int32", "int64"])
 def test_groupby_value_counts(by, int_dtype):

--- a/docs/source/dataframe-api.rst
+++ b/docs/source/dataframe-api.rst
@@ -571,6 +571,8 @@ Series Groupby
    SeriesGroupBy.max
    SeriesGroupBy.mean
    SeriesGroupBy.min
+   SeriesGroupBy.nlargest
+   SeriesGroupBy.nsmallest
    SeriesGroupBy.nunique
    SeriesGroupBy.size
    SeriesGroupBy.std


### PR DESCRIPTION
- [x] Closes #10632 
- [x] Tests added / passed
- [x] Passes `pixi run lint`

Adding `nlargest` and `nsmallest` to `SeriesGroupBy` for parity with the pandas API. Both are
implemented as `SingleAggregation` expressions following the existing `Head`/`Tail` pattern:
pandas keeps the group keys in the result index, so the per-partition results can be regrouped
on those levels and reduced again, with the aggregation step dropping the duplicate index
levels that regrouping introduces.

`keep="first"` (the default) and `keep="all"` behave as in pandas. `keep="last"` raises
`NotImplementedError`, because pandas returns tied values in reverse order of appearance in
that mode — `pd.Series([0.5, 0.5, 0.5, 0.9], index=[14, 18, 20, 25]).nsmallest(3, keep="last")`
returns `20, 18, 14` — so a second reduction pass over the per-partition results would break
ties in favour of the wrong row.