### PR TITLE
Avoid inferring explicitly specified Parquet fields

### DIFF
--- a/dask/dataframe/io/parquet/arrow.py
+++ b/dask/dataframe/io/parquet/arrow.py
@@ -650,20 +650,36 @@ class ArrowDatasetEngine(Engine):
         **kwargs,
     ):
         if schema == "infer" or isinstance(schema, dict):
-            # Start with schema from _meta_nonempty
-            inferred_schema = pyarrow_schema_dispatch(
+            meta = (
                 df._meta_nonempty.set_index(index_cols)
                 if index_cols
                 else df._meta_nonempty
-            ).remove_metadata()
+            )
+            meta_columns = list(meta.columns)
+
+            user_schema = None
+            if isinstance(schema, dict):
+                user_schema = pa.schema(schema)
+                specified_columns = [
+                    name for name in user_schema.names if name in meta.columns
+                ]
+                meta = meta.drop(columns=specified_columns)
+
+            # Infer fields not supplied by the user from _meta_nonempty
+            inferred_schema = pyarrow_schema_dispatch(meta).remove_metadata()
 
             # Use dict to update our inferred schema
-            if isinstance(schema, dict):
-                schema = pa.schema(schema)
-                for name in schema.names:
-                    i = inferred_schema.get_field_index(name)
-                    j = schema.get_field_index(name)
-                    inferred_schema = inferred_schema.set(i, schema.field(j))
+            if user_schema is not None:
+                for i, name in enumerate(meta_columns):
+                    j = user_schema.get_field_index(name)
+                    if j >= 0:
+                        inferred_schema = inferred_schema.insert(
+                            i, user_schema.field(j)
+                        )
+                for field in user_schema:
+                    if field.name not in meta_columns:
+                        i = inferred_schema.get_field_index(field.name)
+                        inferred_schema = inferred_schema.set(i, field)
             schema = inferred_schema
 
         # Check that target directory exists

--- a/dask/dataframe/io/tests/test_parquet.py
+++ b/dask/dataframe/io/tests/test_parquet.py
@@ -1208,6 +1208,21 @@ def test_to_parquet_pyarrow_w_inconsistent_schema_by_partition_succeeds_w_manual
 
 
 @PYARROW_MARK
+def test_to_parquet_manual_list_schema_with_object_meta(tmpdir):
+    @dask.delayed
+    def make_frame():
+        return pd.DataFrame({"a": [[1.0, 2.0]]})
+
+    with dask.config.set({"dataframe.convert-string": False}):
+        meta = dd.utils.make_meta([("a", object)])
+        ddf = dd.from_delayed(make_frame(), meta=meta)
+        ddf.to_parquet(str(tmpdir), schema={"a": pa.list_(pa.float64(), 2)})
+        result = dd.read_parquet(str(tmpdir)).compute()
+
+    assert result["a"].iloc[0].tolist() == [1.0, 2.0]
+
+
+@PYARROW_MARK
 @pytest.mark.parametrize("index", [False, True])
 @pytest.mark.parametrize("schema", ["infer", "complex"])
 def test_pyarrow_schema_inference(tmpdir, index, schema):


### PR DESCRIPTION
When a dictionary schema explicitly provides a type for an object column, Parquet initialization still tries to infer that column from Dask's synthetic non-empty metadata. With pandas 3, the synthetic object sentinel cannot be converted to Arrow and the write fails before any partition is evaluated.

This change excludes explicitly specified data columns from inference, then inserts their user-provided Arrow fields back in the original column order. It also adds a regression test for a fixed-size list column with object metadata.

- [x] Closes #12543
- [x] Tests added / passed
- [x] Passes `pixi run lint`

Validation:

- `python -m pytest dask/dataframe/io/tests/test_parquet.py -q` — 240 passed, 31 skipped, 6 xfailed
- `pre-commit run --all-files` — passed (this is the command configured for the `pixi run lint` task; pixi itself was not available locally)
