### PR TITLE
fix(dataframe): preserve dtype in .str.split's lazy meta

### DIFF
--- a/dask/dataframe/dask_expr/_str_accessor.py
+++ b/dask/dataframe/dask_expr/_str_accessor.py
@@ -181,11 +181,18 @@ class SplitMap(FunctionMap):
 
     @functools.cached_property
     def _meta(self):
+        import pandas as pd
+
         delimiter = " " if self.pat is None else self.pat
+        dtype = self.frame._meta.dtype
+        if isinstance(dtype, pd.CategoricalDtype):
+            # ``str`` operations on a categorical operate on the categories
+            dtype = dtype.categories.dtype
         meta = meta_nonempty(self.frame._meta)
         meta = self.frame._meta._constructor(
             [delimiter.join(["a"] * (self.n + 1))],
             index=meta.iloc[:1].index,
+            dtype=dtype,
         )
         return make_meta(
             getattr(meta.str, self.attr)(n=self.n, expand=self.expand, pat=self.pat)

--- a/dask/dataframe/dask_expr/tests/test_string_accessor.py
+++ b/dask/dataframe/dask_expr/tests/test_string_accessor.py
@@ -140,6 +140,35 @@ def test_str_split_(index):
     assert_eq(dd_a, pd_a)
 
 
+def test_str_split_preserves_dtype():
+    # The lazy `_meta`'s dtype must match the actual computed dtype, not just
+    # fall back to `object`. Regression test for #11884.
+    pytest.importorskip("pyarrow")
+    ser = pd.Series(["a,b", "c,d"], dtype="string[pyarrow]")
+    dser = from_pandas(ser.to_frame("a"), npartitions=1)["a"]
+
+    result = dser.str.split(",", n=1, expand=True)
+    assert result._meta[0].dtype == ser.dtype
+    assert result.compute()[0].dtype == ser.dtype
+
+
+def test_str_split_categorical_preserves_categories_dtype():
+    # `str` operations on a categorical operate on the categories, so the
+    # split result's dtype should follow the categories' dtype, not the
+    # categorical dtype itself. Categories use a pyarrow-backed string dtype
+    # so this actually discriminates from the buggy `object` fallback (a
+    # plain-object categorical's categories dtype is also `object`, which
+    # would pass even without the fix).
+    pytest.importorskip("pyarrow")
+    cat_dtype = pd.CategoricalDtype(pd.array(["a,b", "c,d"], dtype="string[pyarrow]"))
+    ser = pd.Series(["a,b", "c,d"], dtype=cat_dtype)
+    dser = from_pandas(ser.to_frame("a"), npartitions=1)["a"]
+
+    result = dser.str.split(",", n=1, expand=True)
+    assert result._meta[0].dtype == ser.cat.categories.dtype
+    assert result.compute()[0].dtype == ser.cat.categories.dtype
+
+
 def test_str_accessor_not_available():
     pdf = pd.DataFrame({"a": [1, 2, 3]})
     df = from_pandas(pdf, npartitions=2)


### PR DESCRIPTION
## Summary

Fixes #11884. `SplitMap._meta` in `dask/dataframe/dask_expr/_str_accessor.py` built its dummy frame via `self.frame._meta._constructor(...)` without passing `dtype=`, so pandas inferred `object` for the dummy regardless of the real series' dtype. `ddf["c"].str.split(",", n=1, expand=True).dtypes` (lazy) could disagree with `.compute().dtypes` (actual) — e.g. a `string[pyarrow]`-backed column's split result would report `object` in the lazy metadata while the real computation correctly preserved `string[pyarrow]`.

## Fix

Propagate `self.frame._meta.dtype` into the dummy frame's constructor. Also handles the categorical case: `str` operations on a categorical operate on the *categories*, so the categories' dtype is what should be propagated, not the categorical dtype itself (a naive `self.frame._meta.dtype` would incorrectly try to use the `CategoricalDtype` itself).

## Test plan

Added two regression tests to `test_string_accessor.py`:
- `test_str_split_preserves_dtype` — a `string[pyarrow]` series' split result matches in both lazy `_meta` and `.compute()`
- `test_str_split_categorical_preserves_categories_dtype` — same, for a categorical with pyarrow-backed categories (using plain-`object` categories wouldn't actually discriminate from the bug, since the buggy fallback is also `object`)

Verified both fail without the fix (reverted the source change, confirmed `test_str_split_preserves_dtype` fails with the exact lazy/actual dtype mismatch described in the issue) and pass with it. Existing `.str.split`/`.str.rsplit` tests in the same file still pass — no regression.