### PR TITLE
Preserve dtype in Series.str.split(expand=True)

### DIFF
--- a/dask/dataframe/dask_expr/_str_accessor.py
+++ b/dask/dataframe/dask_expr/_str_accessor.py
@@ -181,11 +181,22 @@ class SplitMap(FunctionMap):
 
     @functools.cached_property
     def _meta(self):
+        import pandas as pd
+
         delimiter = " " if self.pat is None else self.pat
         meta = meta_nonempty(self.frame._meta)
+        # Preserve the original dtype so split/rsplit keep e.g. string[pyarrow]
+        # instead of silently downgrading to object. Categorical dtypes are
+        # excluded: the synthetic probe value below is virtually never one of
+        # the fixed categories, which would coerce it to NaN and corrupt the
+        # inferred column count.
+        dtype = self.frame._meta.dtype
+        if isinstance(dtype, pd.CategoricalDtype):
+            dtype = None
         meta = self.frame._meta._constructor(
             [delimiter.join(["a"] * (self.n + 1))],
             index=meta.iloc[:1].index,
+            dtype=dtype,
         )
         return make_meta(
             getattr(meta.str, self.attr)(n=self.n, expand=self.expand, pat=self.pat)

--- a/dask/dataframe/dask_expr/tests/test_string_accessor.py
+++ b/dask/dataframe/dask_expr/tests/test_string_accessor.py
@@ -140,6 +140,28 @@ def test_str_split_(index):
     assert_eq(dd_a, pd_a)
 
 
+def test_str_split_expand_preserves_dtype():
+    pytest.importorskip("pyarrow")
+    df = pd.DataFrame({"a": ["a,b,c", "d,e,f", "g,h,i"]}, dtype="string[pyarrow]")
+    ddf = from_pandas(df, npartitions=1)
+
+    pd_a = df["a"].str.split(",", n=1, expand=True)
+    dd_a = ddf["a"].str.split(",", n=1, expand=True)
+
+    assert_eq(dd_a, pd_a)
+    assert (dd_a.dtypes == pd_a.dtypes).all()
+
+
+def test_str_split_expand_categorical_dtype():
+    df = pd.DataFrame({"a": ["a,b,c", "d,e,f", "g,h,i"]}, dtype="category")
+    ddf = from_pandas(df, npartitions=1)
+
+    pd_a = df["a"].str.split(",", n=1, expand=True)
+    dd_a = ddf["a"].str.split(",", n=1, expand=True)
+
+    assert_eq(dd_a, pd_a)
+
+
 def test_str_accessor_not_available():
     pdf = pd.DataFrame({"a": [1, 2, 3]})
     df = from_pandas(pdf, npartitions=2)


### PR DESCRIPTION
## What was broken

`Series.str.split(pat, n=..., expand=True)` on a dask dataframe always
returned columns with `object` dtype, even when the input column had a
more specific dtype like `string[pyarrow]`. pandas itself keeps the
original dtype in that case, so dask's output disagreed with pandas.

## Why it happened

To figure out the dtype of the output columns ahead of time, dask
builds a tiny one-row "sample" series and runs `.str.split()` on it.
That sample series was built without telling it what dtype to use, so
pandas silently defaulted it to plain `object` — which is why the
final result always came back as `object` regardless of the real
input dtype.

## The fix

Pass the real column's dtype (`self.frame._meta.dtype`) into that
sample series, so the dtype inference matches the actual data.

One case needs special handling: **categorical columns**. The sample
series uses a fixed placeholder string (like `"a a"`) to probe the
split behavior. If the real dtype is `category`, that placeholder
string is almost certainly not one of the real category values —
forcing the categorical dtype on it would silently turn it into `NaN`
and produce the wrong number of output columns. So for categorical
columns, the fix intentionally does nothing (same behavior as before).

## Testing

- Added `test_str_split_expand_preserves_dtype`, which reproduces the
  reported bug exactly (`string[pyarrow]` + `.str.split(expand=True)`)
  and checks dask's output dtype matches pandas.
- Added `test_str_split_expand_categorical_dtype` to lock in the
  categorical edge case. I verified this test actually fails without
  the categorical guard, so it's not a no-op.
- Ran the full `test_string_accessor.py` suite: 55/55 passing.
- Checked the changed lines with `ruff` and `black` — clean (the repo
  has a few pre-existing lint warnings elsewhere in the file, unrelated
  to this change).

Closes #11884.

- [x] Closes #11884
- [x] Tests added / passed
- [x] Passes lint (`ruff` + `black` clean on changed lines; `pixi` not available in this environment)