### PR TITLE
[unsupervised AI] Fix DataFrame.size for zero-column frames

### DIFF
--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -2699,7 +2699,9 @@ class DataFrame(FrameBase):
 
     @property
     def shape(self):
-        return self.size // max(len(self.columns), 1), len(self.columns)
+        if len(self.columns) == 0:
+            return self.index.size, 0
+        return self.size // len(self.columns), len(self.columns)
 
     @property
     def ndim(self):

--- a/dask/dataframe/dask_expr/_reductions.py
+++ b/dask/dataframe/dask_expr/_reductions.py
@@ -1084,7 +1084,7 @@ class Size(Reduction):
         return df.size
 
     def _simplify_down(self):
-        if is_dataframe_like(self.frame._meta) and len(self.frame.columns) > 1:
+        if is_dataframe_like(self.frame._meta):
             return len(self.frame.columns) * Len(self.frame)
         else:
             return Len(self.frame)

--- a/dask/dataframe/dask_expr/tests/test_collection.py
+++ b/dask/dataframe/dask_expr/tests/test_collection.py
@@ -2195,6 +2195,7 @@ def test_shape(df, pdf):
 
 def test_size(df, pdf):
     assert_eq(df.size, pdf.size)
+    assert_eq(df[[]].size, pdf[[]].size)
 
 
 def test_drop_duplicates_groupby(pdf):


### PR DESCRIPTION
> [!WARNING]
> This PR was written autonomously by an AI agent and has not been reviewed
> by a human yet. Maintainers should ignore it until the human author has **reviewed,
> understood, and approved** everything that the AI agent wrote.

Zero-column Dask DataFrames currently report their row count from `.size`, while pandas reports zero. This updates size simplification to account for every DataFrame column count and preserves the existing zero-column `.shape` row count through the index.

- [x] Closes #12241
- [x] Tests added / passed
- [ ] Passes `pixi run lint`

Validation:

- `python -m pytest -q dask/dataframe/dask_expr/tests/test_collection.py::test_size dask/dataframe/dask_expr/tests/test_collection.py::test_shape dask/dataframe/dask_expr/tests/test_collection.py::test_size_optimized dask/dataframe/tests/test_dataframe.py::test_size dask/dataframe/tests/test_dataframe.py::test_shape` (5 passed)
- File-scoped pre-commit hooks passed (`ruff check`, `black`); `pixi` was unavailable in the environment.
