### PR TITLE
feat(array): implement fill_diagonal for dask arrays

### DIFF
--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -183,6 +183,7 @@ __all__ = [
     "einsum",
     "expand_dims",
     "extract",
+    "fill_diagonal",
     "flatnonzero",
     "flip",
     "fliplr",

--- a/dask/array/__init__.py
+++ b/dask/array/__init__.py
@@ -473,6 +473,7 @@ try:
         einsum,
         expand_dims,
         extract,
+        fill_diagonal,
         flatnonzero,
         flip,
         fliplr,

--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -2612,3 +2612,33 @@ def triu_indices_from(arr, k=0):
     if arr.ndim != 2:
         raise ValueError("input array must be 2-d")
     return triu_indices(arr.shape[-2], k=k, m=arr.shape[-1], chunks=arr.chunks)
+
+
+@derived_from(np)
+def fill_diagonal(a, val, wrap=False):
+    if a.ndim < 2:
+        raise ValueError("array must be at least 2-d")
+    if wrap:
+        raise NotImplementedError("wrap=True is not yet supported for dask arrays")
+
+    a = asarray_safe(a, like=a)
+
+    def _fill_diagonal_chunk(block, val, block_info=None):
+        result = block.copy()
+        locs = block_info[0]["array-location"]
+
+        starts = [loc[0] for loc in locs]
+        stops = [loc[1] for loc in locs]
+
+        diag_start = max(starts)
+        diag_stop = min(stops)
+
+        if diag_start < diag_stop:
+            n = diag_stop - diag_start
+            local_starts = [diag_start - s for s in starts]
+            slices = tuple(slice(ls, ls + n) for ls in local_starts)
+            np.fill_diagonal(result[slices], val)
+
+        return result
+
+    return map_blocks(_fill_diagonal_chunk, a, val, dtype=a.dtype)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -2902,3 +2902,56 @@ def test_pickle_vectorized_routines():
     assert_eq(c, [[0], [1]], check_dtype=False)
     c2 = pickle.loads(pickle.dumps(c))
     assert_eq(c2, [[0], [1]], check_dtype=False)
+
+
+def test_fill_diagonal():
+    A = np.random.default_rng().standard_normal((20, 20))
+    for chk in [(5, 5), (4, 6), (7, 3)]:
+        dA = da.from_array(A, chk)
+        expected = A.copy()
+        np.fill_diagonal(expected, 42)
+        result = da.fill_diagonal(dA, 42)
+        assert_eq(result, expected)
+
+
+def test_fill_diagonal_non_square():
+    A = np.random.default_rng().standard_normal((30, 20))
+    dA = da.from_array(A, chunks=(10, 5))
+    expected = A.copy()
+    np.fill_diagonal(expected, 99)
+    result = da.fill_diagonal(dA, 99)
+    assert_eq(result, expected)
+
+    A2 = np.random.default_rng().standard_normal((20, 30))
+    dA2 = da.from_array(A2, chunks=(5, 10))
+    expected2 = A2.copy()
+    np.fill_diagonal(expected2, -1.5)
+    result2 = da.fill_diagonal(dA2, -1.5)
+    assert_eq(result2, expected2)
+
+
+def test_fill_diagonal_ndims():
+    A = np.random.default_rng().standard_normal((10, 10, 10))
+    dA = da.from_array(A, chunks=(5, 5, 5))
+    expected = A.copy()
+    np.fill_diagonal(expected, 7)
+    result = da.fill_diagonal(dA, 7)
+    assert_eq(result, expected)
+
+
+def test_fill_diagonal_raises():
+    x = da.ones(10, chunks=5)
+    with pytest.raises(ValueError):
+        da.fill_diagonal(x, 1)
+
+    x2d = da.ones((10, 10), chunks=5)
+    with pytest.raises(NotImplementedError):
+        da.fill_diagonal(x2d, 1, wrap=True)
+
+
+def test_fill_diagonal_does_not_modify_original():
+    A = np.random.default_rng().standard_normal((10, 10))
+    dA = da.from_array(A, chunks=5)
+    original = A.copy()
+    result = da.fill_diagonal(dA, 999).compute()
+    assert_eq(dA, original)

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -2953,5 +2953,5 @@ def test_fill_diagonal_does_not_modify_original():
     A = np.random.default_rng().standard_normal((10, 10))
     dA = da.from_array(A, chunks=5)
     original = A.copy()
-    result = da.fill_diagonal(dA, 999).compute()
+    da.fill_diagonal(dA, 999).compute()
     assert_eq(dA, original)


### PR DESCRIPTION
## Problem

Closes #9846. numpy provides \
p.fill_diagonal\ for in-place filling of array diagonals, but dask arrays have no equivalent, forcing users to manually construct masks or compute entire arrays.

## Solution

Adds \dask.array.fill_diagonal(a, val)\ that fills the diagonal elements of a dask array in place, matching numpy semantics for square, non-square, and N-D arrays.

## Implementation

- Uses \map_blocks\ with \lock_info\ to compute the diagonal segment within each chunk (intersection of dimension ranges)
- Delegates to \
p.fill_diagonal\ on the diagonal view of each chunk
- Validates at least 2-D input; raises \NotImplementedError\ for \wrap=True\ (numpy option not yet supported)
- Registered as \da.fill_diagonal\ in the array namespace

## Tests

Added 5 tests covering square, non-square, 3-D arrays, error cases, and immutability of the original array. All pass locally:

\\\
python -m pytest dask/array/tests/test_routines.py -k fill_diagonal -v
\\\

## Risks

\wrap=True\ (wrapping diagonals for non-square arrays) is not yet implemented; the error message is explicit. Behavior for square arrays matches numpy exactly.