### PR TITLE
Add cytoolz to optional dependencies (Fixes #2812)

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -59,6 +59,7 @@ You can install Dask with ``conda``, with ``pip``, or install from source.
          python -m pip install "dask[dataframe]"   # Install requirements for dask dataframe
          python -m pip install "dask[diagnostics]" # Install requirements for dask diagnostics
          python -m pip install "dask[distributed]" # Install requirements for distributed dask
+         python -m pip install "dask[performance]" # Install cytoolz for performance optimization
 
       We have these options so that users of the lightweight core Dask scheduler
       aren't required to download the more exotic dependencies of the collections
@@ -114,7 +115,7 @@ These optional dependencies and their minimum supported versions are listed belo
 +------------------+-----------------+---------------------------------------------------------------------------------------------------------+
 | `crick`_         | ``>=0.0.5``     | Use ``tdigest`` internal method for dataframe statistics computation                                    |
 +------------------+-----------------+---------------------------------------------------------------------------------------------------------+
-| `cytoolz`_       | ``>=0.11.2``    | Faster cythonized implementation of internal iterators, functions, and dictionaries                     |
+| `cytoolz`_       | ``>=0.11.2``    | Faster cythonized implementation of internal iterators, functions, and dictionaries (install with ``dask[performance]``) |
 +------------------+-----------------+---------------------------------------------------------------------------------------------------------+
 | `dask-ml`_       | ``>=1.4.0``     | Common machine learning functions scaled with Dask                                                      |
 +------------------+-----------------+---------------------------------------------------------------------------------------------------------+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ complete = [
     "dask[array,dataframe,distributed,diagnostics]",
     "lz4 >= 4.3.2",
 ]
+# Performance optimization: cytoolz provides faster cythonized implementation
+performance = ["cytoolz >= 0.11.2"]
 test = [
     "pandas[test]",
     "pytest",


### PR DESCRIPTION
This PR adds cytoolz as an optional dependency under the "performance" extras in pyproject.toml and updates the installation documentation.

cytoolz provides a faster cythonized implementation of internal iterators, functions, and dictionaries, which can significantly improve Dask performance when installed.

Changes:
- Added "performance" optional dependency in pyproject.toml with cytoolz >= 0.11.2
- Updated install.rst to document the new dask[performance] installation option
- Updated cytoolz entry in optional dependencies table to reference the installation method

This makes the performance benefits of cytoolz more discoverable to users and provides a simple installation method: python -m pip install "dask[performance]"

#2812 