### PR TITLE
Add `__all__` to the top-level dask namespace

### DIFF
--- a/dask/__init__.py
+++ b/dask/__init__.py
@@ -5,8 +5,10 @@ from dask._expr import Expr, HLGExpr, LLGExpr, SingletonExpr
 
 try:
     # Backwards compatibility with versioneer
-    from dask._version import __commit_id__ as __git_revision__
-    from dask._version import __version__
+    from dask._version import __commit_id__
+    from dask._version import __version__ as __version__
+
+    __git_revision__ = __commit_id__
 except ImportError:  # pragma: no cover
     __git_revision__ = "unknown"
     __version__ = "unknown"
@@ -22,3 +24,22 @@ from dask.base import (
 from dask.core import istask
 from dask.delayed import delayed
 from dask.local import get_sync as get
+
+__all__ = [
+    "Expr",
+    "HLGExpr",
+    "LLGExpr",
+    "SingletonExpr",
+    "annotate",
+    "compute",
+    "config",
+    "datasets",
+    "delayed",
+    "get",
+    "get_annotations",
+    "is_dask_collection",
+    "istask",
+    "optimize",
+    "persist",
+    "visualize",
+]

--- a/dask/tests/test_api.py
+++ b/dask/tests/test_api.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from types import ModuleType
+
+DASK_EXPORTED_SUBMODULES = {"config", "datasets"}
+
+
+def test_api():
+    """Tests that `dask.__all__` is correct"""
+    import dask
+
+    member_dict = vars(dask)
+    members = set(member_dict)
+    # unexported submodules
+    members -= {"tests"}
+    members -= {
+        m
+        for m, mod in member_dict.items()
+        if m not in DASK_EXPORTED_SUBMODULES
+        if isinstance(mod, ModuleType)
+        and mod.__spec__.parent
+        and mod.__spec__.parent.startswith("dask")
+    }
+    # imported utility modules
+    members -= {"annotations"}
+    # private utilities and `__dunder__` members
+    members -= {m for m in members if m.startswith("_")}
+
+    assert set(dask.__all__) == members


### PR DESCRIPTION
Names exported without being declared from the top-level package were not
considered re-exports by the type specification; type checkers and LSPs only
followed the inclusion of `import X as X` and `__all__`. This caused users to
see "not exported" errors in the documented API, including dask.compute.

Creating an explicit `__all__` list is consistent with what dask.array,
dask.dataframe and dask.bag already do.

Tested using `mypy --no-implicit-reexport` in a file importing every public
name; 16 errors before adding `__all__`, no errors afterward. It will also
prevent the `from dask import *` statement from containing 18 non-API names,
including the `from __future__ import annotations` object and 17 internal
submodules.

- [x] Closes #12526
- [x] Tests added / passed
- [x] Passes `pixi run lint`
