### PR TITLE
fix: avoid zero chunksize when no tasks are ready

### DIFF
--- a/dask/local.py
+++ b/dask/local.py
@@ -489,6 +489,8 @@ def get_async(
                 """Fire off a task to the thread pool"""
                 # Determine chunksize and/or number of tasks to submit
                 nready = len(state["ready"])
+                if nready == 0:
+                    return
                 if chunksize == -1:
                     ntasks = nready
                     chunksize = -(ntasks // -num_workers)

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -82,6 +82,7 @@ def test_chunksize_minus_one_with_no_ready_tasks():
     dsk = {"x": (inc, 1)}
     assert get(dsk, "x", chunksize=-1) == 2
 
+
 def test_remote_exception():
     e = TypeError("hello")
     a = remote_exception(e, "traceback-body")

--- a/dask/tests/test_multiprocessing.py
+++ b/dask/tests/test_multiprocessing.py
@@ -78,6 +78,10 @@ def test_errors_propagate():
     assert "12345" in str(e.value)
 
 
+def test_chunksize_minus_one_with_no_ready_tasks():
+    dsk = {"x": (inc, 1)}
+    assert get(dsk, "x", chunksize=-1) == 2
+
 def test_remote_exception():
     e = TypeError("hello")
     a = remote_exception(e, "traceback-body")


### PR DESCRIPTION
## Summary

- avoid calculating a zero batch size when `chunksize=-1` and no tasks are ready
- add a regression test for multiprocessing execution with `chunksize=-1`

Fixes #10297