### PR TITLE
Keep by-columns when projecting through merge_asof graphs

### DIFF
--- a/dask/dataframe/dask_expr/_merge.py
+++ b/dask/dataframe/dask_expr/_merge.py
@@ -477,13 +477,24 @@ class Merge(Expr):
             if right_on is None:
                 right_on = []
 
+            # ``merge_asof`` joins on the by-columns in addition to the
+            # index, so those columns must be kept on each side even if a
+            # later projection does not select them.
+            left_by = _convert_to_list(getattr(self, "left_by", None))
+            if left_by is None:
+                left_by = []
+
+            right_by = _convert_to_list(getattr(self, "right_by", None))
+            if right_by is None:
+                right_by = []
+
             left_suffix, right_suffix = self.suffixes[0], self.suffixes[1]
             project_left, project_right = [], []
             right_suff_columns, left_suff_columns = [], []
 
             # Find columns to project on the left
             for col in left.columns:
-                if col in left_on or col in projection:
+                if col in left_on or col in left_by or col in projection:
                     project_left.append(col)
                 elif f"{col}{left_suffix}" in projection:
                     project_left.append(col)
@@ -494,7 +505,7 @@ class Merge(Expr):
 
             # Find columns to project on the right
             for col in right.columns:
-                if col in right_on or col in projection:
+                if col in right_on or col in right_by or col in projection:
                     project_right.append(col)
                 elif f"{col}{right_suffix}" in projection:
                     project_right.append(col)

--- a/dask/dataframe/dask_expr/tests/test_merge_asof.py
+++ b/dask/dataframe/dask_expr/tests/test_merge_asof.py
@@ -76,3 +76,48 @@ def test_merge_asof_one_partition():
         direction="nearest",
     )
     assert_eq(result, expected)
+
+
+def test_merge_asof_drop_by_column():
+    # https://github.com/dask/dask/issues/12544
+    # Dropping a by-column after a merge_asof must not remove it from the
+    # input sides of the optimized graph, where it is still needed.
+    left = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(["2024-01-02", "2024-01-03", "2024-01-04"]),
+            "key": [1, 1, 2],
+        }
+    ).set_index("timestamp")
+    right = pd.DataFrame(
+        {
+            "timestamp_right": pd.to_datetime(
+                ["2024-01-01", "2024-01-02", "2024-01-03"]
+            ),
+            "key_right": [1, 1, 2],
+            "value": ["a", "b", "c"],
+        }
+    ).set_index("timestamp_right")
+
+    ddf_left = from_pandas(left, npartitions=1)
+    ddf_right = from_pandas(right, npartitions=1)
+    result = merge_asof(
+        ddf_left,
+        ddf_right,
+        left_index=True,
+        right_index=True,
+        left_by="key",
+        right_by="key_right",
+        direction="backward",
+    )
+
+    expected = pd.merge_asof(
+        left,
+        right,
+        left_index=True,
+        right_index=True,
+        left_by="key",
+        right_by="key_right",
+        direction="backward",
+    )
+    assert_eq(result.drop(columns=["key_right"]), expected.drop(columns=["key_right"]))
+    assert_eq(result.drop(columns=["key"]), expected.drop(columns=["key"]))


### PR DESCRIPTION
- [x] Closes #12544
- [x] Tests added / passed
- [x] Passes `pre-commit run --all-files`

Fixes the `KeyError` raised when a by-column is dropped (or excluded) from the result of a `dd.merge_asof`.

### Root cause

Projection pushdown in `Merge._simplify_up` keeps the join-key columns (`left_on` / `right_on`) on each input side, but `merge_asof` joins on the index plus the by-columns (`left_by` / `right_by`). Those by-columns were not preserved, so an expression like

```python
merged = dd.merge_asof(left, right, left_index=True, right_index=True,
                       left_by="key", right_by="key_right", direction="backward")
merged.drop(columns=["key_right"])
```

was optimized into a graph whose right input no longer contained `key_right`, and `pd.merge_asof(..., right_by="key_right")` failed with `KeyError: 'key_right'` during optimization.

### Fix

`Merge._simplify_up` now also keeps `left_by` / `right_by` columns on the respective input sides (no-op for plain `merge`, which has no by-columns).

### Verification

- Regression test `test_merge_asof_drop_by_column` added — drops both the right and left by-columns and compares against the pandas reference.
- `test_merge_asof.py` (5 passed), `test_merge.py` (146 passed), `test_collection.py` merge/projection/optimize subset (22 passed), and `test_multi.py` merge_asof subset (31 passed).
- `ruff check` and `black --check` clean on changed files.
