### PR TITLE
fix: Map zero length blocks to single chunks in auto size calculation

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3321,8 +3321,11 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
     limit = max(1, limit)
     chunksize_tolerance = config.get("array.chunk-size-tolerance")
 
-    largest_block = math.prod(
-        cs if isinstance(cs, Number) else max(cs) for cs in chunks if cs != "auto"
+    largest_block = (
+        math.prod(
+            cs if isinstance(cs, Number) else max(cs) for cs in chunks if cs != "auto"
+        )
+        or 1
     )
 
     if previous_chunks:
@@ -3411,7 +3414,7 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
             raise ValueError(
                 "auto-chunking with dtype.itemsize == 0 is not supported, please pass in `chunks` explicitly"
             )
-        size = (limit / dtype.itemsize / (largest_block or 1)) ** (1 / len(autos))
+        size = (limit / dtype.itemsize / (largest_block)) ** (1 / len(autos))
         small = [i for i in autos if shape[i] < size]
         if small:
             for i in small:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3321,11 +3321,11 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
     limit = max(1, limit)
     chunksize_tolerance = config.get("array.chunk-size-tolerance")
 
-    largest_block = (
-        math.prod(
-            cs if isinstance(cs, Number) else max(cs) for cs in chunks if cs != "auto"
-        )
-        or 1
+    if any(s == 0 for s in shape):
+        return tuple((s,) for s in shape)
+
+    largest_block = math.prod(
+        cs if isinstance(cs, Number) else max(cs) for cs in chunks if cs != "auto"
     )
 
     if previous_chunks:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3414,7 +3414,7 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
             raise ValueError(
                 "auto-chunking with dtype.itemsize == 0 is not supported, please pass in `chunks` explicitly"
             )
-        size = (limit / dtype.itemsize / (largest_block)) ** (1 / len(autos))
+        size = (limit / dtype.itemsize / largest_block) ** (1 / len(autos))
         small = [i for i in autos if shape[i] < size]
         if small:
             for i in small:

--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -3411,7 +3411,7 @@ def auto_chunks(chunks, shape, limit, dtype, previous_chunks=None):
             raise ValueError(
                 "auto-chunking with dtype.itemsize == 0 is not supported, please pass in `chunks` explicitly"
             )
-        size = (limit / dtype.itemsize / largest_block) ** (1 / len(autos))
+        size = (limit / dtype.itemsize / (largest_block or 1)) ** (1 / len(autos))
         small = [i for i in autos if shape[i] < size]
         if small:
             for i in small:

--- a/dask/array/tests/test_array_core.py
+++ b/dask/array/tests/test_array_core.py
@@ -4875,6 +4875,7 @@ def test_normalize_chunks_auto_1d(shape, limit, expected):
             ((4, 4, 4, 4, 4), (2, 2, 2, 2, 2, 5, 5)),
         ),
         ((1, 20), "auto", 10, ((1,), (10, 10))),
+        ((0, 20), "auto", 20, ((0,), (20,))),
     ],
 )
 def test_normalize_chunks_auto_2d(shape, chunks, limit, expected):


### PR DESCRIPTION
Avoids a divide by zero error and doesn't seem to cause any test regressions on my local machine.

I think this is the right way to close this edge case - I think it's totally valid for an array to have 0 length dimensions - it currently works fine if the user specifies the chunks, just auto-chunking was failing due to dividing by `largest_block`.

- [x] Closes #12537 
- [x] Tests added / passed
- [x] Passes `pixi run lint`
