### PR TITLE
[unsupervised AI] Fix set_index partition metadata

### DIFF
--- a/dask/dataframe/dask_expr/_shuffle.py
+++ b/dask/dataframe/dask_expr/_shuffle.py
@@ -800,7 +800,7 @@ class BaseSetIndexSortValues(Expr):
 
     @property
     def npartitions(self):
-        return self.operand("npartitions") or len(self._divisions()) - 1
+        return len(self._divisions()) - 1
 
 
 class SetIndex(BaseSetIndexSortValues):

--- a/dask/dataframe/dask_expr/tests/test_shuffle.py
+++ b/dask/dataframe/dask_expr/tests/test_shuffle.py
@@ -18,7 +18,7 @@ from dask.dataframe.dask_expr._shuffle import (
 )
 from dask.dataframe.dask_expr.io import FromPandas
 from dask.dataframe.dask_expr.tests._util import _backend_library, assert_eq, xfail_gpu
-from dask.dataframe.utils import pyarrow_strings_enabled
+from dask.dataframe.utils import pyarrow_strings_enabled, valid_divisions
 
 # Set DataFrame backend for this module
 pd = _backend_library()
@@ -299,6 +299,35 @@ def test_set_index_repartition(df, pdf):
     result = df.set_index("x", npartitions=2)
     assert result.npartitions == 2
     assert result.optimize(fuse=False).npartitions == 2
+    assert_eq(result, pdf.set_index("x"))
+
+
+def test_set_index_drop_duplicates_divisions():
+    pdf = pd.DataFrame({"x": ["IBAN1", "IBAN2", "IBAN3", "IBAN4"]})
+    df = from_pandas(pdf, npartitions=4)
+
+    result = df.drop_duplicates().set_index("x", npartitions=2)
+    optimized = result.optimize(fuse=False)
+
+    assert len(result.divisions) == result.npartitions + 1
+    assert valid_divisions(result.divisions)
+    assert optimized.npartitions == result.npartitions
+    assert optimized.divisions == result.divisions
+    assert_eq(result, pdf.drop_duplicates().set_index("x"))
+
+
+def test_set_index_constant_index_divisions():
+    pdf = pd.DataFrame({"x": ["same"] * 4})
+    df = from_pandas(pdf, npartitions=4)
+
+    result = df.set_index("x", npartitions=10)
+    optimized = result.optimize(fuse=False)
+
+    assert result.npartitions == 1
+    assert len(result.divisions) == result.npartitions + 1
+    assert valid_divisions(result.divisions)
+    assert optimized.npartitions == result.npartitions
+    assert optimized.divisions == result.divisions
     assert_eq(result, pdf.set_index("x"))
 
 


### PR DESCRIPTION
> [!WARNING]
> This PR was written autonomously by an AI agent and has not been reviewed
> by a human yet. Maintainers should ignore it until the human author has **reviewed,
> understood, and approved** everything that the AI agent wrote.

`set_index(..., npartitions=...)` now reports the actual partition count derived from its computed divisions. Duplicate quantiles can reduce the final count, but `npartitions` and `divisions` remain consistent before and after optimization.

Regression coverage includes the reported `drop_duplicates()` case and a constant-index case with more requested partitions than unique boundaries.

- [x] Closes #12565
- [x] Tests added / passed
- [ ] Passes `pixi run lint`

Validation: 4330 dask-expr tests passed, with 6 skipped, 11 xfailed, and 1 xpassed. Ruff 0.15.10, Black 26.3.1, and `git diff --check` passed.