### PR TITLE
fix: make re-exports explicit

### DIFF
--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -9,8 +9,8 @@ from dask._expr import SingletonExpr as SingletonExpr
 
 try:
     # Backwards compatibility with versioneer
-    from dask._version import commit_id as git_revision
-    from dask._version import version as version
+    from dask._version import __commit_id__ as __git_revision__
+    from dask._version import __version__ as __version__
 except ImportError:  # pragma: no cover
     git_revision = "unknown"
     version = "unknown"

--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -1,24 +1,27 @@
 from __future__ import annotations
 
-from dask import config, datasets
-from dask._expr import Expr, HLGExpr, LLGExpr, SingletonExpr
+from dask import config as config
+from dask import datasets as datasets
+from dask._expr import Expr as Expr
+from dask._expr import HLGExpr as HLGExpr
+from dask._expr import LLGExpr as LLGExpr
+from dask._expr import SingletonExpr as SingletonExpr
 
 try:
     # Backwards compatibility with versioneer
-    from dask._version import __commit_id__ as __git_revision__
-    from dask._version import __version__
+    from dask._version import commit_id as git_revision
+    from dask._version import version as version
 except ImportError:  # pragma: no cover
-    __git_revision__ = "unknown"
-    __version__ = "unknown"
-from dask.base import (
-    annotate,
-    compute,
-    get_annotations,
-    is_dask_collection,
-    optimize,
-    persist,
-    visualize,
-)
-from dask.core import istask
-from dask.delayed import delayed
+    git_revision = "unknown"
+    version = "unknown"
+
+from dask.base import annotate as annotate
+from dask.base import compute as compute
+from dask.base import get_annotations as get_annotations
+from dask.base import is_dask_collection as is_dask_collection
+from dask.base import optimize as optimize
+from dask.base import persist as persist
+from dask.base import visualize as visualize
+from dask.core import istask as istask
+from dask.delayed import delayed as delayed
 from dask.local import get_sync as get


### PR DESCRIPTION
If `__all__`-type setup is preferred I would be happy to change this over.

Aside: would arguably be prettier if version import block was moved to top or bottom, is there any reason why it is in the center?

Fixes #12526, this also has some motivation for PR.

Note: Change was done in GitHub web interface, so have not run lint or tests, but I expect CI will do that.