### PR TITLE
Fix categorical dtype after p2p shuffle

### DIFF
--- a/dask/dataframe/dask_expr/_categorical.py
+++ b/dask/dataframe/dask_expr/_categorical.py
@@ -13,6 +13,7 @@ from dask.dataframe.dask_expr._accessor import Accessor, PropertyMap
 from dask.dataframe.dask_expr._expr import Blockwise, Elemwise, Projection
 from dask.dataframe.dask_expr._reductions import ApplyConcatApply
 from dask.dataframe.utils import (
+    UNKNOWN_CATEGORIES,
     AttributeNotImplementedError,
     clear_known_categories,
     has_known_categories,
@@ -82,6 +83,7 @@ class CategoricalAccessor(Accessor):
             .unique()
             .compute()
         )
+        categories = categories[categories != UNKNOWN_CATEGORIES]
         return self.set_categories(categories.values)
 
     def as_unknown(self):

--- a/dask/dataframe/dask_expr/tests/test_distributed.py
+++ b/dask/dataframe/dask_expr/tests/test_distributed.py
@@ -293,6 +293,21 @@ def test_sort_values():
     )
 
 
+def test_as_known_with_p2p_shuffle():
+    expected = pd.Series([1, 2, 1, 0, 2], name="qid", dtype="category")
+    series = from_pandas(expected, npartitions=3).cat.as_unknown()
+
+    with (
+        LocalCluster(processes=False, dashboard_address=":0") as cluster,
+        Client(cluster),
+        dask.config.set({"dataframe.shuffle.method": "p2p"}),
+    ):
+        result = series.cat.as_known()
+
+    assert result.cat.categories.dtype == expected.cat.categories.dtype
+    dd.assert_eq(result, expected, check_categorical=False)
+
+
 @pytest.mark.parametrize("add_repartition", [True, False])
 def test_merge_combine_similar_squash_merges(add_repartition):
     with LocalCluster(processes=False, n_workers=2, dashboard_address=":0") as cluster:


### PR DESCRIPTION
Closes #11572

P2P shuffle can include Dask's internal unknown-category sentinel when `cat.as_known()` computes category values. Filtering that sentinel before setting categories preserves the original categorical value dtype.

Adds a distributed regression test covering the P2P path.

- [x] Closes #11572
- [x] Tests added / passed
- [ ] Passes `pixi run lint` (pixi is unavailable locally; all changed-file pre-commit hooks pass)
