### PR TITLE
Optimize combined expressions before visualization

### DIFF
--- a/dask/base.py
+++ b/dask/base.py
@@ -861,7 +861,10 @@ def visualize(
     """
     args, _ = unpack_collections(*args, traverse=traverse)
 
-    dsk = collections_to_expr(args, optimize_graph=optimize_graph).__dask_graph__()
+    expr = collections_to_expr(args, optimize_graph=optimize_graph)
+    if optimize_graph:
+        expr = expr.optimize()
+    dsk = expr.__dask_graph__()
 
     return visualize_dsk(
         dsk=dsk,

--- a/dask/tests/test_base.py
+++ b/dask/tests/test_base.py
@@ -585,6 +585,19 @@ def test_visualize():
 
 
 @pytest.mark.skipif("not da")
+def test_visualize_optimizes_combined_graph(monkeypatch):
+    x = da.random.random(10, chunks=5)
+    left = x + 1
+    right = x * 2
+    monkeypatch.setattr("dask.base.visualize_dsk", lambda dsk, **kwargs: dsk)
+
+    unoptimized = visualize(left, right, optimize_graph=False)
+    optimized = visualize(left, right, optimize_graph=True)
+
+    assert len(optimized) <= len(unoptimized)
+
+
+@pytest.mark.skipif("not da")
 @pytest.mark.skipif(
     bool(sys.flags.optimize), reason="graphviz exception with Python -OO flag"
 )


### PR DESCRIPTION
`visualize(optimize_graph=True)` currently materializes the combined expression graph without invoking the expression optimizer. For multiple collections sharing the same source, that can duplicate the source tasks in the rendered graph even though `compute()` optimizes and executes a shared graph.

This change optimizes the combined expression before materialization, matching the optimization flow used by compute and persist. The regression test verifies that enabling visualization optimization never increases the task count for two arrays sharing one random source.

- [x] Closes #12517
- [x] Tests added / passed
- [x] Passes `pixi run lint`

Validation:

- `python -m pytest dask/tests/test_base.py -q` — 45 passed, 15 skipped
- `pre-commit run --all-files` — passed (this is the command configured for the `pixi run lint` task; pixi itself was not available locally)
