### PR TITLE
ci: re-enable docs warning failures

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,8 +7,7 @@ build:
 
 sphinx:
   configuration: docs/source/conf.py
-  # Temporarily turning off to get docs build passing
-  # fail_on_warning: true
+  fail_on_warning: true
 
 python:
   install:


### PR DESCRIPTION
## Summary

- Re-enable Read the Docs `fail_on_warning` so documentation warnings fail the build again.

Closes #11193