### PR TITLE
Respect visualization.engine config in dask.dataframe .visualize()

### DIFF
--- a/dask/_expr.py
+++ b/dask/_expr.py
@@ -765,10 +765,67 @@ class Expr:
 
         return g
 
-    def visualize(self, filename="dask-expr.svg", format=None, **kwargs):
+    def _to_cytoscape_json(self, **kwargs):
+        from dask.dot import label, name
+
+        nodes = []
+        edges = []
+        data = {"nodes": nodes, "edges": edges}
+
+        stack = [self]
+        seen = set()
+        dependencies = {}
+        while stack:
+            expr = stack.pop()
+
+            if expr._name in seen:
+                continue
+            seen.add(expr._name)
+
+            dependencies[expr] = set(expr.dependencies())
+            for dep in expr.dependencies():
+                stack.append(dep)
+
+        cache = {}
+        for expr in dependencies:
+            expr_name = name(expr)
+
+            deps = [
+                funcname(type(dep)) if isinstance(dep, Expr) else str(dep)
+                for dep in expr._node_label_args()
+            ]
+            _label = funcname(type(expr))
+            if deps:
+                _label = f"{_label}({', '.join(deps)})" if deps else _label
+            node_label = label(_label, cache=cache)
+
+            nodes.append(
+                {
+                    "data": {
+                        "id": expr_name,
+                        "label": str(node_label),
+                        "shape": "rectangle",
+                        "color": "gray",
+                    }
+                }
+            )
+
+        for expr, deps in dependencies.items():
+            expr_name = name(expr)
+            for dep in deps:
+                dep_name = name(dep)
+                edges.append({"data": {"source": dep_name, "target": expr_name}})
+
+        return data
+
+    def visualize(self, filename="dask-expr.svg", format=None, engine=None, **kwargs):
         """
         Visualize the expression graph.
-        Requires ``graphviz`` to be installed.
+
+        By default this requires ``graphviz`` to be installed. Alternatively,
+        the ``ipycytoscape`` engine can be used by either passing
+        ``engine="cytoscape"`` or by setting the ``visualization.engine``
+        dask config option to ``"cytoscape"``.
 
         Parameters
         ----------
@@ -779,14 +836,46 @@ class Expr:
             rendered in the Jupyter notebook only.
         format : {'png', 'pdf', 'dot', 'svg', 'jpeg', 'jpg'}, optional
             Format in which to write output file. Default is 'svg'.
+        engine : {"graphviz", "ipycytoscape", "cytoscape"}, optional.
+            The visualization engine to use. If not provided, this checks the
+            dask config value ``"visualization.engine"``. If that is not set,
+            it tries to import ``graphviz`` and ``ipycytoscape``, using the
+            first one to succeed.
         **kwargs
-           Additional keyword arguments to forward to ``to_graphviz``.
+           Additional keyword arguments to forward to the visualization engine.
         """
-        from dask.dot import graphviz_to_file
+        engine = engine or dask.config.get("visualization.engine", None)
 
-        g = self._to_graphviz(**kwargs)
-        graphviz_to_file(g, filename, format)
-        return g
+        if not engine:
+            try:
+                import graphviz  # noqa: F401
+
+                engine = "graphviz"
+            except ImportError:
+                try:
+                    import ipycytoscape  # noqa: F401
+
+                    engine = "cytoscape"
+                except ImportError:
+                    pass
+
+        if engine == "graphviz":
+            from dask.dot import graphviz_to_file
+
+            g = self._to_graphviz(**kwargs)
+            graphviz_to_file(g, filename, format)
+            return g
+        elif engine in ("cytoscape", "ipycytoscape"):
+            from dask.dot import _cytoscape_widget
+
+            data = self._to_cytoscape_json()
+            return _cytoscape_widget(data, filename=filename, **kwargs)
+        elif engine is None:
+            raise RuntimeError(
+                "No visualization engine detected, please install graphviz or ipycytoscape"
+            )
+        else:
+            raise ValueError(f"Visualization engine {engine} not recognized")
 
     def walk(self) -> Generator[Expr]:
         """Iterate through all expressions in the tree

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -5416,9 +5416,7 @@ def test_visualize_respects_cytoscape_engine_config(monkeypatch):
         return "cytoscape-widget"
 
     def fake_graphviz_to_file(*args, **kwargs):
-        raise AssertionError(
-            "graphviz path should not be used when engine='cytoscape'"
-        )
+        raise AssertionError("graphviz path should not be used when engine='cytoscape'")
 
     monkeypatch.setattr("dask.dot._cytoscape_widget", fake_cytoscape_widget)
     monkeypatch.setattr("dask.dot.graphviz_to_file", fake_graphviz_to_file)

--- a/dask/dataframe/tests/test_dataframe.py
+++ b/dask/dataframe/tests/test_dataframe.py
@@ -5398,3 +5398,42 @@ def test_loc_partitions_are_plain_scalars():
 
     result = ddf.loc[indexer.tolist()]
     assert type(result.divisions[0]) is int
+
+
+def test_visualize_respects_cytoscape_engine_config(monkeypatch):
+    # Regression test for https://github.com/dask/dask/issues/11447
+    # `.visualize()` on a dask.dataframe collection (backed by `Expr`) must
+    # respect the "visualization.engine" config, just like `dask.array` does,
+    # instead of always going through the graphviz-only code path.
+    df = pd.DataFrame({"a": range(8), "b": range(8)})
+    ddf = dd.from_pandas(df, npartitions=2)
+
+    called = {}
+
+    def fake_cytoscape_widget(data, filename=None, **kwargs):
+        called["data"] = data
+        called["filename"] = filename
+        return "cytoscape-widget"
+
+    def fake_graphviz_to_file(*args, **kwargs):
+        raise AssertionError(
+            "graphviz path should not be used when engine='cytoscape'"
+        )
+
+    monkeypatch.setattr("dask.dot._cytoscape_widget", fake_cytoscape_widget)
+    monkeypatch.setattr("dask.dot.graphviz_to_file", fake_graphviz_to_file)
+
+    with dask.config.set({"visualization.engine": "cytoscape"}):
+        result = ddf.visualize(filename=None)
+
+    assert result == "cytoscape-widget"
+    assert "data" in called
+    assert called["data"]["nodes"]
+    assert called["filename"] is None
+
+    # Passing engine explicitly also works, overriding the config.
+    called.clear()
+    with dask.config.set({"visualization.engine": "graphviz"}):
+        result = ddf.visualize(filename=None, engine="cytoscape")
+    assert result == "cytoscape-widget"
+    assert called["data"]["nodes"]

--- a/dask/dot.py
+++ b/dask/dot.py
@@ -469,6 +469,37 @@ def cytoscape_graph(
     -------
     result : ipycytoscape.CytoscapeWidget
     """
+    data = _to_cytoscape_json(dsk, **kwargs)
+    return _cytoscape_widget(
+        data,
+        filename=filename,
+        rankdir=rankdir,
+        node_sep=node_sep,
+        edge_sep=edge_sep,
+        spacing_factor=spacing_factor,
+        node_style=node_style,
+        edge_style=edge_style,
+    )
+
+
+def _cytoscape_widget(
+    data,
+    filename: str | None = "mydask",
+    *,
+    rankdir: str = "BT",
+    node_sep: float = 10,
+    edge_sep: float = 10,
+    spacing_factor: float = 1,
+    node_style: dict[str, str] | None = None,
+    edge_style: dict[str, str] | None = None,
+):
+    """Build (and optionally write to disk) an ipycytoscape widget from
+    Cytoscape JSON data (see ``_to_cytoscape_json``).
+
+    This is factored out of ``cytoscape_graph`` so that callers which do not
+    have a plain dask task graph (e.g. ``dask_expr`` expression graphs) can
+    still render using the cytoscape engine.
+    """
     ipycytoscape = import_required(
         "ipycytoscape",
         "Drawing dask graphs with the cytoscape engine requires the `ipycytoscape` "
@@ -481,7 +512,6 @@ def cytoscape_graph(
     node_style = node_style or {}
     edge_style = edge_style or {}
 
-    data = _to_cytoscape_json(dsk, **kwargs)
     # TODO: it's not easy to programmatically increase the height of the widget.
     # Ideally we would make it a bit bigger, but that will probably require upstreaming
     # some fixes.


### PR DESCRIPTION
Fixes #11447

## Problem

`dask.config.set({"visualization.engine": "cytoscape"})` is correctly respected by `dask.array`'s `.visualize()` (via `dask.base.visualize`/`visualize_dsk`, which check the `visualization.engine` config), but calling `.visualize()` on a `dask.dataframe` object ignores it entirely. That's because the default (non-`tasks=True`) dataframe visualization path goes through `Expr.visualize()` in `dask/_expr.py`, which always called the graphviz-only `_to_graphviz`/`graphviz_to_file` helpers directly - never consulting `visualization.engine` or an `engine=` kwarg. As a result, `ddf.visualize()` raises a graphviz `RuntimeError`/import error even when `graphviz` isn't installed but `ipycytoscape` is and the cytoscape engine was explicitly requested.

## Fix

- `Expr.visualize()` now mirrors the engine-selection logic already used by `dask.base.visualize`/`visualize_dsk`: explicit `engine=` kwarg, then the `visualization.engine` config value, then whichever of `graphviz`/`ipycytoscape` is importable.
- Added `Expr._to_cytoscape_json`, which builds Cytoscape JSON from the expression tree using the same traversal as the existing `Expr._to_graphviz`.
- Factored the ipycytoscape widget-construction logic out of `dask.dot.cytoscape_graph` into a new `dask.dot._cytoscape_widget(data, ...)` helper, so both the plain task-graph path (`cytoscape_graph`) and the new expression-graph path (`Expr.visualize`) share the same rendering code instead of duplicating it.

## Test plan

- Added `test_visualize_respects_cytoscape_engine_config` in `dask/dataframe/tests/test_dataframe.py`, which monkeypatches `dask.dot._cytoscape_widget` and `dask.dot.graphviz_to_file` to assert that `ddf.visualize()` routes to the cytoscape path (and never touches the graphviz path) both when the engine is set via config and via an explicit `engine=` kwarg.
- Ran `dask/dataframe/tests/test_dataframe.py::test_visualize_respects_cytoscape_engine_config`, `dask/tests/test_dot.py`, and `dask/tests/test_expr.py` locally - the cytoscape-related tests all pass. (A handful of unrelated `test_dot.py` graphviz-rendering tests fail in this environment because the `dot` executable isn't installed/on `PATH` on this Windows machine; that's a pre-existing local environment gap, not a regression from this change.)