### PR TITLE
Fix full docstring wrapper

### DIFF
--- a/dask/array/tests/test_wrap.py
+++ b/dask/array/tests/test_wrap.py
@@ -54,7 +54,10 @@ def test_full_docstring_and_signature():
     assert list(inspect.signature(da.full).parameters)[:2] == ["shape", "fill_value"]
     assert da.full.__doc__ is not None
     assert "Blocked variant of full\n" in da.full.__doc__
-    assert np.full.__doc__ in da.full.__doc__
+    assert "fill_value : scalar\n" in da.full.__doc__
+    assert "fill_value : scalar or array_like" not in da.full.__doc__
+    assert ">>> np.full((2, 2), 10)" in da.full.__doc__
+    assert ">>> np.full((2, 2), [1, 2])" not in da.full.__doc__
 
 
 def test_full_like_keyword():

--- a/dask/array/tests/test_wrap.py
+++ b/dask/array/tests/test_wrap.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import inspect
+import pickle
+
 import pytest
 
 pytest.importorskip("numpy")
@@ -43,7 +46,41 @@ def test_full():
     assert (a.compute() == 100).all()
     assert a.dtype == a.compute(scheduler="sync").dtype == "i8"
 
+    # np.full_like remains the backend-aware implementation.
     assert a.name.startswith("full_like-")
+
+
+def test_full_docstring_and_signature():
+    assert list(inspect.signature(da.full).parameters)[:2] == ["shape", "fill_value"]
+    assert da.full.__doc__ is not None
+    assert "Blocked variant of full\n" in da.full.__doc__
+    assert np.full.__doc__ in da.full.__doc__
+
+
+def test_full_like_keyword():
+    like = np.array((), dtype=np.float32)
+    result = da.full((2, 3), 7, chunks=(1, 2), like=like)
+    expected = np.full((2, 3), 7, like=like)
+
+    assert type(result._meta) is type(expected)
+    assert_eq(result, expected)
+
+    result = da.full((2, 3), 7, chunks=(1, 2), like=like, dtype=np.float32)
+    assert_eq(result, expected.astype(np.float32))
+
+
+def test_full_like_keyword_forgets_graph():
+    like = da.arange(3).map_blocks(lambda x: x)
+    with pytest.raises(Exception, match="local object"):
+        pickle.dumps(like)
+
+    result = da.full((2, 3), 7, chunks=(1, 2), like=like)
+    pickle.dumps(result)
+
+
+def test_full_like_keyword_rejects_meta():
+    with pytest.raises(TypeError, match="both 'like' and 'meta'"):
+        da.full((2, 3), 7, like=np.array(()), meta=np.array(()))
 
 
 def test_full_error_nonscalar_fill_value():

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -194,20 +194,8 @@ empty_like = w_like(np.empty, func_like=np.empty_like)
 _full = array_creation_dispatch.register_inplace(
     backend="numpy",
     name="full",
-)(w(broadcast_trick(np.full_like)))
+)(w(np.full, func_like=broadcast_trick(np.full_like)))
 _full_like = w_like(np.full, func_like=np.full_like)
-
-
-# workaround for numpy doctest failure: https://github.com/numpy/numpy/pull/17472
-if _full.__doc__ is not None:
-    _full.__doc__ = _full.__doc__.replace(
-        "array([0.1,  0.1,  0.1,  0.1,  0.1,  0.1])",
-        "array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1])",
-    )
-    _full.__doc__ = _full.__doc__.replace(
-        ">>> np.full_like(y, [0, 0, 255])",
-        ">>> np.full_like(y, [0, 0, 255])  # doctest: +NORMALIZE_WHITESPACE",
-    )
 
 
 def full(shape, fill_value, *args, **kwargs):
@@ -217,6 +205,11 @@ def full(shape, fill_value, *args, **kwargs):
         raise ValueError(
             f"fill_value must be scalar. Received {type(fill_value).__name__} instead."
         )
+    like = kwargs.pop("like", None)
+    if like is not None:
+        if kwargs.get("meta") is not None:
+            raise TypeError("full() received both 'like' and 'meta'")
+        kwargs["meta"] = meta_from_array(like)
     if kwargs.get("dtype") is None:
         if hasattr(fill_value, "dtype"):
             kwargs["dtype"] = fill_value.dtype

--- a/dask/array/wrap.py
+++ b/dask/array/wrap.py
@@ -189,6 +189,21 @@ w_like = wrap(wrap_func_like)
 empty_like = w_like(np.empty, func_like=np.empty_like)
 
 
+def _remove_docstring_example(docstring, example):
+    """Remove one complete doctest example from a docstring."""
+    lines = docstring.splitlines()
+    try:
+        start = next(i for i, line in enumerate(lines) if line.lstrip() == example)
+    except StopIteration:
+        return docstring
+
+    end = start + 1
+    while end < len(lines) and lines[end].strip():
+        end += 1
+    del lines[start:end]
+    return "\n".join(lines)
+
+
 # full and full_like require special casing due to argument check on fill_value
 # Generate wrapped functions only once
 _full = array_creation_dispatch.register_inplace(
@@ -196,6 +211,11 @@ _full = array_creation_dispatch.register_inplace(
     name="full",
 )(w(np.full, func_like=broadcast_trick(np.full_like)))
 _full_like = w_like(np.full, func_like=np.full_like)
+
+if _full.__doc__ is not None:
+    _full.__doc__ = _remove_docstring_example(
+        _full.__doc__, ">>> np.full((2, 2), [1, 2])"
+    ).replace("fill_value : scalar or array_like", "fill_value : scalar")
 
 
 def full(shape, fill_value, *args, **kwargs):


### PR DESCRIPTION
Closes #9656.

`da.full` currently executes through the backend-aware `np.full_like` adapter, which also causes it to inherit the wrong public documentation. This separates those responsibilities: the wrapper now sources its public documentation from `np.full` while retaining `np.full_like` for backend-aware execution.

Because the corrected NumPy documentation exposes `like=`, this also translates `like` into Dask's existing `meta` exemplar. It rejects ambiguous calls that provide both `like` and `meta`, and forgets any Dask input graph before constructing the result.

Tests cover the corrected documentation and signature, NumPy `like=` behavior, explicit dtype precedence, graph forgetting, and the `like`/`meta` conflict.

Validation:

- `test_wrap.py`: 15 passed
- full/full_like creation selection: 110 passed, 72 CuPy skips, 2 expected xfails
- minimum-dependency full tests: 9 passed
- repository pre-commit suite: passed (ruff, black, codespell, mypy)

CuPy was not installed locally. Its execution adapter is unchanged, and the configured CuPy entrypoint already accepts `meta` and forwards through this NumPy dispatcher.
