### PR TITLE
Update dataframe tests to use sort_results=False (Fixes #9158)

### DIFF
--- a/dask/dataframe/tests/test_boolean.py
+++ b/dask/dataframe/tests/test_boolean.py
@@ -10,7 +10,9 @@ def test_meta():
     ds = dd.from_pandas(pd.Series(values), 2)
     assert ds.dtype == pd.BooleanDtype()
 
-    dd.utils.assert_eq(ds._meta_nonempty, pd.Series([True, pd.NA], dtype="boolean"))
+    dd.utils.assert_eq(
+        ds._meta_nonempty, pd.Series([True, pd.NA], dtype="boolean"), sort_results=False
+    )
 
     ddf = dd.from_pandas(pd.DataFrame({"A": values}), 2)
     assert ddf.dtypes["A"] == pd.BooleanDtype()
@@ -18,6 +20,7 @@ def test_meta():
     dd.utils.assert_eq(
         ddf._meta_nonempty,
         pd.DataFrame({"A": pd.array([True, pd.NA], dtype="boolean")}),
+        sort_results=False,
     )
 
 
@@ -28,6 +31,6 @@ def test_ops():
     ds1 = dd.from_pandas(s1, 2)
     ds2 = dd.from_pandas(s2, 2)
 
-    dd.utils.assert_eq(ds1 | ds2, s1 | s2)
-    dd.utils.assert_eq(ds1 & ds2, s1 & s2)
-    dd.utils.assert_eq(ds1 ^ ds2, s1 ^ s2)
+    dd.utils.assert_eq(ds1 | ds2, s1 | s2, sort_results=False)
+    dd.utils.assert_eq(ds1 & ds2, s1 & s2, sort_results=False)
+    dd.utils.assert_eq(ds1 ^ ds2, s1 ^ s2, sort_results=False)

--- a/dask/dataframe/tests/test_extensions.py
+++ b/dask/dataframe/tests/test_extensions.py
@@ -28,17 +28,17 @@ def test_register_extension_type():
     arr = DecimalArray._from_sequence([Decimal("1.0")] * 10)
     ser = pd.Series(arr)
     dser = dd.from_pandas(ser, 2)
-    assert_eq(ser, dser)
+    assert_eq(ser, dser, sort_results=False)
 
     df = pd.DataFrame({"A": ser})
     ddf = dd.from_pandas(df, 2)
-    assert_eq(df, ddf)
+    assert_eq(df, ddf, sort_results=False)
 
 
 def test_reduction():
     ser = pd.Series(DecimalArray._from_sequence([Decimal("0"), Decimal("1")]))
     dser = dd.from_pandas(ser, 2)
-    assert_eq(ser.mean(skipna=False), dser.mean(skipna=False))
+    assert_eq(ser.mean(skipna=False), dser.mean(skipna=False), sort_results=False)
 
     # It's unclear whether this can be reliably provided, at least with the current
     # implementation, which uses pandas.DataFrame.sum(), returning a (homogeneous)

--- a/dask/dataframe/tests/test_hashing.py
+++ b/dask/dataframe/tests/test_hashing.py
@@ -35,7 +35,7 @@ def test_hash_pandas_object(obj):
     if isinstance(a, np.ndarray):
         np.testing.assert_equal(a, b)
     else:
-        assert_eq(a, b)
+        assert_eq(a, b, sort_results=False)
 
 
 def test_categorical_consistency():
@@ -81,4 +81,4 @@ def test_object_missing_values():
 def test_hash_object_dispatch(obj):
     result = dd.dispatch.hash_object_dispatch(obj)
     expected = pd.util.hash_pandas_object(obj)
-    assert_eq(result, expected)
+    assert_eq(result, expected, sort_results=False)


### PR DESCRIPTION
This PR updates specific dataframe test files to use the sort_results=False argument in assert_eq calls. The sort_results argument was added in PR #9130 to allow DataFrame equality checks without sorting, which is more appropriate for tests that don't require ordering validation.

Updated test files:
- test_boolean.py: Added sort_results=False to assert_eq calls in test_meta and test_ops
- test_extensions.py: Added sort_results=False to assert_eq calls in test_register_extension_type and test_reduction
- test_hashing.py: Added sort_results=False to assert_eq calls in test_hash_pandas_object and test_hash_object_dispatch

These changes make the tests more efficient by avoiding unnecessary sorting while maintaining the same test coverage.
#9158 