### PR TITLE
feat: define reshape copy behavior

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -2252,7 +2252,7 @@ class Array(DaskMethodsMixin):
 
         return choose(self, choices)
 
-    def reshape(self, *shape, merge_chunks=True, limit=None):
+    def reshape(self, *shape, merge_chunks=True, limit=None, copy=None):
         """Reshape array to new shape
 
         Refer to :func:`dask.array.reshape` for full documentation.
@@ -2265,7 +2265,7 @@ class Array(DaskMethodsMixin):
 
         if len(shape) == 1 and not isinstance(shape[0], Number):
             shape = shape[0]
-        return reshape(self, shape, merge_chunks=merge_chunks, limit=limit)
+        return reshape(self, shape, merge_chunks=merge_chunks, limit=limit, copy=copy)
 
     def topk(self, k, axis=-1, split_every=None):
         """The top k elements of an array.

--- a/dask/array/reshape.py
+++ b/dask/array/reshape.py
@@ -9,6 +9,7 @@ import numpy as np
 
 from dask._task_spec import Task, TaskRef
 from dask.array.core import Array
+from dask.array.numpy_compat import NUMPY_GE_210
 from dask.array.utils import meta_from_array
 from dask.base import tokenize
 from dask.core import flatten
@@ -280,7 +281,28 @@ def contract_tuple(chunks, factor):
     return tuple(out)
 
 
-def reshape(x, shape, merge_chunks=True, limit=None):
+def _reshape_block(x, shape, copy):
+    if copy is True:
+        return x.copy().reshape(shape)
+    if copy is False:
+        if isinstance(x, np.ndarray) and NUMPY_GE_210:
+            return np.reshape(x, shape, copy=False)
+        try:
+            view = x.view()
+            view.shape = shape
+        except (AttributeError, ValueError) as error:
+            raise ValueError("Unable to avoid a copy while reshaping.") from error
+        return view
+    return x.reshape(shape)
+
+
+def _reshape_task(key, input_key, shape, copy):
+    if copy is None:
+        return Task(key, M.reshape, TaskRef(input_key), shape)
+    return Task(key, _reshape_block, TaskRef(input_key), shape, copy)
+
+
+def reshape(x, shape, merge_chunks=True, limit=None, *, copy=None):
     """Reshape array to new shape
 
     Parameters
@@ -298,6 +320,9 @@ def reshape(x, shape, merge_chunks=True, limit=None):
     limit: int (optional)
         The maximum block size to target in bytes. If no limit is provided,
         it defaults to using the ``array.chunk-size`` Dask config value.
+    copy : bool, optional
+        If True, copy each output block. If False, raise a ValueError when the
+        reshape needs different input chunks or a block cannot return a view.
 
     Notes
     -----
@@ -332,23 +357,27 @@ def reshape(x, shape, merge_chunks=True, limit=None):
         # Fastpath for x.reshape(-1) on 1D arrays, allows unknown shape in x
         # for this case only.
         if len(shape) == 1 and x.ndim == 1:
+            if copy is True:
+                return x.map_blocks(M.copy, meta=x._meta)
             return x
         missing_size = sanitize_index(x.size / reduce(mul, known_sizes, 1))
         shape = tuple(missing_size if s == -1 else s for s in shape)
 
     _sanity_checks(x, shape)
 
-    if x.shape == shape:
+    if x.shape == shape and copy is not True:
         return x
 
     meta = meta_from_array(x, len(shape))
 
     name = "reshape-" + tokenize(x, shape)
+    if copy is not None:
+        name = "reshape-" + tokenize(x, shape, copy)
 
     if x.npartitions == 1:
         key = next(flatten(x.__dask_keys__()))
         new_key = (name,) + (0,) * len(shape)
-        dsk = {new_key: Task(new_key, M.reshape, TaskRef(key), shape)}
+        dsk = {new_key: _reshape_task(new_key, key, shape, copy)}
         chunks = tuple((d,) for d in shape)
         graph = HighLevelGraph.from_collections(name, dsk, dependencies=[x])
         return Array(graph, name, chunks, meta=meta)
@@ -357,9 +386,14 @@ def reshape(x, shape, merge_chunks=True, limit=None):
     din = len(x.shape)
     dout = len(shape)
     if not merge_chunks and din > dout:
-        x = x.rechunk(dict.fromkeys(range(din - dout), 1))
+        rechunked = x.rechunk(dict.fromkeys(range(din - dout), 1))
+        if copy is False and rechunked.chunks != x.chunks:
+            raise ValueError("Unable to avoid a copy while reshaping.")
+        x = rechunked
 
     inchunks, outchunks, _, _ = reshape_rechunk(x.shape, shape, x.chunks)
+    if copy is False and inchunks != x.chunks:
+        raise ValueError("Unable to avoid a copy while reshaping.")
     x2 = x.rechunk(inchunks)
 
     # Construct graph
@@ -367,7 +401,7 @@ def reshape(x, shape, merge_chunks=True, limit=None):
     out_keys = list(product([name], *[range(len(c)) for c in outchunks]))
     shapes = list(product(*outchunks))
     dsk = {
-        a: Task(a, M.reshape, TaskRef(b), shape)
+        a: _reshape_task(a, b, shape, copy)
         for a, b, shape in zip(out_keys, in_keys, shapes)
     }
 

--- a/dask/array/tests/test_reshape.py
+++ b/dask/array/tests/test_reshape.py
@@ -6,6 +6,7 @@ import pytest
 import dask.array as da
 from dask.array import from_array
 from dask.array.reshape import (
+    _reshape_block,
     _smooth_chunks,
     contract_tuple,
     expand_tuple,
@@ -89,6 +90,28 @@ def test_reshape_unknown_sizes():
         a.reshape((60, -1, -1))
     with pytest.raises(ValueError):
         A.reshape((60, -1, -1))
+
+
+def test_reshape_copy():
+    array = np.arange(12)
+
+    copied = _reshape_block(array, (3, 4), copy=True)
+    assert not np.shares_memory(array, copied)
+
+    view = _reshape_block(array, (3, 4), copy=False)
+    assert np.shares_memory(array, view)
+
+    with pytest.raises(ValueError, match="Unable to avoid"):
+        _reshape_block(array.reshape((3, 4)).T, (12,), copy=False)
+
+    dask_array = da.from_array(array, chunks=4)
+    assert_eq(dask_array.reshape((3, 4), copy=False), array.reshape((3, 4)))
+    assert_eq(dask_array.reshape((3, 4), copy=True), array.reshape((3, 4)))
+    assert_eq(da.asarray(False).reshape((1,), copy=False), np.array([False]))
+    assert_eq(da.zeros((0,), chunks=(0,)).reshape((0,), copy=False), np.zeros(0))
+
+    with pytest.raises(ValueError, match="Unable to avoid"):
+        da.from_array(array.reshape((3, 4)), chunks=(2, 2)).reshape((12,), copy=False)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Dask `reshape` does not accept the `copy` keyword. This limits compatibility with callers that use the Array API `reshape` contract.

This change implements the `reshape` `copy` contract in Dask. 

Related: 
[data-apis/array-api-tests#446](https://github.com/data-apis/array-api-tests/issues/446)
[scikit-learn/scikit-learn issue#26724](https://github.com/scikit-learn/scikit-learn/issues/26724)

- [x] Tests added / passed
- [x] Passes `pixi run lint`

#### Benchmark

timeit measured `copy_compute` at 16.435 milliseconds before the change and 13.330 milliseconds after the change.  
timeit measured `default_compute` at 13.146 milliseconds before the change and 11.984 milliseconds after the change.  
timeit measured `no_copy_graph` at 0.330 milliseconds before the change and 0.311 milliseconds after the change.

The reported times are medians from 67 repeats for each case on each revision.

Each result matched the expected values.

The [timeit benchmark on my fork](https://github.com/stanbot8/dask/tree/3a5a59eacb2e9517471feab472c0a0861c409368/benchmarks/dask-reshape-copy) is AI generated.
