### PR TITLE
Fix docstring parameters that do not match signatures

### DIFF
--- a/dask/array/core.py
+++ b/dask/array/core.py
@@ -1794,7 +1794,6 @@ class Array(DaskMethodsMixin):
 
         Parameters
         ----------
-        chunks: tuple
         size: int
             Rough size of the image
 

--- a/dask/array/reductions.py
+++ b/dask/array/reductions.py
@@ -1355,7 +1355,7 @@ def topk(a, k, axis=-1, split_every=None):
 
     Parameters
     ----------
-    x: Array
+    a: Array
         Data being sorted
     k: int
     axis: int, optional
@@ -1414,7 +1414,7 @@ def argtopk(a, k, axis=-1, split_every=None):
 
     Parameters
     ----------
-    x: Array
+    a: Array
         Data being sorted
     k: int
     axis: int, optional

--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -4493,8 +4493,6 @@ class Series(FrameBase):
             If dict-like or callable, the transformation is applied to the
             index. Scalar or hashable sequence-like will alter the
             ``Series.name`` attribute.
-        inplace : boolean, default False
-            Whether to return a new Series or modify this one inplace.
         sorted_index : bool, default False
             If true, the output ``Series`` will have known divisions inferred
             from the input series and the transformation. Ignored for
@@ -4984,7 +4982,7 @@ def from_array(arr, chunksize=50_000, columns=None, meta=None):
 
     Parameters
     ----------
-    x : array_like
+    arr : array_like
     chunksize : int, optional
         The number of rows per partition to use.
     columns : list or string, optional

--- a/dask/dataframe/shuffle.py
+++ b/dask/dataframe/shuffle.py
@@ -183,7 +183,7 @@ def shuffle_group(df, cols, stage, k, npartitions, ignore_index, nfinal):
         we're in, starting from zero up to some small integer
     k: int
         Desired number of splits from this dataframe
-    npartition: int
+    npartitions: int
         Total number of output partitions for the full dataframe
     nfinal: int
         Total number of output partitions after repartitioning

--- a/dask/delayed.py
+++ b/dask/delayed.py
@@ -137,7 +137,7 @@ def unpack_collections(expr, _return_collections=True):
         The object to be normalized. This function knows how to handle
         dask collections, as well as most builtin python types.
 
-    _optimize_collections: bool, optional
+    _return_collections: bool, optional
         Internal use only!
 
 

--- a/dask/highlevelgraph.py
+++ b/dask/highlevelgraph.py
@@ -700,8 +700,6 @@ class HighLevelGraph(Graph):
 
         Parameters
         ----------
-        hlg : HighLevelGraph
-            The high level graph's layers to sort
 
         Returns
         -------

--- a/dask/rewrite.py
+++ b/dask/rewrite.py
@@ -320,7 +320,7 @@ class RuleSet:
 
         Parameters
         ----------
-        term: a task
+        task: a task
             The task to be rewritten
         strategy: str, optional
             The rewriting strategy to use. Options are "bottom_up" (default),


### PR DESCRIPTION
Nine `Parameters` entries name something the function does not accept.

| Where | Documented | Actual |
|---|---|---|
| `dask/array/core.py:1797` `Array.to_svg` | `chunks` | `to_svg(self, size=500)` — no such parameter |
| `dask/array/reductions.py:1358` `topk` | `x` | the parameter is `a` |
| `dask/array/reductions.py:1417` `argtopk` | `x` | the parameter is `a` |
| `dask/dataframe/dask_expr/_collection.py:4496` `Series.rename` | `inplace` | `rename(self, index, sorted_index=False)` — no such parameter |
| `dask/dataframe/dask_expr/_collection.py:4985` `from_array` | `x` | the parameter is `arr` |
| `dask/dataframe/shuffle.py:186` `shuffle_group` | `npartition` | the parameter is `npartitions` |
| `dask/delayed.py:140` `unpack_collections` | `_optimize_collections` | the parameter is `_return_collections` |
| `dask/highlevelgraph.py:703` `_toposort_layers` | `hlg` | describes `self`; the method takes nothing else |
| `dask/rewrite.py:322` `RuleSet.rewrite` | `term` | the parameter is `task` |

`Series.rename` looks like the clearest one for users: `inplace` is documented with
"Whether to return a new Series or modify this one inplace", but passing it raises
`TypeError`.

Docstrings only — no signature, call site, or behaviour is touched.

## Not changed

Two more turned up in the same sweep and are **not** defects, recorded so nobody
re-checks them:

- `dask/graph_manipulation.py:210` `bind` — the entry reads `split_every` followed by
  `See :func:`checkpoint``, and `split_every` is a real parameter.
- `dask/array/core.py:3256` `auto_chunks` — `normalize_chunks: for full docstring and
  parameters` sits in the `See also` section, not in `Parameters`.

Both are artefacts of the tool I used to find these, not of the code.
