### PR TITLE
[unsupervised AI] Preserve index-only frames during concat projection

### DIFF
--- a/dask/dataframe/dask_expr/_concat.py
+++ b/dask/dataframe/dask_expr/_concat.py
@@ -269,7 +269,7 @@ class Concat(Expr):
                     else frame
                 )
                 for frame, cols in zip(self._frames, columns_frame)
-                if len(cols) > 0
+                if len(cols) > 0 or self.axis == 0
             ]
             result = type(self)(
                 self.join,

--- a/dask/dataframe/dask_expr/tests/test_concat.py
+++ b/dask/dataframe/dask_expr/tests/test_concat.py
@@ -92,6 +92,16 @@ def test_concat_multiple_no_columns(df, pdf):
     assert_eq(result, expected)
 
 
+def test_concat_reset_set_index_repr():
+    pdf1 = pd.DataFrame({"trid": [0, 1], "ts": [100, 101]}).set_index("trid")
+    pdf2 = pd.DataFrame({"trid": [2, 3], "ts": [102, 103]}).set_index("trid")
+    result = concat([from_pandas(pdf1), from_pandas(pdf2)]).reset_index()
+    result = result.set_index("trid")
+
+    assert "Dask DataFrame Structure" in repr(result)
+    assert_eq(result, pd.concat([pdf1, pdf2]))
+
+
 def test_concat_simplify(pdf, df):
     pdf2 = pdf.copy()
     pdf2["z"] = 1


### PR DESCRIPTION
> [!WARNING]
> This PR was written autonomously by an AI agent and has not been reviewed
> by a human yet. Maintainers should ignore it until the human author has **reviewed,
> understood, and approved** everything that the AI agent wrote.

Fixes #12147.

Keep index-only inputs when pushing a column projection through an axis-0 concat. This prevents reset-index/set-index expressions from rebuilding an empty concat and raising `IndexError` during repr or computation.

- [x] Closes #12147
- [x] Tests added / passed
- [ ] Passes `pixi run lint`

Validation:
- `.venv/bin/python -m pytest dask/dataframe/dask_expr/tests/test_concat.py -q` (34 passed)
- `.venv/bin/pre-commit run --files dask/dataframe/dask_expr/_concat.py dask/dataframe/dask_expr/tests/test_concat.py` (passed; pixi was unavailable in the local environment)