### PR TITLE
docs: fix duplicate word typo in _can_apply_blockwise comment

### DIFF
--- a/dask/graph_manipulation.py
+++ b/dask/graph_manipulation.py
@@ -120,7 +120,7 @@ def _can_apply_blockwise(collection) -> bool:
     """Return True if _map_blocks can be sped up via blockwise operations; False
     otherwise.
 
-    FIXME this returns False for collections that wrap around around da.Array, such as
+    FIXME this returns False for collections that wrap around da.Array, such as
           pint.Quantity, xarray DataArray, Dataset, and Variable.
     """
     try:


### PR DESCRIPTION
## Description
Fixes a minor duplicate word typo in `dask/graph_manipulation.py`:
```diff
-    FIXME this returns False for collections that wrap around around da.Array, such as
+    FIXME this returns False for collections that wrap around da.Array, such as
```