### PR TITLE
Make DataFrame.visualize() respect the visualization.engine config

### DIFF
--- a/dask/dataframe/dask_expr/_collection.py
+++ b/dask/dataframe/dask_expr/_collection.py
@@ -26,7 +26,7 @@ from tlz import first
 
 import dask.array as da
 import dask.dataframe.dask_expr._backends  # noqa: F401
-from dask import compute, get_annotations
+from dask import compute, config, get_annotations
 from dask._collections import new_collection
 from dask._expr import OptimizerStage
 from dask._task_spec import Dict, TaskRef
@@ -629,6 +629,19 @@ Expr={expr}"""
             Whether to visualize the task graph. By default
             the expression graph will be visualized instead.
         """
+        if not tasks:
+            # The expression-graph visualization (``Expr.visualize``) only
+            # knows how to render with ``graphviz``. If the user has
+            # configured a different engine (e.g. via
+            # ``dask.config.set({"visualization.engine": "cytoscape"})``
+            # or an explicit ``engine`` kwarg), fall back to the task-graph
+            # visualization instead, since that path already respects the
+            # configured/requested engine.
+            engine = kwargs.get("engine", None) or config.get(
+                "visualization.engine", None
+            )
+            if engine not in (None, "graphviz"):
+                tasks = True
         if tasks:
             return super().visualize(**kwargs)
         return self.expr.visualize(**kwargs)

--- a/dask/dataframe/dask_expr/tests/test_collection.py
+++ b/dask/dataframe/dask_expr/tests/test_collection.py
@@ -2804,3 +2804,24 @@ def test_align_known_divisions_in_assign():
     df = df.assign(c=df["a"])
     assert_eq(ddf, df)
     assert_eq(ddf.optimize(), df)
+
+
+def test_visualize_respects_configured_engine():
+    # See https://github.com/dask/dask/issues/11447
+    # The default (expression-graph) visualization only supports the
+    # ``graphviz`` engine. When a different engine is configured (or
+    # requested explicitly), ``visualize`` should fall back to the
+    # task-graph visualization instead of silently ignoring the setting
+    # and always trying to use ``graphviz``.
+    ipycytoscape = pytest.importorskip("ipycytoscape")
+
+    pdf = pd.DataFrame({"a": [1, 2, 3, 4]})
+    ddf = from_pandas(pdf, npartitions=2)
+
+    with dask.config.set({"visualization.engine": "cytoscape"}):
+        result = ddf.visualize(filename=None)
+    assert isinstance(result, ipycytoscape.CytoscapeWidget)
+
+    # An explicit ``engine`` kwarg should also be respected.
+    result = ddf.visualize(filename=None, engine="cytoscape")
+    assert isinstance(result, ipycytoscape.CytoscapeWidget)


### PR DESCRIPTION
Fixes #11447

`FrameBase.visualize()` always rendered the default expression graph via `Expr.visualize()`, which is hardcoded to use `graphviz`. It never checked the `visualization.engine` config or an `engine` kwarg, unlike `dask.array`, so setting `dask.config.set({"visualization.engine": "cytoscape"})` and calling `.visualize()` on a DataFrame silently ignored it.

**Fix:** in `FrameBase.visualize()`, check the effective engine (explicit `engine` kwarg, else `visualization.engine` config); if it resolves to something other than `graphviz`/`None`, fall back to the task-graph path (`super().visualize()`), which already dispatches correctly to `cytoscape`/`ipycytoscape`.

Added `test_visualize_respects_configured_engine`. Full `dask/dataframe/dask_expr/tests/test_collection.py` suite passes (2867 passed) with no regressions.
