### PR TITLE
The link in the readme doesnt go to the documentation

### DIFF
--- a/docs/source/array-chunks.rst
+++ b/docs/source/array-chunks.rst
@@ -84,7 +84,7 @@ result in an error.
    ...
    ValueError: Array chunk sizes unknown
 
-   A possible solution: https://docs.dask.org/en/latest/array-chunks.html#unknown-chunks.
+   A possible solution: https://docs.dask.org/en/stable/array-chunks.html#unknown-chunks.
    Summary: to compute chunks sizes, use
 
        x.compute_chunk_sizes()  # for Dask Array


### PR DESCRIPTION
This PR fixes the documentation issue reported in #11838: corrects `https://docs.dask.org/en/latest/` to `https://docs.dask.org/en/stable/` in `docs/source/array-chunks.rst`.

Fixes #11838

- [ ] Closes #xxxx
- [ ] Tests added / passed
- [ ] Passes `pixi run lint`

Fixes #11838