### PR TITLE
Fix DataFrame.drop(labels=[], axis=1) treating empty list as falsy

### DIFF
--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -3314,7 +3314,7 @@ class DataFrame(FrameBase):
         axis = _validate_axis(axis)
 
         if axis == 1:
-            columns = labels or columns
+            columns = labels if columns is None else columns
         elif axis == 0 and columns is None:
             raise NotImplementedError(
                 "Drop currently only works for axis=1 or when columns is not None"


### PR DESCRIPTION
## Summary
Fixes #12510 — `ddf.drop([], axis=1)` and `ddf.drop(labels=[], axis=1)` raise `ValueError`, while the pandas equivalents (`df.drop([], axis=1)`, `df.drop(labels=[], axis=1)`, `df.drop(columns=[])`) are all no-ops.

**Root cause:** `DataFrame.drop` resolves the target columns with:

```python
columns = labels or columns
```

Since an empty list is falsy in Python, `labels or columns` discards a valid (but empty) `labels=[]` and falls back to `columns`, which is `None` in this call shape. `Drop` then receives `columns=None`, which raises downstream.

## Fix
```python
columns = labels if columns is None else columns
```

This only falls back to `columns` when the caller didn't pass `labels` at all (i.e. `columns` wasn't already resolved some other way), and otherwise preserves whatever was passed to `labels` — including an empty list — matching pandas' semantics of "drop nothing" for `axis=1`.

## Verification
Manually traced the four call shapes from the issue's repro against the patched logic:
- `columns=[]` → `columns is None` is `False` → stays `[]` ✓ (already worked before, unaffected)
- `labels=[], axis=1` → `columns is None` is `True` → `columns = []` ✓ (previously became `None`, the bug)
- `labels=['a'], axis=1` → `columns = ['a']` ✓ (normal case, unaffected)

Wasn't able to run this against the actual `dask.dataframe` test suite in this environment (local Python is 3.7; this codebase requires 3.9+ for `typing.Literal`/`overload`), so flagging that in case CI wants a second look.

## Test plan
- [x] Traced all call shapes from the issue's repro by hand against the patched code.
- [ ] Not run through dask's test suite locally — CI/maintainer verification appreciated.
