### PR TITLE
docs: note rot90 view semantics

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -238,7 +238,10 @@ def fliplr(m):
     return flip(m, 1)
 
 
-@derived_from(np)
+@derived_from(
+    np,
+    inconsistencies="Unlike NumPy, Dask returns a lazy Dask array rather than a NumPy view.",
+)
 def rot90(m, k=1, axes=(0, 1)):
     axes = tuple(axes)
     if len(axes) != 2:


### PR DESCRIPTION
## Summary

- document that Dask's `rot90` returns a lazy Dask array rather than a NumPy view

Issue: #9576

This change only clarifies the generated documentation; array behavior is unchanged.