### PR TITLE
docs: fix duplicated-word typos in docstrings

### DIFF
--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -3433,7 +3433,7 @@ class DataFrame(FrameBase):
         A common case is when we have a datetime column that we know to be
         sorted and is cleanly divided by day.  We can set this index for free
         by specifying both that the column is pre-sorted and the particular
-        divisions along which is is separated
+        divisions along which is separated
 
         >>> import pandas as pd
         >>> divisions = pd.date_range(start="2021-01-01", end="2021-01-07", freq='1D')

--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -3433,7 +3433,7 @@ class DataFrame(FrameBase):
         A common case is when we have a datetime column that we know to be
         sorted and is cleanly divided by day.  We can set this index for free
         by specifying both that the column is pre-sorted and the particular
-        divisions along which is separated
+        divisions along which it is separated
 
         >>> import pandas as pd
         >>> divisions = pd.date_range(start="2021-01-01", end="2021-01-07", freq='1D')

--- a/dask/dataframe/dask_expr/_groupby.py
+++ b/dask/dataframe/dask_expr/_groupby.py
@@ -1983,7 +1983,7 @@ Please provide `meta` if the result is unexpected.
 
         .. warning::
 
-           Pandas' groupby-apply can be used to to apply arbitrary functions,
+           Pandas' groupby-apply can be used to apply arbitrary functions,
            including aggregations that result in one row per group. Dask's
            groupby-apply will apply ``func`` once on each group, doing a shuffle
            if needed, such that each group is contained in one partition.

--- a/dask/dataframe/partitionquantiles.py
+++ b/dask/dataframe/partitionquantiles.py
@@ -31,7 +31,7 @@ Let us describe this to a child of five.  We are given many small cubes
 (of equal size) with numbers on them.  Split these into many piles.  This
 is like the original data.  Let's sort and stack the cubes from one of the
 piles.  Next, we are given a bunch of unlabeled blocks of different sizes,
-and most are much larger than the the original cubes.  Stack these blocks
+and most are much larger than the original cubes.  Stack these blocks
 until they're the same height as our first stack.  Let's write a number on
 each block of the new stack.  To do this, choose the number of the cube in
 the first stack that is located in the middle of an unlabeled block.  We

--- a/dask/tests/test_config.py
+++ b/dask/tests/test_config.py
@@ -753,7 +753,7 @@ def test_default_search_paths():
 
 def test_config_files_order(tmp_path, monkeypatch):
     """Test that config files in different directories are read in priority order, while
-    within the the same directory are read in alphabetical order, regardless of what
+    within the same directory are read in alphabetical order, regardless of what
     order the syscalls return them in. os.listdir _typically_ returns results in
     alphabetical order but there is no guarantee in POSIX for it.
     """


### PR DESCRIPTION
- [ ] Closes #xxxx  (no issue; trivial typo cleanup)
- [x] Tests added / passed  (docs-only change; no test impact)
- [ ] Passes `pixi run lint`  (text-only change in docstrings; I did not run pixi locally, but it only removes accidental repeated words, so it cannot affect lint)

Removes a few accidental repeated words in docstrings and one test docstring. Text only, no behavior change.

- `dask/dataframe/partitionquantiles.py`: "the the original cubes" -> "the original cubes"
- `dask/dataframe/dask_expr/_groupby.py`: "used to to apply" -> "used to apply"
- `dask/dataframe/dask_expr/_collection.py`: "which is is separated" -> "which is separated"
- `dask/tests/test_config.py`: "within the the same directory" -> "within the same directory"

I deliberately left `dask/dataframe/shuffle.py` "The dtype to cast to to avoid nullability issues" unchanged, since that is a legitimate "cast to, to avoid" and not a repeated word.