### PR TITLE
[unsupervised AI] Make dask.array.take match NumPy for boolean indices

### DIFF
--- a/dask/array/routines.py
+++ b/dask/array/routines.py
@@ -2055,6 +2055,12 @@ def extract(condition, arr):
 def take(a, indices, axis=0):
     axis = validate_axis(axis, a.ndim)
 
+    indices_array = indices if is_arraylike(indices) else np.asarray(indices)
+    if indices_array.dtype.kind == "b":
+        indices = indices_array.astype(np.intp)
+        if not isinstance(indices, Array) and indices.ndim == 0:
+            indices = indices.item()
+
     if isinstance(a, np.ndarray) and isinstance(indices, Array):
         return _take_dask_array_from_numpy(a, indices, axis)
     else:

--- a/dask/array/tests/test_routines.py
+++ b/dask/array/tests/test_routines.py
@@ -1691,6 +1691,51 @@ def test_take():
     assert same_keys(da.take(a, [3, 4, 5], axis=-1), da.take(a, [3, 4, 5], axis=-1))
 
 
+def test_take_boolean_indices():
+    x = np.arange(12).reshape((3, 4))
+    a = da.from_array(x, chunks=(2, 2))
+
+    lazy_indices = da.from_array(np.array([True, False, True]), chunks=2)
+    lazy_indices = lazy_indices[lazy_indices]
+    indices = [
+        [True, False],
+        (False, True),
+        np.array([True, False]),
+        da.from_array(np.array([False, True]), chunks=1),
+        lazy_indices,
+        True,
+        np.bool_(False),
+        np.array(True),
+        da.from_array(np.array(False), chunks=()),
+    ]
+
+    for index in indices:
+        expected_index = index.compute() if isinstance(index, da.Array) else index
+        for axis in [0, 1, -1]:
+            assert_eq(np.take(x, expected_index, axis), da.take(a, index, axis))
+
+
+def test_take_does_not_convert_arraylike_indices():
+    class ArrayLike:
+        ndim = 1
+
+        def __getitem__(self, index):
+            return index
+
+    class Indices:
+        shape = (2,)
+        dtype = np.dtype(np.intp)
+
+        def __array_function__(self, func, types, args, kwargs):
+            return NotImplemented
+
+        def __array__(self, *args, **kwargs):
+            raise AssertionError("unexpected implicit conversion")
+
+    indices = Indices()
+    assert da.take(ArrayLike(), indices) == (indices,)
+
+
 def test_take_large():
     a = da.arange(1_000_000_000_000, chunks=(200_000_000,), dtype="int64")
 


### PR DESCRIPTION
> [!WARNING]
> This PR was written autonomously by an AI agent and has not been reviewed
> by a human yet. Maintainers should ignore it until the human author has **reviewed,
> understood, and approved** everything that the AI agent wrote.

- [x] Closes #11984
- [x] Tests added / passed
- [ ] Passes `pixi run lint`

## Summary

`dask.array.take` currently routes boolean indices through ordinary Dask indexing, which treats them as masks. NumPy `take` instead coerces booleans to integer positions.

Convert boolean scalar and array-like indices to `np.intp` before dispatch while preserving duck-array inputs. Eager, lazy, scalar, and unknown-chunk boolean indices now match NumPy without forcing non-NumPy backends through host conversion.

## Validation

- Exact upstream behavior reproduced: NumPy returned `[20, 10]` while Dask returned `[10]`
- `python -m pytest dask/array/tests/test_routines.py` (`728 passed, 5 xfailed`)
- Focused `take` tests (`5 passed`)
- Pre-commit checks on both changed files, including Ruff, Black, and mypy
- `git diff --check`

`pixi run lint` was not run because Pixi is not installed locally.
