### PR TITLE
fix: add input dtype in SplitMap class metadata

### DIFF
--- a/dask/dataframe/dask_expr/_str_accessor.py
+++ b/dask/dataframe/dask_expr/_str_accessor.py
@@ -186,6 +186,7 @@ class SplitMap(FunctionMap):
         meta = self.frame._meta._constructor(
             [delimiter.join(["a"] * (self.n + 1))],
             index=meta.iloc[:1].index,
+            dtype=self.frame._meta.dtype,
         )
         return make_meta(
             getattr(meta.str, self.attr)(n=self.n, expand=self.expand, pat=self.pat)

--- a/dask/dataframe/dask_expr/tests/test_string_accessor.py
+++ b/dask/dataframe/dask_expr/tests/test_string_accessor.py
@@ -140,6 +140,22 @@ def test_str_split_(index):
     assert_eq(dd_a, pd_a)
 
 
+def test_str_split_expand_preserves_dtype():
+    # GH#11884: ``str.split(..., expand=True)`` dropped the input string dtype
+    # and coerced the result to ``object`` in the lazy metadata.
+    pytest.importorskip("pyarrow")
+    ser = pd.Series(["a,b,c", "d,e,f"], dtype="string[pyarrow]")
+    dser = from_pandas(ser, npartitions=1)
+
+    result = dser.str.split(",", n=1, expand=True)
+
+    # the lazy meta must agree with the materialized result ...
+    assert list(result.dtypes) == list(result.compute().dtypes)
+    # ... and must not collapse back to ``object``
+    assert not (result.dtypes == object).any()
+    assert_eq(result, ser.str.split(",", n=1, expand=True))
+
+
 def test_str_accessor_not_available():
     pdf = pd.DataFrame({"a": [1, 2, 3]})
     df = from_pandas(pdf, npartitions=2)


### PR DESCRIPTION
SplitMap._meta rebuilt its one-row sample frame by calling self.frame._meta._constructor(...) without specifying the input dtype. As a result, str.split(pat, expand=True) returned an object result dtype in the lazy metadata, even when the input was a string dtype, such as string[pyarrow] or the pandas-3.0 default string dtype. This caused a discrepancy between the metadata and the actual result.

To fix this, pass dtype=self.frame._meta.dtype to the constructor. This way, the sample and the reported metadata will keep the input dtype and match what the compute method produces.

Disclosure: I used an AI tool to help with this change. It created the patch and the regression test, reproduced the bug, and ran the test suite and lint. I have reviewed, understood, and verified the change and take full responsibility for it.

Fixes #11884

- [x] Closes #11884
- [x] Tests added / passed
- [x] Passes `pixi run lint`
