### PR TITLE
DOC: clarify memory constraints of low-cardinality join keys

### DIFF
--- a/docs/source/dataframe-joins.rst
+++ b/docs/source/dataframe-joins.rst
@@ -23,6 +23,17 @@ performance costs.
 These problems are solvable, but will be significantly slower than many other
 operations.  They are best avoided if possible.
 
+Because all of the rows that share a value in the join column are shuffled into
+the same partition, every group of matching rows needs to be able to fit into
+memory on a single worker.  This means that joining on a column with very few
+unique values (for example a column with ten distinct values and thousands of
+partitions) can be problematic: each partition ends up holding every row that
+belongs to one of those values, and the resulting partition size can grow much
+larger than the original partitions.  If the largest group of matching rows
+does not fit in memory, the join can raise a ``MemoryError``.  In that case,
+joining on a column with higher cardinality, or joining on the index after a
+``set_index`` (see `Sorted Joins`_ below), may be a better option.
+
 Large to Small Joins
 --------------------
 


### PR DESCRIPTION
## Summary

Addresses the documentation portion of dask/dask#8769. When merging two
large DataFrames on a column, Dask hash-shuffles the data so that all rows
sharing a value in the join column land in the same partition. This means
each group of matching rows must fit in the memory of a single worker.

The joins guide previously implied this ("rows with matching values in the
joining columns are in the same partition") but did not spell out the
practical consequence: joining on a column with very few unique values can
create partitions far larger than the originals, and can raise a
`MemoryError` when the largest group of matching rows does not fit in
memory. This change makes that explicit and points users at higher-
cardinality columns or sorted/indexed joins as alternatives.

## Changes

- `docs/source/dataframe-joins.rst`: added a paragraph in the
  "Large to Large Unsorted Joins" section describing the partition-size
  implications of low-cardinality join keys and the `MemoryError` failure
  mode, with pointers to `Sorted Joins`.

## Validation

- Full Sphinx docs build (`python -m sphinx -b html docs/source`) succeeds
  with no warnings for this page; the new paragraph and its internal link to
  the `Sorted Joins` section render correctly.
- Behavioral claim verified locally: merging two DataFrames on a column with
  few unique values places every row of a given value in the same partition
  (verified via `to_delayed`/`compute` on a 15-row example split across 3
  partitions).
- `codespell` clean.

Closes dask/dask#8769 (documentation portion)