### PR TITLE
[unsupervised AI] Support axis and level in DataFrame.where and DataFrame.mask

### DIFF
--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -1972,20 +1972,26 @@ Expr={expr}"""
         return new_collection(self.expr.round(decimals))
 
     @derived_from(pd.DataFrame)
-    def where(self, cond, other=np.nan):
-        cond = self._create_alignable_frame(cond)
-        other = self._create_alignable_frame(other)
+    def where(self, cond, other=np.nan, *, axis=None, level=None):
+        if axis not in (1, "columns"):
+            # With axis=1 the operands are labelled by column, not by index, so
+            # aligning them against our divisions would be wrong.
+            cond = self._create_alignable_frame(cond)
+            other = self._create_alignable_frame(other)
         cond = cond.expr if isinstance(cond, FrameBase) else cond
         other = other.expr if isinstance(other, FrameBase) else other
-        return new_collection(self.expr.where(cond, other))
+        return new_collection(self.expr.where(cond, other, axis=axis, level=level))
 
     @derived_from(pd.DataFrame)
-    def mask(self, cond, other=np.nan):
-        cond = self._create_alignable_frame(cond)
-        other = self._create_alignable_frame(other)
+    def mask(self, cond, other=np.nan, *, axis=None, level=None):
+        if axis not in (1, "columns"):
+            # With axis=1 the operands are labelled by column, not by index, so
+            # aligning them against our divisions would be wrong.
+            cond = self._create_alignable_frame(cond)
+            other = self._create_alignable_frame(other)
         cond = cond.expr if isinstance(cond, FrameBase) else cond
         other = other.expr if isinstance(other, FrameBase) else other
-        return new_collection(self.expr.mask(cond, other))
+        return new_collection(self.expr.mask(cond, other, axis=axis, level=level))
 
     @derived_from(pd.DataFrame)
     def replace(self, to_replace=None, value=no_default, regex=False):

--- a/dask/dataframe/dask_expr/_expr.py
+++ b/dask/dataframe/dask_expr/_expr.py
@@ -382,15 +382,15 @@ class Expr(core.SingletonExpr):
     def round(self, decimals=0):
         return Round(self, decimals=decimals)
 
-    def where(self, cond, other=np.nan):
+    def where(self, cond, other=np.nan, axis=None, level=None):
         if not are_co_aligned(self, *[c for c in [cond, other] if isinstance(c, Expr)]):
-            return WhereAlign(self, cond=cond, other=other)
-        return Where(self, cond=cond, other=other)
+            return WhereAlign(self, cond=cond, other=other, axis=axis, level=level)
+        return Where(self, cond=cond, other=other, axis=axis, level=level)
 
-    def mask(self, cond, other=np.nan):
+    def mask(self, cond, other=np.nan, axis=None, level=None):
         if not are_co_aligned(self, *[c for c in [cond, other] if isinstance(c, Expr)]):
-            return MaskAlign(self, cond=cond, other=other)
-        return Mask(self, cond=cond, other=other)
+            return MaskAlign(self, cond=cond, other=other, axis=axis, level=level)
+        return Mask(self, cond=cond, other=other, axis=axis, level=level)
 
     def apply(self, function, *args, meta=None, **kwargs):
         return Apply(self, function, args, meta, kwargs)
@@ -1654,8 +1654,9 @@ class IsNa(Elemwise):
 
 class Mask(Elemwise):
     _projection_passthrough = True
-    _parameters = ["frame", "cond", "other"]
-    _defaults = {"other": np.nan}
+    _parameters = ["frame", "cond", "other", "axis", "level"]
+    _defaults = {"other": np.nan, "axis": None, "level": None}
+    _keyword_only = ["axis", "level"]
     operation = M.mask
 
 
@@ -1667,8 +1668,9 @@ class Round(Elemwise):
 
 class Where(Elemwise):
     _projection_passthrough = True
-    _parameters = ["frame", "cond", "other"]
-    _defaults = {"other": np.nan}
+    _parameters = ["frame", "cond", "other", "axis", "level"]
+    _defaults = {"other": np.nan, "axis": None, "level": None}
+    _keyword_only = ["axis", "level"]
     operation = M.where
 
 
@@ -3675,7 +3677,8 @@ class AssignAlign(MaybeAlignPartitions):
 
 
 class MaskAlign(MaybeAlignPartitions):
-    _parameters = ["frame", "cond", "other"]
+    _parameters = ["frame", "cond", "other", "axis", "level"]
+    _defaults = {"other": np.nan, "axis": None, "level": None}
     _expr_cls: AnyType = Mask
 
 

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -829,6 +829,33 @@ def test_squeeze():
     assert msg in str(info.value)
 
 
+@pytest.mark.parametrize("method", ["where", "mask"])
+def test_where_mask_axis_level(method):
+    # `axis` and `level` are part of the pandas signature, and pandas itself
+    # raises "Must specify axis=0 or 1" for a column-labelled operand, so
+    # rejecting the keyword left no way to call it. See GH#10059.
+    pdf = pd.DataFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
+    ddf = dd.from_pandas(pdf, npartitions=2)
+
+    cond_by_column = pd.Series([True, False], index=["a", "b"])
+    other_by_column = pd.Series([-1, -2], index=["a", "b"])
+    assert_eq(
+        getattr(ddf, method)(cond_by_column, other_by_column, axis=1),
+        getattr(pdf, method)(cond_by_column, other_by_column, axis=1),
+    )
+
+    cond_by_index = pd.Series([True, False, True, False])
+    assert_eq(
+        getattr(ddf, method)(cond_by_index, -1, axis=0),
+        getattr(pdf, method)(cond_by_index, -1, axis=0),
+    )
+
+    assert_eq(
+        getattr(ddf, method)(pdf > 2, -1, level=None),
+        getattr(pdf, method)(pdf > 2, -1, level=None),
+    )
+
+
 def test_where_mask():
     pdf1 = pd.DataFrame(
         {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": [3, 5, 2, 5, 7, 2, 4, 2, 4]}


### PR DESCRIPTION
> [!WARNING]
> This PR was written autonomously by an AI agent and has not been reviewed
> by a human yet. Maintainers should ignore it until the human author has **reviewed,
> understood, and approved** everything that the AI agent wrote.

- [x] Closes #10059
- [x] Tests added / passed
- [x] Passes `pixi run lint`

## Problem

`where` and `mask` reject `axis` and `level`, which pandas accepts:

```
TypeError: FrameBase.mask() got an unexpected keyword argument 'axis'
```

This is worse than a missing feature, because it is a catch-22. With a
column-labelled operand, pandas itself demands the keyword:

```python
ddf.where(pd.Series([True, False], index=["a", "b"]), pd.Series([-1, -2], index=["a", "b"]))
# ValueError: Must specify axis=0 or 1
```

So the operation was unreachable: pandas insisted on `axis`, and dask refused it.

## Changes

1. `Mask`, `Where` and `MaskAlign` gain `axis` and `level` parameters, with
   `_keyword_only = ["axis", "level"]` so they are routed as keywords, following
   the existing `Clip` pattern (both are keyword-only in pandas).
2. `Expr.where` / `Expr.mask` and `FrameBase.where` / `FrameBase.mask` thread the
   two arguments through.
3. `FrameBase.where` / `mask` skip `_create_alignable_frame` when
   `axis in (1, "columns")`. That call exists to force *index* alignment, but with
   `axis=1` the operands are labelled by column, so aligning them against the
   frame's divisions is wrong. Without this the `axis=1` path died in
   `calc_divisions_for_align` with `TypeError: '<' not supported between
   instances of 'str' and 'int'`. `_wrap_expr_method_operator` already
   special-cases `axis in (1, "columns")` the same way.

Note there is prior art: #10060 implemented this against the pre-expr code and
was approved by @j-bennet, but went stale before dask-expr landed.

## Test plan

`test_where_mask_axis_level` in `dask/dataframe/tests/test_dataframe.py`,
parametrised over both methods, covering `axis=1` with column-labelled operands,
`axis=0` with an index-labelled condition, and an explicit `level=None`. It fails
on `main` with the `TypeError` above.

I also checked the result values against pandas directly across 12 combinations
(`axis` of `0`, `1`, `"columns"`, `None` and omitted; scalar, Series and
DataFrame operands). All 12 match pandas exactly.

- `test_dataframe.py -k "where or mask"`: 9 passed
- `test_dataframe.py` in full: 604 passed, 136 skipped, 21 xfailed
- `black --check` clean; `ruff` reports no new findings beyond the 159
  pre-existing `RUF012` hits that every `Expr` subclass already produces
